### PR TITLE
fix: increase the count of config items shown per page

### DIFF
--- a/src/components/DataTable/Pagination/Pagination.tsx
+++ b/src/components/DataTable/Pagination/Pagination.tsx
@@ -45,13 +45,13 @@ export const Pagination = ({
             />
           </div>
           <select
-            className="rounded-md w-20 border-gray-300 py-2 pl-3 pr-10 shadow-sm inline-block"
+            className="rounded-md w-35 border-gray-300 py-2 pl-3 pr-10 shadow-sm inline-block"
             value={pageSize}
             onChange={(e) => {
               setPageSize(Number(e.target.value));
             }}
           >
-            {[10, 20, 30, 40, 50].map((pageSize) => (
+            {[50, 100, 150, 200, 250].map((pageSize) => (
               <option key={pageSize} value={pageSize}>
                 {pageSize}
               </option>

--- a/src/pages/config/configChanges.tsx
+++ b/src/pages/config/configChanges.tsx
@@ -9,7 +9,7 @@ import { SearchLayout } from "../../components/Layout";
 export function ConfigChangesPage() {
   const [{ pageIndex, pageSize }, setPageState] = useState({
     pageIndex: 0,
-    pageSize: 20
+    pageSize: 50
   });
 
   const { data, isLoading, error, isRefetching, refetch } =


### PR DESCRIPTION
Shows a minimum of 50 items, all the way to 200.

Closes #741 