### PR TITLE
fix: while editing resource spec hide remaining tabs

### DIFF
--- a/src/components/SchemaResourcePage/SchemaResourceEdit.tsx
+++ b/src/components/SchemaResourcePage/SchemaResourceEdit.tsx
@@ -64,8 +64,13 @@ export function SchemaResourceEdit({
     if (!resourceType) {
       return [];
     }
-    return resourceType.subNav;
-  }, [resourceName]);
+    return resourceType.subNav.filter((nav) => {
+      if (edit) {
+        return nav.label === "Spec";
+      }
+      return true;
+    });
+  }, [resourceName, edit]);
 
   const table = useMemo(() => {
     const resourceType = schemaResourceTypes.find(


### PR DESCRIPTION
This is done to keep user in editing flow once he clicks on edit instead of allowing him to navigate to other sections.