### PR TITLE
694: Dropdowns should always have a white background

### DIFF
--- a/src/components/ReactSelectDropdown/index.tsx
+++ b/src/components/ReactSelectDropdown/index.tsx
@@ -145,8 +145,8 @@ export const ReactSelectDropdown = ({
           )}
           <div
             className={clsx(
-              `relative cursor-pointer h-full pl-3 rounded-md shadow-sm pr-8 py-2 text-left border border-gray-300 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 sm:text-sm
-                ${SelectedOption?.id === "_empty" && "text-gray-400"}
+              `relative cursor-pointer h-full pl-3 rounded-md shadow-sm pr-8 py-2 text-left border border-gray-300 bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 sm:text-sm
+                ${SelectedOption?.id === "_empty" ? "text-gray-400" : ""}
               `,
               className
             )}

--- a/src/components/TopologyPopover/topologySort.tsx
+++ b/src/components/TopologyPopover/topologySort.tsx
@@ -151,7 +151,7 @@ export const TopologySort = ({
     <>
       <div
         ref={popoverRef}
-        className="flex mt-1 cursor-pointer md:mt-0 md:items-center border border-gray-300 rounded-md shadow-sm px-3 py-2"
+        className="flex mt-1 cursor-pointer md:mt-0 md:items-center border border-gray-300 bg-white rounded-md shadow-sm px-3 py-2"
       >
         {sortByDirection === "asc" && (
           <BsSortUp


### PR DESCRIPTION
@moshloop was also updated `TopologyPopover` background for page design consistency. 😊

<img width="911" alt="flanksource-topology" src="https://user-images.githubusercontent.com/1412629/209973305-499e3f41-403b-450b-b769-5e376a2ed277.png">
<img width="962" alt="flanksource-health" src="https://user-images.githubusercontent.com/1412629/209973311-d707a2aa-3f7c-42ac-a498-764e94c909e4.png">
<img width="538" alt="flanksource-logs" src="https://user-images.githubusercontent.com/1412629/209973312-e9d4957f-7343-4f93-bbdf-dc15f2bf786e.png">
<img width="899" alt="flanksource-configs" src="https://user-images.githubusercontent.com/1412629/209973314-b869f886-e263-4e34-8cce-6d37c15e2a58.png">
<img width="729" alt="flanksource-incidents" src="https://user-images.githubusercontent.com/1412629/209973318-9dde6154-cc73-428b-bd88-5adcedee8000.png">
