### PR TITLE
fix: retain scroll & expansion state of config list table

### DIFF
--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -39,8 +39,9 @@ export type ConfigTypeRelationships = {
 };
 
 interface Change {
-  type: string;
-  count: number;
+  change_type: string;
+  total: number;
+  severity?: string;
 }
 
 interface Analysis {

--- a/src/components/ConfigChangeHistory/index.tsx
+++ b/src/components/ConfigChangeHistory/index.tsx
@@ -114,6 +114,8 @@ export function ConfigChangeHistory({
       tableStyle={tableStyle}
       pagination={pagination}
       virtualizedRowEstimatedHeight={500}
+      preferencesKey="config-change-history"
+      savePreferences={false}
     />
   );
 }

--- a/src/components/ConfigList/Cells/ConfigListAnalysisCell.tsx
+++ b/src/components/ConfigList/Cells/ConfigListAnalysisCell.tsx
@@ -1,5 +1,4 @@
 import { CellContext } from "@tanstack/react-table";
-import { useEffect } from "react";
 import { AiFillWarning } from "react-icons/ai";
 import { BiDollarCircle } from "react-icons/bi";
 import { FaTasks } from "react-icons/fa";
@@ -7,8 +6,8 @@ import { GrIntegration, GrWorkshop } from "react-icons/gr";
 import { ImHeartBroken } from "react-icons/im";
 import { IoMdSpeedometer } from "react-icons/io";
 import { MdSecurity } from "react-icons/md";
-import ReactTooltip from "react-tooltip";
 import { ConfigItem } from "../../../api/services/configs";
+import Popover from "../../Popover/Popover";
 
 export function AnalysisIcon({
   analysis
@@ -53,32 +52,41 @@ export default function ConfigListAnalysisCell({
 }: CellContext<ConfigItem, unknown>) {
   const analysis = row?.getValue<ConfigItem["analysis"]>(column.id) || [];
 
-  useEffect(() => {
-    if (analysis.length > 0) {
-      ReactTooltip.rebuild();
-    }
-  });
-
   if (analysis.length === 0) {
     return null;
   }
 
   return (
-    <div className="flex flex-col w-full max-w-full">
-      {analysis.map((item, index) => (
-        <div
-          data-tip={`${item.analyzer}`}
-          className="flex flex-row space-x-2 pb-0.5 max-w-full"
-          key={index}
-        >
-          <span className="w-auto">
-            <AnalysisIcon analysis={item} />
-          </span>
-          <span className="flex-1 overflow-hidden overflow-ellipsis">
-            {item.analyzer}
-          </span>
+    <Popover
+      toggle={
+        <div className="flex flex-row items-center">
+          <div className="flex flex-row items-center flex-shrink space-x-1 truncate">
+            <span className="w-auto">
+              <AnalysisIcon analysis={analysis[0]} />
+            </span>
+            <span className="flex-1">{analysis[0].analyzer}</span>
+          </div>
+          {analysis.length > 1 && (
+            <div className="flex-shrink underline decoration-solid justify-left text-xs mx-2">
+              +{analysis.length - 1} more
+            </div>
+          )}
         </div>
-      ))}
-    </div>
+      }
+      placement="left"
+    >
+      <div className="flex flex-col w-full max-w-full space-y-2 p-1">
+        {analysis.map((item, index) => (
+          <div className="flex flex-row space-x-2 max-w-full" key={index}>
+            <span className="w-auto">
+              <AnalysisIcon analysis={item} />
+            </span>
+            <span className="flex-1 overflow-hidden overflow-ellipsis">
+              {item.analyzer}
+            </span>
+          </div>
+        ))}
+      </div>
+    </Popover>
   );
 }

--- a/src/components/ConfigList/Cells/ConfigListChangeCell.tsx
+++ b/src/components/ConfigList/Cells/ConfigListChangeCell.tsx
@@ -1,70 +1,31 @@
 import { CellContext } from "@tanstack/react-table";
-import { useState, useEffect } from "react";
-import { IoMdArrowDropdown, IoMdArrowDropright } from "react-icons/io";
-import ReactTooltip from "react-tooltip";
+import { useMemo } from "react";
 import { ConfigItem } from "../../../api/services/configs";
-
-const MIN_ITEMS = 2;
 
 export default function ConfigListChangeCell({
   row,
   column
 }: CellContext<ConfigItem, any>) {
-  const [showMore, setShowMore] = useState(false);
-
   const changes = row?.getValue<ConfigItem["changes"]>(column.id);
-
-  useEffect(() => {
-    ReactTooltip.rebuild();
-  });
+  const totalChanges = useMemo(() => {
+    let total = 0;
+    (changes || []).forEach((change) => {
+      total += change.total || 0;
+    });
+    return total;
+  }, [changes]);
 
   if (changes == null) {
     return null;
   }
 
-  const renderKeys = showMore ? changes : changes.slice(0, MIN_ITEMS);
-
-  const cell = renderKeys.map((item: any, index: number) => {
-    return (
-      <div className="flex flex-row max-w-full overflow-hidden" key={index}>
+  return (
+    <div className="flex flex-col flex-1 w-full max-w-full">
+      <div className="flex flex-row max-w-full overflow-hidden">
         <div className="flex max-w-full items-center px-2.5 py-0.5 m-0.5 rounded-md text-sm font-medium bg-blue-100 text-blue-800 overflow-hidden">
-          {item.change_type === "diff" ? (
-            item.total
-          ) : (
-            <div
-              data-tip={`${item.change_type}: ${item.total}`}
-              className="flex flex-row max-w-full space-x-1"
-            >
-              <div className="text-ellipsis overflow-hidden">
-                {item.change_type}
-              </div>
-              :<div className="flex-1"> {item.total}</div>
-            </div>
-          )}
+          {totalChanges}
         </div>
       </div>
-    );
-  });
-  return (
-    <div
-      className="flex flex-row items-start"
-      onClick={(e) => {
-        if (changes.length > MIN_ITEMS) {
-          e.stopPropagation();
-          setShowMore((showMore) => !showMore);
-        }
-      }}
-    >
-      {changes.length > MIN_ITEMS && (
-        <button className="text-sm focus:outline-none">
-          {showMore ? (
-            <IoMdArrowDropdown size={24} />
-          ) : (
-            <IoMdArrowDropright size={24} />
-          )}
-        </button>
-      )}
-      <div className="flex flex-col flex-1 w-full max-w-full">{cell}</div>
     </div>
   );
 }

--- a/src/components/ConfigList/Cells/ConfigListTagsCell.tsx
+++ b/src/components/ConfigList/Cells/ConfigListTagsCell.tsx
@@ -1,9 +1,8 @@
 import { CellContext } from "@tanstack/react-table";
-import { useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
-import ReactTooltip from "react-tooltip";
 import { ConfigItem } from "../../../api/services/configs";
-import { TagList } from "../../TagList/TagList";
+import Popover from "../../Popover/Popover";
+import { TagItem, TagList } from "../../TagList/TagList";
 
 export default function ConfigListTagsCell({
   getValue,
@@ -19,10 +18,6 @@ export default function ConfigListTagsCell({
     .filter((key) => key !== "toString");
   const groupByProp = decodeURIComponent(params.get("groupByProp") ?? "");
 
-  useEffect(() => {
-    ReactTooltip.rebuild();
-  });
-
   if (tagKeys.length === 0) {
     return null;
   }
@@ -35,7 +30,6 @@ export default function ConfigListTagsCell({
     return (
       <div className="font-mono flex flex-wrap w-full max-w-full pl-1 space-y-1">
         <div
-          data-tip={`${groupByProp}: ${tagMap[groupByProp]}`}
           className="max-w-full overflow-hidden text-ellipsis bg-gray-200 border border-gray-300 px-1 py-0.75 mr-1 rounded-md text-gray-600 font-semibold text-xs"
           key={groupByProp}
         >
@@ -53,5 +47,32 @@ export default function ConfigListTagsCell({
     };
   });
 
-  return <TagList tags={tags} minimumItemsToShow={2} />;
+  return (
+    <Popover
+      toggle={
+        <div className="flex flex-row items-center">
+          <div className="flex-shrink overflow-x-hidden cursor-pointer">
+            <TagItem tag={tags[0]!} />
+          </div>
+          {tags.length > 1 && (
+            <div className="flex-shrink space-x-2 underline decoration-solid justify-left text-xs cursor-pointer">
+              +{tags.length - 1} more
+            </div>
+          )}
+        </div>
+      }
+      placement="left"
+      menuClass="top-8"
+    >
+      <div className="flex flex-col p-1">
+        <div className="flex flex-col items-stretch max-h-64 overflow-y-auto">
+          <TagList
+            className="flex flex-col flex-1"
+            tags={tags}
+            minimumItemsToShow={tags.length}
+          />
+        </div>
+      </div>
+    </Popover>
+  );
 }

--- a/src/components/ConfigList/ConfigListColumn.tsx
+++ b/src/components/ConfigList/ConfigListColumn.tsx
@@ -25,7 +25,7 @@ export const configListColumns: ColumnDef<ConfigItem, any>[] = [
     header: "Name",
     accessorKey: "name",
     cell: ConfigListNameCell,
-    size: 350,
+    size: 270,
     enableGrouping: true,
     enableSorting: true
   },
@@ -47,7 +47,7 @@ export const configListColumns: ColumnDef<ConfigItem, any>[] = [
         </span>
       );
     },
-    size: 150,
+    size: 75,
     meta: {
       cellClassName: "overflow-hidden"
     },
@@ -58,13 +58,13 @@ export const configListColumns: ColumnDef<ConfigItem, any>[] = [
     accessorKey: "analysis",
     cell: ConfigListAnalysisCell,
     aggregatedCell: "",
-    size: 120
+    size: 150
   },
   {
     header: "Cost",
     accessorKey: "",
     cell: ConfigListCostCell,
-    size: 120,
+    size: 180,
     enableSorting: false,
     columns: [
       {
@@ -106,10 +106,7 @@ export const configListColumns: ColumnDef<ConfigItem, any>[] = [
     accessorKey: "tags",
     cell: React.memo(ConfigListTagsCell),
     aggregatedCell: "",
-    size: 250,
-    meta: {
-      cellClassName: "overflow-hidden"
-    }
+    size: 210
   },
   {
     header: "All Tags",
@@ -118,24 +115,21 @@ export const configListColumns: ColumnDef<ConfigItem, any>[] = [
       <ConfigListTagsCell {...props} hideGroupByView />
     )),
     aggregatedCell: "",
-    size: 250,
-    meta: {
-      cellClassName: "overflow-hidden"
-    }
+    size: 210
   },
   {
     header: "Created",
     accessorKey: "created_at",
     cell: ConfigListDateCell,
     aggregatedCell: "",
-    size: 80
+    size: 100
   },
   {
     header: "Last Updated",
     accessorKey: "updated_at",
     cell: ConfigListDateCell,
     aggregatedCell: "",
-    size: 90
+    size: 130
   },
   {
     header: "Deleted At",

--- a/src/components/ConfigList/index.tsx
+++ b/src/components/ConfigList/index.tsx
@@ -20,6 +20,7 @@ export default function ConfigList({ data, handleRowClick, isLoading }: Props) {
 
   const groupByField = queryParams.get("groupBy") || "config_type";
   const sortField = queryParams.get("sortBy");
+  const expandedRowId = queryParams.get("expandedRowId");
 
   const isSortOrderDesc =
     queryParams.get("sortOrder") === "desc" ? true : false;
@@ -154,6 +155,8 @@ export default function ConfigList({ data, handleRowClick, isLoading }: Props) {
       tableSortByState={sortBy}
       onTableSortByChanged={updateSortBy}
       determineRowClassNamesCallback={determineRowClassNames}
+      preferencesKey="config-list"
+      savePreferences
     />
   );
 }

--- a/src/components/ConfigList/index.tsx
+++ b/src/components/ConfigList/index.tsx
@@ -20,7 +20,6 @@ export default function ConfigList({ data, handleRowClick, isLoading }: Props) {
 
   const groupByField = queryParams.get("groupBy") || "config_type";
   const sortField = queryParams.get("sortBy");
-  const expandedRowId = queryParams.get("expandedRowId");
 
   const isSortOrderDesc =
     queryParams.get("sortOrder") === "desc" ? true : false;
@@ -157,6 +156,8 @@ export default function ConfigList({ data, handleRowClick, isLoading }: Props) {
       determineRowClassNamesCallback={determineRowClassNames}
       preferencesKey="config-list"
       savePreferences
+      virtualizedRowEstimatedHeight={37}
+      overScan={20}
     />
   );
 }

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -54,6 +54,7 @@ type DataTableProps<TableColumns, Data extends TableColumns> = {
   paginationClassName?: string;
   preferencesKey: string;
   savePreferences: boolean;
+  overScan?: number;
   /**
    * Columns used for sorting the table
    *
@@ -126,6 +127,7 @@ export function DataTable<TableColumns, Data extends TableColumns>({
   enableServerSideSorting = false,
   preferencesKey,
   savePreferences,
+  overScan = 10,
   ...rest
 }: DataTableProps<TableColumns, Data>) {
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -221,13 +223,13 @@ export function DataTable<TableColumns, Data extends TableColumns>({
       ? table.getPaginationRowModel()
       : table.getRowModel();
 
-  const enableVirtualization = isVirtualized && !isGrouped;
+  const enableVirtualization = isVirtualized;
 
   const { getVirtualItems, getTotalSize } = useVirtualizer({
     count: enableVirtualization ? rows.length : 0,
     getScrollElement: () => tableContainerRef.current,
     estimateSize: () => virtualizedRowEstimatedHeight,
-    overscan: 10
+    overscan: overScan
   });
 
   const virtualRows = enableVirtualization ? getVirtualItems() : [];

--- a/src/components/JobsHistory/JobsHistoryTable.tsx
+++ b/src/components/JobsHistory/JobsHistoryTable.tsx
@@ -89,6 +89,8 @@ export default function JobsHistoryTable({
         handleRowClick={onSelectJob}
         pagination={pagination}
         stickyHead
+        preferencesKey="job-history"
+        savePreferences={false}
       />
       <JobsHistoryDetails
         job={selectedJob}

--- a/src/components/Logs/Table/LogsTable.tsx
+++ b/src/components/Logs/Table/LogsTable.tsx
@@ -193,7 +193,7 @@ export function LogsTable({
   const { getVirtualItems, getTotalSize } = useVirtualizer({
     count: rows.length,
     getScrollElement: () => tableContainerRef.current,
-    estimateSize: () => 35,
+    estimateSize: () => 62,
     overscan: 10
   });
 
@@ -280,7 +280,6 @@ export function LogsTable({
                       style={{
                         width: cell.column.getSize()
                       }}
-                      className="overflow-hidden"
                     >
                       {flexRender(
                         cell.column.columnDef.cell,

--- a/src/components/Logs/Table/LogsTableCells.tsx
+++ b/src/components/Logs/Table/LogsTableCells.tsx
@@ -2,7 +2,8 @@ import { Cell } from "@tanstack/react-table";
 import dayjs from "dayjs";
 import LogItem from "../../../types/Logs";
 import { IndeterminateCheckbox } from "../../IndeterminateCheckbox/IndeterminateCheckbox";
-import { TagList } from "../../TagList/TagList";
+import Popover from "../../Popover/Popover";
+import { TagItem, TagList } from "../../TagList/TagList";
 
 export type LogsTableTimestampCellProps = React.HTMLProps<HTMLDivElement> & {
   cell: Cell<LogItem, unknown>;
@@ -47,5 +48,31 @@ export function LogsTableLabelsCell({
     };
   });
 
-  return <TagList tags={tags} />;
+  return (
+    <Popover
+      toggle={
+        <div className="flex flex-row items-center">
+          <div className="flex-shrink overflow-x-hidden cursor-pointer">
+            <TagItem tag={tags[0]!} />
+          </div>
+          {tags.length > 1 && (
+            <div className="flex-shrink space-x-2 underline decoration-solid justify-left text-xs  cursor-pointer">
+              +{tags.length - 1} more
+            </div>
+          )}
+        </div>
+      }
+      placement="left"
+    >
+      <div className="flex flex-col p-1">
+        <div className="flex flex-col items-stretch max-h-96 overflow-y-auto">
+          <TagList
+            className="flex flex-col flex-1"
+            tags={tags}
+            minimumItemsToShow={tags.length}
+          />
+        </div>
+      </div>
+    </Popover>
+  );
 }

--- a/src/components/TagList/TagList.tsx
+++ b/src/components/TagList/TagList.tsx
@@ -65,7 +65,7 @@ export function TagList({ tags, minimumItemsToShow = 1 }: TagListProps) {
         style={
           !showAll
             ? {
-                height: `${1.75 * minimumItemsToShow}rem`
+                maxHeight: `${1.75 * minimumItemsToShow}rem`
               }
             : {}
         }

--- a/src/components/TagList/TagList.tsx
+++ b/src/components/TagList/TagList.tsx
@@ -7,18 +7,51 @@ type TagEntry = {
   value: string;
 };
 
-type TagListProps = {
+type TagListProps = React.HTMLProps<HTMLDivElement> & {
   tags: TagEntry[];
   minimumItemsToShow?: number;
 };
 
-export function TagList({ tags, minimumItemsToShow = 1 }: TagListProps) {
+type TagItemProps = {
+  containerWidth?: string;
+  tag: {
+    key: string;
+    value: string;
+  };
+};
+
+export function TagItem({ tag: { key, value }, containerWidth }: TagItemProps) {
+  return (
+    <div
+      className="flex flex-row p-[0.15rem] bg-gray-200 rounded-md mx-1"
+      data-tip={`${key}:${value}`}
+    >
+      <div
+        className="flex flex-row space-x-1 font-semibold p-[0.2rem] text-gray-600 text-xs truncate"
+        style={containerWidth ? { width: containerWidth } : {}}
+      >
+        <span className="inline">{key}:</span>
+        <span className="inline font-light">{value}</span>
+      </div>
+    </div>
+  );
+}
+
+export function TagList({
+  tags,
+  minimumItemsToShow = 1,
+  className = `flex flex-row text-left items-start flex-1`,
+  ...rest
+}: TagListProps) {
   const [showAll, setShowAll] = useState(false);
 
   const outerContainerRef = useRef<HTMLDivElement>(null);
   const innerContainerRef = useRef<HTMLDivElement>(null);
 
   const [isOverflowing, setIsOverflowing] = useState(false);
+  const containerWidth = `${
+    (innerContainerRef.current?.clientWidth || 0) - 10
+  }px`;
 
   useEffect(() => {
     const handleResize = () => {
@@ -35,16 +68,10 @@ export function TagList({ tags, minimumItemsToShow = 1 }: TagListProps) {
   }, []);
 
   return (
-    <div
-      ref={outerContainerRef}
-      className={`flex flex-row text-left items-start h-full`}
-    >
+    <div ref={outerContainerRef} className={className} {...rest}>
       {isOverflowing && (
         <button
           onClick={(e) => {
-            /* Don't trigger click for parent. E.g without stopPropagation,
-           handleRowClick would be called. */
-            e.stopPropagation();
             setShowAll((showMore) => !showMore);
           }}
           className="text-sm focus:outline-none"
@@ -56,31 +83,27 @@ export function TagList({ tags, minimumItemsToShow = 1 }: TagListProps) {
           )}
         </button>
       )}
+
       <div
         ref={innerContainerRef}
         className={clsx(
-          `flex flex-wrap flex-1 h-auto`,
+          `flex flex-col flex-1 h-auto space-y-2`,
           !showAll ? `overflow-y-hidden` : ""
         )}
         style={
           !showAll
             ? {
-                maxHeight: `${1.75 * minimumItemsToShow}rem`
+                maxHeight: `${2.25 * minimumItemsToShow}rem`
               }
             : {}
         }
       >
         {tags.map(({ key, value }) => (
-          <div className="flex flex-row p-[0.15rem] max-w-full" key={key}>
-            <div className="flex flex-row max-w-full space-x-1 font-semibold p-[0.2rem] bg-gray-200 text-gray-600 rounded-md text-xs">
-              <span className="inline text-ellipsis overflow-hidden">
-                {key}:
-              </span>
-              <span className="inline text-ellipsis overflow-hidden font-light">
-                {value}
-              </span>
-            </div>
-          </div>
+          <TagItem
+            key={key}
+            tag={{ key, value }}
+            containerWidth={containerWidth}
+          />
         ))}
       </div>
     </div>

--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -51,6 +51,8 @@ export function UserList({
         tableStyle={{ borderSpacing: "0" }}
         isLoading={isLoading}
         style={{ maxHeight: "calc(100vh - 12rem)" }}
+        preferencesKey="user-list"
+        savePreferences={false}
       />
     </div>
   );

--- a/src/hooks/useMouseActivity.ts
+++ b/src/hooks/useMouseActivity.ts
@@ -7,7 +7,7 @@ export function useOnMouseActivity() {
 
   useEffect(() => {
     const listener = (event: MouseEvent) => {
-      if (ref.current?.contains(event.target)) {
+      if (ref.current?.contains(event.target as HTMLElement)) {
         return;
       }
       setIsActive(false);

--- a/src/hooks/userPreferences.ts
+++ b/src/hooks/userPreferences.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+
+export default function usePreferences<T>(key: string) {
+  const preferences = useMemo<T>(() => {
+    const data = sessionStorage.getItem(key) || "{}";
+    try {
+      return JSON.parse(data!);
+    } catch (ex) {
+      return {};
+    }
+  }, [key]);
+
+  const storePreferences = (data: T) => {
+    sessionStorage.setItem(key, JSON.stringify(data));
+  };
+
+  return {
+    storePreferences,
+    preferences
+  };
+}


### PR DESCRIPTION
- [x] remove tooltips
- [x] style the popover it should look different from background ui & only one popover should be shown.
- [x] only clicking on more should open popover
- [x] if there is one item don't show popover
- [x] auto close popover after 5 seconds after opened.
- [x] improve performance of config list