### PR TITLE
786- Job History Improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,6 +300,7 @@ function SidebarWrapper() {
 
   const pathTrack = [
     "users",
+    "jobs",
     "teams",
     "incident_rules",
     "config_scrapers",

--- a/src/api/query-hooks/useJobsHistoryQuery.ts
+++ b/src/api/query-hooks/useJobsHistoryQuery.ts
@@ -27,18 +27,46 @@ export function useJobsHistoryForSettingQuery(
     pageIndex,
     pageSize,
     resourceType,
-    resourceId
+    resourceId,
+    name,
+    status,
+    sortBy,
+    sortOrder
   }: {
     pageIndex: number;
     pageSize: number;
-    resourceType: string;
-    resourceId: string;
+    resourceType?: string;
+    resourceId?: string;
+    name?: string;
+    status?: string;
+    sortBy?: string;
+    sortOrder?: string;
   },
   options?: UseQueryOptions<Response, Error>
 ) {
   return useQuery<Response, Error>(
-    ["jobs_history", pageIndex, pageSize, resourceType, resourceId],
-    () => getJobsHistory(pageIndex, pageSize, resourceType, resourceId),
+    [
+      "jobs_history",
+      pageIndex,
+      pageSize,
+      resourceType,
+      resourceId,
+      name,
+      status,
+      sortBy,
+      sortOrder
+    ],
+    () =>
+      getJobsHistory(
+        pageIndex,
+        pageSize,
+        resourceType,
+        resourceId,
+        name,
+        status,
+        sortBy,
+        sortOrder
+      ),
     options
   );
 }

--- a/src/api/services/jobsHistory.ts
+++ b/src/api/services/jobsHistory.ts
@@ -6,7 +6,11 @@ export const getJobsHistory = async (
   pageIndex: number,
   pageSize: number,
   resourceType?: string,
-  resourceId?: string
+  resourceId?: string,
+  name?: string,
+  status?: string,
+  sortBy?: string,
+  sortOrder?: string
 ) => {
   const pagingParams = `&limit=${pageSize}&offset=${pageIndex * pageSize}`;
 
@@ -16,9 +20,17 @@ export const getJobsHistory = async (
 
   const resourceIdParam = resourceId ? `&resource_id=eq.${resourceId}` : "";
 
+  const nameParam = name ? `&name=eq.${name}` : "";
+
+  const statusParam = status ? `&status=eq.${status}` : "";
+
+  const sortByParam = sortBy ? `&order=${sortBy}` : "&order=created_at";
+
+  const sortOrderParam = sortOrder ? `.${sortOrder}` : ".desc";
+
   return resolve(
     IncidentCommander.get<JobHistory[] | null>(
-      `/job_history?order=created_at.desc&select=*${pagingParams}${resourceTypeParam}${resourceIdParam}`,
+      `/job_history?&select=*${pagingParams}${resourceTypeParam}${resourceIdParam}${nameParam}${statusParam}${sortByParam}${sortOrderParam}`,
       {
         headers: {
           Prefer: "count=exact"
@@ -26,4 +38,17 @@ export const getJobsHistory = async (
       }
     )
   );
+};
+
+export type JobHistoryNames = {
+  name: string;
+};
+
+export const getJobsHistoryNames = async () => {
+  const res = await resolve(
+    IncidentCommander.get<JobHistoryNames[] | null>(
+      `/job_history_names?order=name.asc`
+    )
+  );
+  return res.data ?? [];
 };

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -188,6 +188,7 @@ export function DataTable<TableColumns, Data extends TableColumns>({
         : undefined,
     manualPagination: !!pagination?.enable && pagination.remote,
     manualSorting: enableServerSideSorting,
+    enableSortingRemoval: true,
     enableHiding: true,
     onSortingChange: (sorting) => {
       if (onTableSortByChanged) {

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -226,17 +226,15 @@ export function DataTable<TableColumns, Data extends TableColumns>({
       ? table.getPaginationRowModel()
       : table.getRowModel();
 
-  const enableVirtualization = isVirtualized;
-
   const { getVirtualItems, getTotalSize } = useVirtualizer({
-    count: enableVirtualization ? rows.length : 0,
+    count: isVirtualized ? rows.length : 0,
     getScrollElement: () => tableContainerRef.current,
     estimateSize: () => virtualizedRowEstimatedHeight,
     overscan: overScan
   });
 
-  const virtualRows = enableVirtualization ? getVirtualItems() : emptyList;
-  const totalSize = enableVirtualization ? getTotalSize() : 0;
+  const virtualRows = isVirtualized ? getVirtualItems() : emptyList;
+  const totalSize = isVirtualized ? getTotalSize() : 0;
 
   const paddingTop = virtualRows.length > 0 ? virtualRows?.[0]?.start || 0 : 0;
   const paddingBottom =
@@ -327,12 +325,12 @@ export function DataTable<TableColumns, Data extends TableColumns>({
             ))}
           </thead>
           <tbody>
-            {enableVirtualization && paddingTop > 0 && (
+            {isVirtualized && paddingTop > 0 && (
               <tr>
                 <td style={{ height: `${paddingTop}px` }} />
               </tr>
             )}
-            {enableVirtualization
+            {isVirtualized
               ? getVirtualItems().map(({ index }) => {
                   const row = rows[index];
                   return (
@@ -358,7 +356,7 @@ export function DataTable<TableColumns, Data extends TableColumns>({
                     key={row.id}
                   />
                 ))}
-            {enableVirtualization && paddingBottom > 0 && (
+            {isVirtualized && paddingBottom > 0 && (
               <tr>
                 <td style={{ height: `${paddingBottom}px` }} />
               </tr>

--- a/src/components/JobsHistory/Filters/JobHistoryNames.tsx
+++ b/src/components/JobsHistory/Filters/JobHistoryNames.tsx
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+import { getJobsHistoryNames } from "../../../api/services/jobsHistory";
+import { ReactSelectDropdown, StateOption } from "../../ReactSelectDropdown";
+import { useSearchParams } from "react-router-dom";
+
+export default function JobHistoryNamesDropdown() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const name = searchParams.get("name") ?? "";
+
+  const { data: jobNames = [], isLoading } = useQuery(
+    ["jobHistoryNames"],
+    () => getJobsHistoryNames(),
+    {
+      select: (data) => {
+        return data.map(
+          (job) =>
+            ({
+              label: job.name,
+              value: job.name,
+              id: job.name
+            } as StateOption)
+        );
+      }
+    }
+  );
+
+  return (
+    <div className="flex flex-col">
+      <ReactSelectDropdown
+        name="name"
+        label=""
+        value={name}
+        isLoading={isLoading}
+        items={[{ label: "All", value: "" }, ...jobNames]}
+        className="inline-block p-3 w-auto max-w-[500px]"
+        dropDownClassNames="w-auto max-w-[400px] left-0"
+        onChange={(val: any) => {
+          setSearchParams({
+            ...Object.fromEntries(searchParams),
+            name: val
+          });
+        }}
+        prefix="Job Type:"
+      />
+    </div>
+  );
+}

--- a/src/components/JobsHistory/Filters/JobsHistoryFilters.tsx
+++ b/src/components/JobsHistory/Filters/JobsHistoryFilters.tsx
@@ -1,0 +1,99 @@
+import { useSearchParams } from "react-router-dom";
+import { ReactSelectDropdown } from "../../ReactSelectDropdown";
+import { JobHistory } from "../JobsHistoryTable";
+import JobHistoryNamesDropdown from "./JobHistoryNames";
+
+const statusOptions = {
+  all: {
+    id: "0",
+    label: "All",
+    value: ""
+  },
+  finished: {
+    id: "1",
+    label: "Finished",
+    value: "FINISHED"
+  },
+  running: {
+    id: "2",
+    label: "Running",
+    value: "RUNNING"
+  }
+};
+
+export const jobHistoryResourceTypes = [
+  {
+    label: "All",
+    value: ""
+  },
+  {
+    label: "Canary",
+    value: "canary"
+  },
+  {
+    label: "Topology",
+    value: "topology"
+  },
+  {
+    label: "Config Scraper",
+    value: "config_scraper"
+  }
+];
+
+type JobHistoryFiltersProps = {
+  jobs: JobHistory[];
+  onFilterChange?: () => void;
+};
+
+export default function JobHistoryFilters({
+  jobs,
+  onFilterChange
+}: JobHistoryFiltersProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const resourceType = searchParams.get("resource_type") ?? "";
+  const status = searchParams.get("status") ?? "";
+
+  return (
+    <div className="flex flex-wrap py-4 gap-2">
+      <JobHistoryNamesDropdown />
+
+      <div className="flex flex-col">
+        <ReactSelectDropdown
+          name="resource_type"
+          label=""
+          value={resourceType}
+          items={jobHistoryResourceTypes}
+          className="inline-block p-3 w-auto max-w-[500px]"
+          dropDownClassNames="w-auto max-w-[400px] left-0"
+          onChange={(val: any) => {
+            setSearchParams({
+              ...Object.fromEntries(searchParams),
+              resource_type: val
+            });
+            onFilterChange?.();
+          }}
+          prefix="Resource Type:"
+        />
+      </div>
+      <div className="flex flex-col">
+        <ReactSelectDropdown
+          name="status"
+          label=""
+          value={status}
+          items={statusOptions}
+          className="inline-block p-3 w-auto max-w-[500px]"
+          dropDownClassNames="w-auto max-w-[400px] left-0"
+          onChange={(val: any) => {
+            setSearchParams({
+              ...Object.fromEntries(searchParams),
+              status: val
+            });
+            onFilterChange?.();
+          }}
+          prefix="Status:"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/JobsHistory/JobsHistoryDetails.tsx
+++ b/src/components/JobsHistory/JobsHistoryDetails.tsx
@@ -1,11 +1,29 @@
 import { Modal } from "../Modal";
 import { JobHistory } from "./JobsHistoryTable";
+import clsx from "clsx";
 
 type JobsHistoryDetailsProps = {
   job?: JobHistory;
   isModalOpen: boolean;
   setIsModalOpen: (value: boolean) => void;
 };
+
+interface CellProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function HCell({ children, className }: CellProps) {
+  return <th className={className}>{children}</th>;
+}
+
+function Cell({ children, className }: CellProps) {
+  return (
+    <td className={clsx("px-3 py-3 text-sm border-b", className)}>
+      {children}
+    </td>
+  );
+}
 
 export function JobsHistoryDetails({
   job,
@@ -22,13 +40,30 @@ export function JobsHistoryDetails({
       onClose={() => setIsModalOpen(false)}
       open={isModalOpen}
     >
-      <div className="flex flex-col space-y-2">
-        <div className="flex flex-col space-y-4 px-2 py-6">
-          {job.details?.errors?.map((error, index) => (
-            <div className="block w-full">
-              {index + 1}. {error}
-            </div>
-          ))}
+      <div className="max-w-screen-xl mx-auto space-y-6 flex flex-col justify-center">
+        <div
+          className="overflow-y-auto"
+          style={{ maxHeight: "calc(100vh - 8rem)" }}
+        >
+          <table
+            className="table-auto table-fixed w-full relative"
+            aria-label="table"
+          >
+            <thead className={`bg-white sticky top-0 z-01`}>
+              <tr>
+                <HCell>Error</HCell>
+              </tr>
+            </thead>
+            <tbody>
+              {job.details?.errors?.map((error, index) => (
+                <tr className="last:border-b-0 border-b cursor-pointer">
+                  <Cell className="leading-5 text-gray-900 font-medium">
+                    {error}
+                  </Cell>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </Modal>

--- a/src/components/JobsHistory/JobsHistorySettingsPage.tsx
+++ b/src/components/JobsHistory/JobsHistorySettingsPage.tsx
@@ -1,9 +1,14 @@
 import { useState } from "react";
-import { useJobsHistoryQuery } from "../../api/query-hooks/useJobsHistoryQuery";
+import { useSearchParams } from "react-router-dom";
+import {
+  useJobsHistoryForSettingQuery,
+  useJobsHistoryQuery
+} from "../../api/query-hooks/useJobsHistoryQuery";
+import { BreadcrumbNav, BreadcrumbRoot } from "../BreadcrumbNav";
 import { Head } from "../Head/Head";
 import { SearchLayout } from "../Layout";
 import JobsHistoryTable from "./JobsHistoryTable";
-import { BreadcrumbNav, BreadcrumbRoot } from "../BreadcrumbNav";
+import JobHistoryFilters from "./Filters/JobsHistoryFilters";
 
 export default function JobsHistorySettingsPage() {
   const [{ pageIndex, pageSize }, setPageState] = useState({
@@ -11,17 +16,34 @@ export default function JobsHistorySettingsPage() {
     pageSize: 150
   });
 
-  const { data, isLoading, refetch, isRefetching } = useJobsHistoryQuery(
-    pageIndex,
-    pageSize,
-    {
-      keepPreviousData: true
-    }
-  );
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const name = searchParams.get("name") ?? "";
+  const resourceType = searchParams.get("resource_type") ?? "";
+  const sortBy = searchParams.get("sortBy") ?? "";
+  const sortOrder = searchParams.get("sortOrder") ?? "desc";
+  const status = searchParams.get("status") ?? "";
+
+  const { data, isLoading, refetch, isRefetching } =
+    useJobsHistoryForSettingQuery(
+      {
+        pageIndex,
+        pageSize,
+        resourceType,
+        name,
+        status,
+        sortBy,
+        sortOrder
+      },
+      {
+        keepPreviousData: true
+      }
+    );
+
+  const { data: fullJobs } = useJobsHistoryQuery(0, 1000000);
 
   const jobs = data?.data;
   const totalEntries = data?.totalEntries;
-
   const pageCount = totalEntries ? Math.ceil(totalEntries / pageSize) : -1;
 
   return (
@@ -40,13 +62,36 @@ export default function JobsHistorySettingsPage() {
         loading={isLoading || isRefetching}
       >
         <div className="flex flex-col flex-1 p-6 pb-0 h-full w-full">
+          <JobHistoryFilters
+            jobs={fullJobs?.data ?? []}
+            onFilterChange={() => {
+              setPageState((state) => ({
+                ...state,
+                pageIndex: 0
+              }));
+            }}
+          />
+
           <JobsHistoryTable
             jobs={jobs ?? []}
-            isLoading={isLoading}
+            isLoading={isLoading || isRefetching}
             pageCount={pageCount}
             pageIndex={pageIndex}
             pageSize={pageSize}
             setPageState={setPageState}
+            sortBy={sortBy}
+            sortOrder={sortOrder}
+            onSortByChanged={(sortBy) => {
+              const sort = typeof sortBy === "function" ? sortBy([]) : sortBy;
+              if (sort.length === 0) {
+                searchParams.delete("sortBy");
+                searchParams.delete("sortOrder");
+              } else {
+                searchParams.set("sortBy", sort[0]?.id);
+                searchParams.set("sortOrder", sort[0].desc ? "desc" : "asc");
+              }
+              setSearchParams(searchParams);
+            }}
           />
         </div>
       </SearchLayout>

--- a/src/components/JobsHistory/JobsHistoryTable.tsx
+++ b/src/components/JobsHistory/JobsHistoryTable.tsx
@@ -1,4 +1,4 @@
-import { Row, SortingState } from "@tanstack/react-table";
+import { Row, SortingState, Updater } from "@tanstack/react-table";
 import { useCallback, useMemo, useState } from "react";
 import { DataTable } from "../DataTable";
 import { JobsHistoryDetails } from "./JobsHistoryDetails";
@@ -30,8 +30,11 @@ type JobsHistoryTableProps = {
   pageCount: number;
   pageIndex: number;
   pageSize: number;
+  sortBy: string;
+  sortOrder: string;
   setPageState?: (state: { pageIndex: number; pageSize: number }) => void;
   hiddenColumns?: string[];
+  onSortByChanged?: (sortByState: Updater<SortingState>) => void;
 };
 
 export default function JobsHistoryTable({
@@ -40,17 +43,22 @@ export default function JobsHistoryTable({
   pageCount,
   pageIndex,
   pageSize,
-  setPageState = () => {},
-  hiddenColumns = []
+  hiddenColumns = [],
+  sortBy,
+  sortOrder,
+  onSortByChanged = () => {},
+  setPageState = () => {}
 }: JobsHistoryTableProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedJob, setSelectedJob] = useState<JobHistory>();
-  const [tableSortByState, setTableSortByState] = useState<SortingState>([
-    {
-      id: "time_start",
-      desc: true
-    }
-  ]);
+  const tableSortByState = useMemo(() => {
+    return [
+      {
+        id: sortBy,
+        desc: sortOrder === "desc"
+      }
+    ];
+  }, [sortBy, sortOrder]);
 
   const pagination = useMemo(() => {
     return {
@@ -84,14 +92,15 @@ export default function JobsHistoryTable({
         data={jobs}
         columns={columns}
         isLoading={isLoading}
-        tableSortByState={tableSortByState}
-        onTableSortByChanged={setTableSortByState}
         handleRowClick={onSelectJob}
         pagination={pagination}
         stickyHead
         preferencesKey="job-history"
         savePreferences={false}
         hiddenColumns={hiddenColumns}
+        tableSortByState={tableSortByState}
+        onTableSortByChanged={onSortByChanged}
+        enableServerSideSorting
       />
       <JobsHistoryDetails
         job={selectedJob}

--- a/src/components/JobsHistory/JobsHistoryTableColumn.tsx
+++ b/src/components/JobsHistory/JobsHistoryTableColumn.tsx
@@ -1,26 +1,33 @@
-import { CellContext, ColumnDef } from "@tanstack/react-table";
+import { ColumnDef } from "@tanstack/react-table";
 import { FaDotCircle } from "react-icons/fa";
-import { relativeDateTime } from "../../utils/date";
 import { JobHistory, JobHistoryStatus } from "./JobsHistoryTable";
+import { formatJobName } from "../../utils/common";
+import dayjs from "dayjs";
+import { DateCell } from "../ConfigViewer/columns";
+import duration from "dayjs/plugin/duration";
+import relativeTime from "dayjs/plugin/relativeTime";
 
-function JobsTableDateCell({ getValue }: CellContext<JobHistory, any>) {
-  const value = getValue();
-  return <span>{relativeDateTime(value)}</span>;
-}
+dayjs.extend(duration);
+dayjs.extend(relativeTime);
 
 export const JobsHistoryTableColumn: ColumnDef<JobHistory, any>[] = [
   {
     header: "Timestamp",
     id: "time_start",
     accessorKey: "time_start",
-    size: 100,
-    cell: JobsTableDateCell
+    size: 150,
+    cell: DateCell
   },
   {
     header: "Job Name",
     id: "name",
     accessorKey: "name",
-    size: 250
+    size: 200,
+    cell: ({ getValue }) => {
+      const value = getValue<JobHistory["name"]>();
+      const formattedName = formatJobName(value);
+      return <span>{formattedName}</span>;
+    }
   },
   {
     header: "Status",
@@ -42,18 +49,16 @@ export const JobsHistoryTableColumn: ColumnDef<JobHistory, any>[] = [
     }
   },
   {
-    header: "Duration (Millis)",
+    header: "Duration",
     id: "duration_millis",
     accessorKey: "duration_millis",
-    size: 100
+    size: 100,
+    cell: ({ getValue }) => {
+      const value = getValue<JobHistory["duration_millis"]>();
+      const readableTime = dayjs.duration(value, "milliseconds").humanize();
+      return <span>{readableTime}</span>;
+    }
   },
-  // {
-  //   header: "Host Name",
-  //   id: "hostname",
-  //   accessorKey: "hostname",
-  //   size: 100
-  // },
-
   {
     header: "Statistics",
     id: "statistics",
@@ -109,11 +114,4 @@ export const JobsHistoryTableColumn: ColumnDef<JobHistory, any>[] = [
       );
     }
   }
-  // {
-  //   header: "Time End",
-  //   id: "time_end",
-  //   accessorKey: "time_end",
-  //   size: 100,
-  //   cell: JobsTableDateCell
-  // }
 ];

--- a/src/components/SchemaResourcePage/SchemaResourceEditJobsTab.tsx
+++ b/src/components/SchemaResourcePage/SchemaResourceEditJobsTab.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useJobsHistoryForSettingQuery } from "../../api/query-hooks/useJobsHistoryQuery";
 import JobsHistoryTable from "../JobsHistory/JobsHistoryTable";
 import ErrorPage from "../Errors/ErrorPage";
+import { useSearchParams } from "react-router-dom";
 
 type SchemaResourceJobsTabProps = {
   tableName: keyof typeof resourceTypeMap;
@@ -25,10 +26,15 @@ export function SchemaResourceJobsTab({
     pageSize: 150
   });
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const sortBy = searchParams.get("sortBy") ?? "";
+  const sortOrder = searchParams.get("sortOrder") ?? "desc";
+
   const resourceType = useMemo(() => resourceTypeMap[tableName], [tableName]);
 
   const { isLoading, data, error } = useJobsHistoryForSettingQuery(
-    { pageIndex, pageSize, resourceId, resourceType },
+    { pageIndex, pageSize, resourceId, resourceType, sortBy, sortOrder },
     {
       keepPreviousData: true
     }
@@ -52,6 +58,19 @@ export function SchemaResourceJobsTab({
           pageSize={pageSize}
           setPageState={setPageState}
           hiddenColumns={["resource_id", "resource_type"]}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSortByChanged={(sortBy) => {
+            const sort = typeof sortBy === "function" ? sortBy([]) : sortBy;
+            if (sort.length === 0) {
+              searchParams.delete("sortBy");
+              searchParams.delete("sortOrder");
+            } else {
+              searchParams.set("sortBy", sort[0]?.id);
+              searchParams.set("sortOrder", sort[0].desc ? "desc" : "asc");
+            }
+            setSearchParams(searchParams);
+          }}
         />
       )}
     </div>

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -82,3 +82,8 @@ export const stringSortHelper = (val1: string, val2: string) => {
   }
   return 0;
 };
+
+export function formatJobName(word: string | null) {
+  const wordRe = /($[a-z])|[A-Z][^A-Z]+/g;
+  return word?.match(wordRe)?.join(" ");
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,6 +1,7 @@
 import dayjs, { ConfigType as DateConfig, ManipulateType } from "dayjs";
 import isBetween from "dayjs/plugin/isBetween";
 import isToday from "dayjs/plugin/isToday";
+import duration from "dayjs/plugin/duration";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 import relativeTime from "dayjs/plugin/relativeTime";
 import updateLocale from "dayjs/plugin/updateLocale";
@@ -15,6 +16,7 @@ dayjs.extend(isSameOrAfter);
 dayjs.extend(relativeTime);
 dayjs.extend(updateLocale);
 dayjs.extend(utc);
+dayjs.extend(duration);
 
 dayjs.updateLocale("en", {
   relativeTime: {


### PR DESCRIPTION
Fixes #786  and Fixes #1138

- [x] In the error popup use a table style, not list style
- [x] Use the actual date and time rather than time ago
- [x] Duration - convert to human duration
- [x] Add filters on job type, resource type, id, success
- [x] Move sorting server side
- [x] Convert from CamelCase to Camel Case in the job names