### PR TITLE
795-Log search API triggered when "none" or "empty log" component is selected 

### DIFF
--- a/src/pages/LogsPage.tsx
+++ b/src/pages/LogsPage.tsx
@@ -110,6 +110,7 @@ export function LogsPage() {
                   type="button"
                   onClick={() => refetch()}
                   className="hover"
+                  disabled={!logs}
                 >
                   <SearchIcon
                     className="h-5 w-5 text-gray-400 hover:text-gray-600"
@@ -134,6 +135,7 @@ export function LogsPage() {
                   }
                 }}
                 defaultValue={query ?? undefined}
+                disabled={!logs}
               />
             </div>
           </div>


### PR DESCRIPTION
Fixes #795 

- Disabled search icon and search input when no component is selected or when component has no logs