### PR TITLE
chore: update browserlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flanksource/flanksource-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "files": [
     "build",
@@ -72,6 +72,7 @@
     "fix:eslint": "cross-env NODE_ENV=development eslint --fix --ext .js,.jsx,.ts,.tsx .",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
+    "check:browserslist": "npx browserslist",
     "prepare": "husky install"
   },
   "husky": {
@@ -81,7 +82,9 @@
   },
   "browserslist": {
     "production": [
+      "defaults",
       ">0.2%",
+      "not IE 11",
       "not dead",
       "not op_mini all"
     ],


### PR DESCRIPTION
This is the supported list with the new config (run `npm run checkbrowserslist` to see):

```and_chr 92
and_ff 90
and_qq 10.4
and_uc 12.12
android 92
android 4.4.3-4.4.4
baidu 7.12
chrome 92
chrome 91
chrome 90
chrome 89
chrome 87
chrome 85
edge 92
edge 91
firefox 90
firefox 89
firefox 78
ios_saf 14.5-14.7
ios_saf 14.0-14.4
ios_saf 13.4-13.7
kaios 2.5
op_mob 64
opera 77
opera 76
safari 14.1
safari 14
safari 13.1
samsung 14.0
samsung 13.0```