### PR TITLE
ci: configure a release branch for production releases

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - main
+      - production
   pull_request:
     paths:
       - 'Makefile'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - main
+      - production
 jobs:
   semantic-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - main
+      - production
   pull_request:
 
 name: Test

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,7 @@
 branches:
   - name: main
+    prerelease: true
+  - name: release
 plugins:
   - - "@semantic-release/commit-analyzer"
     - releaseRules:


### PR DESCRIPTION
This will release pre-releases from the master branch and production releases every time there is a commit to a branch called `release`