### PR TITLE
Fix: Tailwind styles absent in build-storybook 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/storybook-static
 /.pnp
 .pnp.js
 dist/

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,35 +1,29 @@
-const path = require('path');
+const path = require("path");
 
 module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
-  ],
-  "addons": [
+  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
     "@storybook/preset-create-react-app"
   ],
-  "framework": "@storybook/react",
-  "logLevel": 'debug',
+  framework: "@storybook/react",
+  logLevel: "debug",
   webpackFinal: async (config) => {
     config.module.rules.push({
       test: /\,css&/,
       use: [
         {
-          loader: 'postcss-loader',
+          loader: "postcss-loader",
           options: {
-            ident: 'postcss',
-            plugins: [
-              require('tailwindcss'),
-              require('autoprefixer')
-            ]
+            ident: "postcss",
+            plugins: [require("tailwindcss"), require("autoprefixer")]
           }
         }
       ],
-      include: path.resolve(__dirname, '../'),
-    })
-    return config
+      include: path.resolve(__dirname, "../")
+    });
+    return config;
   }
-}
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,11 +1,13 @@
-import '../src/index.css';
+import "!style-loader!css-loader!postcss-loader!tailwindcss/tailwind.css";
+import "tailwindcss/tailwind.css";
+import "../src/index.css";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
     matchers: {
       color: /(background|color)$/i,
-      date: /Date$/,
-    },
-  },
-}
+      date: /Date$/
+    }
+  }
+};

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+const tailwindcss = require("tailwindcss");
+
+module.exports = {
+  // eslint-disable-next-line import/no-extraneous-dependencies, global-require
+  plugins: [tailwindcss("./tailwind.config.js"), require("autoprefixer")]
+};

--- a/src/components/Canary/CanaryPopup/CheckDetails.js
+++ b/src/components/Canary/CanaryPopup/CheckDetails.js
@@ -14,6 +14,7 @@ import { StatusHistory } from "./StatusHistory";
 import { DetailField } from "./DetailField";
 import { CanaryStatusChart } from "../CanaryStatusChart";
 import { Duration } from "../renderers";
+
 export function CheckDetails({ check, ...rest }) {
   const prevCheck = usePrevious(check);
   const validCheck = check || prevCheck;

--- a/src/components/Canary/Columns/index.js
+++ b/src/components/Canary/Columns/index.js
@@ -88,8 +88,9 @@ export function TitleCell({ row }) {
           rowValues.namespaces ? (
             <Badge
               className="ml-2"
-              text={`${rowValues.namespaces[0]}${rowValues.namespaces.length > 1 ? ", ..." : ""
-                }`}
+              text={`${rowValues.namespaces[0]}${
+                rowValues.namespaces.length > 1 ? ", ..." : ""
+              }`}
               title={
                 rowValues.namespaces.length > 1
                   ? rowValues.namespaces.join(", ")
@@ -117,14 +118,14 @@ function getPivotSortValueOrDefault(a, b, pivotAccessor) {
     const aValue =
       a.original?.pivoted === true
         ? a?.original[a?.original?.valueLookup] ??
-        a?.original?.aggregate ??
-        undefined
+          a?.original?.aggregate ??
+          undefined
         : a?.original;
     const bValue =
       b?.original?.pivoted === true
         ? b?.original[b?.original?.valueLookup] ??
-        b?.original?.aggregate ??
-        undefined
+          b?.original?.aggregate ??
+          undefined
         : b?.original;
     return { aValue, bValue };
   }
@@ -228,8 +229,8 @@ export function getColumns({ columnObject, pivotCellType = null }) {
         pivotCellType != null
           ? getSortType(pivotCellType, pivotAccessor)
           : accessor != null
-            ? getSortType(accessor, pivotAccessor)
-            : "alphanumeric"
+          ? getSortType(accessor, pivotAccessor)
+          : "alphanumeric"
     };
     return acc;
   }, []);

--- a/src/components/CanaryInterface/minimal.js
+++ b/src/components/CanaryInterface/minimal.js
@@ -17,7 +17,6 @@ export function CanaryInterfaceMinimal({
   onFilterCallback,
   onLabelFiltersCallback
 }) {
-
   const [filteredChecks, setFilteredChecks] = useState(checks);
   const [checksForTabGeneration, setChecksForTabGeneration] = useState(checks);
   const [selectedTab, setSelectedTab] = useState(null);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,8 @@
 const colors = require("tailwindcss/colors");
 
 module.exports = {
-  purge: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
+  content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
+  purge: false,
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {


### PR DESCRIPTION
Fixed issue where tailwind styles aren't loaded in the built version of storybook (`npm run build-storybook`).

Had to add `postcss.config.js` and make some slight changes in `tailwind.config.js` where:

`purge: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"]`
is changed into
`content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"]` 

Also added a gitignore entry for `./storybook-static`, and re-fix some recurring linting errors from `main` branch.