### PR TITLE
fix: hide details not found text when loading on config sidebar

### DIFF
--- a/src/components/ConfigSidebar/ConfigDetails.tsx
+++ b/src/components/ConfigSidebar/ConfigDetails.tsx
@@ -71,8 +71,9 @@ export function ConfigDetails({ configId }: Props) {
       }
     >
       <div className="flex flex-col space-y-2 py-2 max-w-full">
-        {isLoading && <TextSkeletonLoader />}
-        {displayDetails && !error ? (
+        {isLoading ? (
+          <TextSkeletonLoader />
+        ) : displayDetails && !error ? (
           <DescriptionCard items={displayDetails} />
         ) : (
           <InfoMessage message="Details not found" />


### PR DESCRIPTION
Closes #824

https://user-images.githubusercontent.com/34602861/221948659-d54be93d-0b04-4fa9-8684-67710bcbe024.mov