### PR TITLE
fix: replace `border-border-color` with `border-gray-200` temporarily…

### DIFF
--- a/src/components/Incidents/IncidentList/index.js
+++ b/src/components/Incidents/IncidentList/index.js
@@ -8,10 +8,10 @@ import { IncidentStatus } from "../incident-status";
 
 export function IncidentList({ list, ...rest }) {
   return (
-    <div className="border border-border-color rounded-md">
+    <div className="border border-gray-200 rounded-md">
       <table className="table-auto w-full" aria-label="table" {...rest}>
         <thead className="rounded-md">
-          <tr className="border-b border-border-color uppercase bg-column-background rounded-t-md items-center">
+          <tr className="border-b border-gray-200 uppercase bg-column-background rounded-t-md items-center">
             <th
               className="px-6 py-3 text-gray-500 font-medium text-xs col-span-2 text-left"
               colSpan={2}

--- a/src/index.css
+++ b/src/index.css
@@ -56,12 +56,12 @@
     border-radius: 8px;
     -moz-border-radius: 8px;
     -webkit-border-radius: 8px;
-    @apply border-border-color shadow-md;
+    @apply border-gray-200 shadow-md;
   }
 
   .comfortable-table td,
   .comfortable-table th {
-    @apply border-border-color;
+    @apply border-gray-200;
   }
 
   .comfortable-table td {
@@ -109,7 +109,7 @@
 
   .compact-table td,
   .compact-table th {
-    @apply border-border-color;
+    @apply border-gray-200;
   }
 
   .compact-table th {


### PR DESCRIPTION
… to resolve compilation issues, when being consumed by `incident-commander`.

```
> incident-commander@0.1.0 build
> DISABLE_ESLINT_PLUGIN=true NODE_OPTIONS="--max_old_space_size=4096" craco build

craco:  *** Cannot find ESLint plugin (ESLintWebpackPlugin). ***
Creating an optimized production build...
Failed to compile.

./node_modules/@flanksource/flanksource-ui/dist/index.css
Syntax error: The `border-border-color` class does not exist. If you're sure that `border-border-color` exists, make sure that any `@import` statements are being properly processed before Tailwind CSS sees your CSS, as `@apply` can only be used for classes in the same CSS tree. (59:12)

  [57](https://github.com/flanksource/incident-commander/runs/5967322729?check_suite_focus=true#step:6:57) |     -moz-border-radius: 8px;
  [58](https://github.com/flanksource/incident-commander/runs/5967322729?check_suite_focus=true#step:6:58) |     -webkit-border-radius: 8px;
> [59](https://github.com/flanksource/incident-commander/runs/5967322729?check_suite_focus=true#step:6:59) |     @apply border-border-color shadow-md;
     |            ^
  [60](https://github.com/flanksource/incident-commander/runs/5967322729?check_suite_focus=true#step:6:60) |   }
  61 |
```

@JIamep20 might want to re-correct this in the future, didn't know what styles `border-border-color` should have, so I simply replaced it with `border-gray-200`