### PR TITLE
fix: match table outline corner to table background corner radius

### DIFF
--- a/src/components/Canary/table.tsx
+++ b/src/components/Canary/table.tsx
@@ -19,7 +19,7 @@ import clsx from "clsx";
 const styles = {
   outerDivClass: "border-l border-r border-gray-300 overflow-y-scroll",
   topBgClass: "bg-red-500",
-  tableClass: "min-w-full border-separate shadow-lg bg-white rounded-lg",
+  tableClass: "min-w-full border-separate shadow-lg bg-white",
   theadClass: "bg-white z-10 sticky top-0",
   theadRowClass: "z-10",
   theadHeaderClass:


### PR DESCRIPTION
closes #836

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.