### PR TITLE
chore: ensure package.json lockfile is up to date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43658,9 +43658,11 @@
       "resolved": "https://registry.npmjs.org/@ory/integrations/-/integrations-0.2.8.tgz",
       "integrity": "sha512-khK2lVUQm+TZ+Mtq+aArrJCw1IldILp1CnmrdC/R9XMgEEVuA4hjkIqKx/z72KSfXtaQvdVgMKmcLgYs+8V0bQ==",
       "requires": {
+        "@ory/client": "^0.2.0-alpha.16",
         "@types/tldjs": "^2.3.1",
         "cookie": "^0.4.1",
         "istextorbinary": "^6.0.0",
+        "next": ">=12.0.10",
         "ory-prettier-styles": "^1.3.0",
         "prettier": "^2.3.2",
         "request": "^2.88.2",
@@ -52959,7 +52961,9 @@
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
           "peer": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -54562,7 +54566,9 @@
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
           "peer": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -61577,7 +61583,9 @@
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
           "peer": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -67516,6 +67524,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
+        "postcss": "^8.4.14",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",
@@ -69183,7 +69192,9 @@
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
           "peer": true,
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",


### PR DESCRIPTION
When you run npm i, the package-lock file has some changes to it, which should never happen unless installing/updating dependencies.