### PR TITLE
Feat/add back totals

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,7 +27,6 @@ import { RsDemoPage } from "./pages/Examples/rs-demo";
 import { TopologyPage as ExamplesTopologyPage } from "./pages/Examples/Topology/topology-page";
 import { TopologySelectorModalPage } from "./pages/Examples/TopologySelectorModalPage/TopologySelectorModalPage";
 import { HealthPage } from "./pages/health";
-import { Canary } from "./components/Canary";
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,7 @@ import { RsDemoPage } from "./pages/Examples/rs-demo";
 import { TopologyPage as ExamplesTopologyPage } from "./pages/Examples/Topology/topology-page";
 import { TopologySelectorModalPage } from "./pages/Examples/TopologySelectorModalPage/TopologySelectorModalPage";
 import { HealthPage } from "./pages/health";
+import { Canary } from "./components/Canary";
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/components/Canary/Canary.stories.jsx
+++ b/src/components/Canary/Canary.stories.jsx
@@ -1,0 +1,18 @@
+import { Canary } from "./index";
+
+export default {
+  title: "Canary",
+  component: Canary,
+  argTypes: {}
+};
+
+const Template = (arg) => <Canary {...arg} />;
+
+export const Variant1 = Template.bind({});
+Variant1.args = {
+  url: "/canary/api",
+  refreshInterval: 15 * 1000,
+  topLayoutOffset: 0,
+  hideSearch: false,
+  hideTimeRange: false
+};

--- a/src/components/Canary/CanaryPopup/CheckStat.js
+++ b/src/components/Canary/CanaryPopup/CheckStat.js
@@ -4,17 +4,21 @@ export function CheckStat({
   title,
   value,
   append,
-  containerClass,
+  bottomAppend,
+  containerClass = "",
+  valueContainerClass = "",
+  valueClass,
   className,
   ...rest
 }) {
   return (
     <div className={`flex flex-col ${containerClass} ${className}`} {...rest}>
       <div className="text-sm font-medium text-gray-500">{title}</div>
-      <div className="flex">
-        <span className="text-4xl font-bold">{value}</span>
+      <div className={`flex ${valueContainerClass}`}>
+        <span className={`text-4xl font-bold ${valueClass}`}>{value}</span>
         {append}
       </div>
+      {bottomAppend}
     </div>
   );
 }

--- a/src/pages/health.js
+++ b/src/pages/health.js
@@ -40,7 +40,7 @@ export function HealthPage({ url }) {
       }
       contentClass="p-0"
     >
-      <Canary url={url} topLayoutOffset={64} hideSearch hideTimeRange />
+      <Canary url={url} hideSearch hideTimeRange />
     </SearchLayout>
   );
 }


### PR DESCRIPTION
Add totals/filtered statistics to Canary sidebar that was previously overlooked when porting canary from v1 to v2.

2nd Filtered card will disappear if `total checks` is equal to `filtered checks`


![image](https://user-images.githubusercontent.com/88124024/165704472-46d4d581-a284-4208-9747-ad38e2f0026f.png)
