### PR TITLE
fix: incident details sidebar ui/ux improvements

### DIFF
--- a/src/components/Changelog/IncidentChangelog.tsx
+++ b/src/components/Changelog/IncidentChangelog.tsx
@@ -1,10 +1,7 @@
 import { useEffect } from "react";
 import { MdRefresh } from "react-icons/md";
 import { RiPlayListAddFill } from "react-icons/ri";
-import {
-  useIncidentQuery,
-  useIncidentsHistoryQuery
-} from "../../api/query-hooks";
+import { useIncidentsHistoryQuery } from "../../api/query-hooks";
 import { useIncidentState } from "../../store/incident.state";
 import { Badge } from "../Badge";
 import { ClickableSvg } from "../ClickableSvg/ClickableSvg";
@@ -66,26 +63,26 @@ export function IncidentChangelog({
           </div>
         </div>
       }
+      className={className}
+      {...props}
     >
-      <div className={className} {...props}>
-        {isLoading || !incidentHistory ? (
-          <Loading text="Loading ..." />
-        ) : incidentHistory.length > 0 ? (
-          <VerticalSCrollView>
-            <div className="px-8 py-2">
-              <ul className="border-l border-gray-200 dark:border-gray-900 relative flex-col px-4">
-                {incidentHistory.map((history) => (
-                  <IncidentChangelogItem key={history.id} history={history} />
-                ))}
-              </ul>
-            </div>
-          </VerticalSCrollView>
-        ) : (
-          <div className="px-4 py-4">
-            <p className="text-gray-800">No changelog found</p>
+      {isLoading || !incidentHistory ? (
+        <Loading text="Loading ..." />
+      ) : incidentHistory.length > 0 ? (
+        <VerticalSCrollView>
+          <div className="px-8 py-2">
+            <ul className="border-l border-gray-200 dark:border-gray-900 relative flex-col px-4">
+              {incidentHistory.map((history) => (
+                <IncidentChangelogItem key={history.id} history={history} />
+              ))}
+            </ul>
           </div>
-        )}
-      </div>
+        </VerticalSCrollView>
+      ) : (
+        <div className="px-4 py-4">
+          <p className="text-gray-800">No changelog found</p>
+        </div>
+      )}
     </CollapsiblePanel>
   );
 }

--- a/src/components/Changelog/IncidentChangelog.tsx
+++ b/src/components/Changelog/IncidentChangelog.tsx
@@ -70,7 +70,7 @@ export function IncidentChangelog({
         <Loading text="Loading ..." />
       ) : incidentHistory.length > 0 ? (
         <VerticalSCrollView>
-          <div className="px-8 py-2">
+          <div className="px-4 py-4">
             <ul className="border-l border-gray-200 dark:border-gray-900 relative flex-col px-4">
               {incidentHistory.map((history) => (
                 <IncidentChangelogItem key={history.id} history={history} />

--- a/src/components/CollapsiblePanel/index.tsx
+++ b/src/components/CollapsiblePanel/index.tsx
@@ -22,6 +22,7 @@ export default function CollapsiblePanel({
     <div
       className={clsx("flex flex-col", isOpen && "flex-1", className)}
       {...props}
+      data-minimized={!isOpen}
     >
       <div
         onClick={() => setIsOpen(!isOpen)}

--- a/src/components/CollapsiblePanel/index.tsx
+++ b/src/components/CollapsiblePanel/index.tsx
@@ -20,7 +20,7 @@ export default function CollapsiblePanel({
 
   return (
     <div
-      className={clsx("flex flex-col", isOpen && "flex-1", className)}
+      className={clsx("flex flex-col", className)}
       {...props}
       data-minimized={!isOpen}
     >

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
@@ -145,9 +145,9 @@ export function IncidentsDefinitionOfDone({
     >
       <div className="flex flex-col">
         <div className="flex overflow-x-hidden w-full px-4 pb-6">
-          <div className="w-full">
+          <div className="w-full space-y-1">
             {isLoading && !incident ? (
-              <div className="flex items-start py-2 pl-2 pr-2">
+              <div className="flex items-start pl-2 pr-2">
                 <div className="text-sm text-gray-500">
                   Loading evidences please wait...
                 </div>

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
@@ -13,6 +13,7 @@ import { BsCardChecklist } from "react-icons/bs";
 import { ClickableSvg } from "../../ClickableSvg/ClickableSvg";
 import { Badge } from "../../Badge";
 import { useIncidentState } from "../../../store/incident.state";
+import EmptyState from "../../EmptyState";
 
 type DefinitionOfDoneProps = React.HTMLProps<HTMLDivElement> & {
   incidentId: string;
@@ -208,6 +209,7 @@ export function IncidentsDefinitionOfDone({
           }}
           rootHypothesis={rootHypothesis!}
         />
+        {dodEvidences.length === 0 && !isLoading && <EmptyState />}
       </div>
     </CollapsiblePanel>
   );

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
@@ -14,7 +14,7 @@ import { ClickableSvg } from "../../ClickableSvg/ClickableSvg";
 import { Badge } from "../../Badge";
 import { useIncidentState } from "../../../store/incident.state";
 
-type DefinitionOfDoneProps = {
+type DefinitionOfDoneProps = React.HTMLProps<HTMLDivElement> & {
   incidentId: string;
 };
 
@@ -54,7 +54,9 @@ function AddDefinitionOfDone({ onClick, ...rest }: AddDefinitionOfDoneProps) {
 }
 
 export function IncidentsDefinitionOfDone({
-  incidentId
+  incidentId,
+  className,
+  ...props
 }: DefinitionOfDoneProps) {
   const [openDeleteConfirmDialog, setOpenDeleteConfirmDialog] = useState(false);
   const [evidenceBeingRemoved, setEvidenceBeingRemoved] = useState<Evidence>();
@@ -138,6 +140,8 @@ export function IncidentsDefinitionOfDone({
           </div>
         </div>
       }
+      className={clsx(className)}
+      {...props}
     >
       <div className="flex flex-col">
         <div className="flex overflow-x-hidden w-full px-4 pb-6">

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
@@ -144,7 +144,7 @@ export function IncidentsDefinitionOfDone({
       {...props}
     >
       <div className="flex flex-col">
-        <div className="flex overflow-x-hidden w-full px-4 pb-6">
+        <div className="flex overflow-x-hidden w-full pb-6">
           <div className="w-full space-y-1">
             {isLoading && !incident ? (
               <div className="flex items-start pl-2 pr-2">

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDoneItem.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDoneItem.tsx
@@ -40,7 +40,7 @@ export default function IncidentsDefinitionOfDoneItem({
 
   return (
     <>
-      <div className="relative flex items-center py-2">
+      <div className="relative flex items-center">
         {isLoading ? (
           <MdRefresh className="animate-spin" />
         ) : evidence.done ? (
@@ -49,7 +49,7 @@ export default function IncidentsDefinitionOfDoneItem({
           <BsHourglassSplit className="mr-1" />
         )}
 
-        <div className="min-w-0 flex-1 text-sm ml-2">
+        <div className="min-w-0 flex-1 text-sm">
           <EvidenceView evidence={evidence} size={Size.small} />
         </div>
         <div className="flex items-center">

--- a/src/components/IncidentDetails/IncidentDetailsPanel.tsx
+++ b/src/components/IncidentDetails/IncidentDetailsPanel.tsx
@@ -88,9 +88,9 @@ export function IncidentDetailsPanel({
       className={clsx(className)}
       {...props}
     >
-      <div className="flex flex-col">
+      <div className="flex flex-col space-y-2">
         <div className="py-4 border-b border-gray-200 hidden">
-          <div className="flex justify-between px-4">
+          <div className="flex justify-between">
             <h2 className="mt-0.5 text-2xl font-medium leading-7 text-dark-gray">
               Details
             </h2>
@@ -104,7 +104,7 @@ export function IncidentDetailsPanel({
         </div>
         <IncidentDetailsRow
           title="Type"
-          className="mt-3 px-4"
+          className=""
           value={
             <IncidentTypeDropdown
               control={control}
@@ -119,7 +119,7 @@ export function IncidentDetailsPanel({
         />
         <IncidentDetailsRow
           title="Status"
-          className="mt-3 px-4"
+          className=""
           value={
             <IncidentWorkflow
               control={control}
@@ -133,7 +133,7 @@ export function IncidentDetailsPanel({
         />
         <IncidentDetailsRow
           title="Priority"
-          className="mt-3 px-4"
+          className=""
           value={
             <ReactSelectDropdown
               control={control}
@@ -147,7 +147,7 @@ export function IncidentDetailsPanel({
         />
         <IncidentDetailsRow
           title="Commanders"
-          className="mt-4 px-4"
+          className=""
           value={
             <ReactSelectDropdown
               control={control}
@@ -159,10 +159,10 @@ export function IncidentDetailsPanel({
             />
           }
         />
-        <Responders incident={incident} />
+        <Responders className="py-3" incident={incident} />
         <IncidentDetailsRow
           title="Started"
-          className="mt-2.5 px-4"
+          className="h-8"
           value={
             <span className="text-gray-500 font-medium">
               {formattedCreatedAt}
@@ -171,7 +171,7 @@ export function IncidentDetailsPanel({
         />
         <IncidentDetailsRow
           title="Duration"
-          className="mt-2.5 px-4"
+          className="h-8"
           value={
             <span className="text-gray-500 font-medium">
               {formattedDuration}

--- a/src/components/IncidentDetails/IncidentDetailsPanel.tsx
+++ b/src/components/IncidentDetails/IncidentDetailsPanel.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { useMemo, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { BsCardList, BsShareFill } from "react-icons/bs";
@@ -12,6 +13,7 @@ import Title from "../Title/title";
 import { IncidentDetailsRow } from "./IncidentDetailsRow";
 import { priorities } from "./IncidentSidebar";
 import { IncidentWorkflow } from "./IncidentWorkflow";
+import { Responders } from "./Responders";
 
 type IncidentDetailsPanelProps = React.HTMLProps<HTMLDivElement> & {
   incident: Incident;
@@ -20,7 +22,9 @@ type IncidentDetailsPanelProps = React.HTMLProps<HTMLDivElement> & {
 
 export function IncidentDetailsPanel({
   incident,
-  updateIncidentHandler
+  updateIncidentHandler,
+  className,
+  ...props
 }: IncidentDetailsPanelProps) {
   const commandersArray = useMemo(
     () => [
@@ -81,6 +85,8 @@ export function IncidentDetailsPanel({
       Header={
         <Title title="Details" icon={<BsCardList className="w-6 h-6" />} />
       }
+      className={clsx(className)}
+      {...props}
     >
       <div className="flex flex-col">
         <div className="py-4 border-b border-gray-200 hidden">
@@ -96,38 +102,6 @@ export function IncidentDetailsPanel({
             </button>
           </div>
         </div>
-        <IncidentDetailsRow
-          title="Commanders"
-          className="mt-4 px-4"
-          value={
-            <ReactSelectDropdown
-              control={control}
-              label=""
-              name="commanders"
-              className="w-full"
-              items={commandersArray}
-              value={watchCommanders}
-            />
-          }
-        />
-        <IncidentDetailsRow
-          title="Started"
-          className="mt-2.5 px-4"
-          value={
-            <span className="text-gray-500 font-medium">
-              {formattedCreatedAt}
-            </span>
-          }
-        />
-        <IncidentDetailsRow
-          title="Duration"
-          className="mt-2.5 px-4"
-          value={
-            <span className="text-gray-500 font-medium">
-              {formattedDuration}
-            </span>
-          }
-        />
         <IncidentDetailsRow
           title="Type"
           className="mt-3 px-4"
@@ -169,6 +143,39 @@ export function IncidentDetailsPanel({
               items={priorities}
               value={watchPriority}
             />
+          }
+        />
+        <IncidentDetailsRow
+          title="Commanders"
+          className="mt-4 px-4"
+          value={
+            <ReactSelectDropdown
+              control={control}
+              label=""
+              name="commanders"
+              className="w-full"
+              items={commandersArray}
+              value={watchCommanders}
+            />
+          }
+        />
+        <Responders incident={incident} />
+        <IncidentDetailsRow
+          title="Started"
+          className="mt-2.5 px-4"
+          value={
+            <span className="text-gray-500 font-medium">
+              {formattedCreatedAt}
+            </span>
+          }
+        />
+        <IncidentDetailsRow
+          title="Duration"
+          className="mt-2.5 px-4"
+          value={
+            <span className="text-gray-500 font-medium">
+              {formattedDuration}
+            </span>
           }
         />
       </div>

--- a/src/components/IncidentDetails/IncidentSidebar.tsx
+++ b/src/components/IncidentDetails/IncidentSidebar.tsx
@@ -28,7 +28,7 @@ export const IncidentSidebar = ({
       <IncidentDetailsPanel
         incident={incident}
         updateIncidentHandler={updateIncidentHandler}
-        data-panel-height-ratio="1.5"
+        data-panel-height-ratio="1.25"
       />
       <IncidentsDefinitionOfDone
         incidentId={incident.id}
@@ -37,7 +37,7 @@ export const IncidentSidebar = ({
       <IncidentChangelog
         incidentId={incident.id}
         className="flex flex-col bg-white"
-        data-panel-height-ratio="0.75"
+        data-panel-height-ratio="1.0"
       />
     </SlidingSideBar>
   );

--- a/src/components/IncidentDetails/IncidentSidebar.tsx
+++ b/src/components/IncidentDetails/IncidentSidebar.tsx
@@ -29,12 +29,17 @@ export const IncidentSidebar = ({
       <IncidentDetailsPanel
         incident={incident}
         updateIncidentHandler={updateIncidentHandler}
+        data-panel-height-ratio="1.25"
       />
-      <RespondersPanel incident={incident} />
-      <IncidentsDefinitionOfDone incidentId={incident.id} />
+      <RespondersPanel incident={incident} data-panel-height-ratio="0.75" />
+      <IncidentsDefinitionOfDone
+        incidentId={incident.id}
+        data-panel-height-ratio="0.75"
+      />
       <IncidentChangelog
         incidentId={incident.id}
         className="flex flex-col bg-white"
+        data-panel-height-ratio="1.25"
       />
     </SlidingSideBar>
   );

--- a/src/components/IncidentDetails/IncidentSidebar.tsx
+++ b/src/components/IncidentDetails/IncidentSidebar.tsx
@@ -28,7 +28,7 @@ export const IncidentSidebar = ({
       <IncidentDetailsPanel
         incident={incident}
         updateIncidentHandler={updateIncidentHandler}
-        data-panel-height-ratio="1.25"
+        data-panel-height-ratio="1.125"
       />
       <IncidentsDefinitionOfDone
         incidentId={incident.id}
@@ -37,7 +37,7 @@ export const IncidentSidebar = ({
       <IncidentChangelog
         incidentId={incident.id}
         className="flex flex-col bg-white"
-        data-panel-height-ratio="1.0"
+        data-panel-height-ratio="1.125"
       />
     </SlidingSideBar>
   );

--- a/src/components/IncidentDetails/IncidentSidebar.tsx
+++ b/src/components/IncidentDetails/IncidentSidebar.tsx
@@ -4,7 +4,6 @@ import { Incident, IncidentStatus } from "../../api/services/incident";
 import { IncidentsDefinitionOfDone } from "./DefinitionOfDone/IncidentsDefinitionOfDone";
 import { IncidentChangelog } from "../Changelog/IncidentChangelog";
 import SlidingSideBar from "../SlidingSideBar";
-import { RespondersPanel } from "./RespondersPanel";
 import { IncidentDetailsPanel } from "./IncidentDetailsPanel";
 
 export const priorities = Object.entries(severityItems).map(([key, value]) => ({
@@ -29,9 +28,8 @@ export const IncidentSidebar = ({
       <IncidentDetailsPanel
         incident={incident}
         updateIncidentHandler={updateIncidentHandler}
-        data-panel-height-ratio="1.25"
+        data-panel-height-ratio="1.5"
       />
-      <RespondersPanel incident={incident} data-panel-height-ratio="0.75" />
       <IncidentsDefinitionOfDone
         incidentId={incident.id}
         data-panel-height-ratio="0.75"
@@ -39,7 +37,7 @@ export const IncidentSidebar = ({
       <IncidentChangelog
         incidentId={incident.id}
         className="flex flex-col bg-white"
-        data-panel-height-ratio="1.25"
+        data-panel-height-ratio="0.75"
       />
     </SlidingSideBar>
   );

--- a/src/components/IncidentDetails/Responders.tsx
+++ b/src/components/IncidentDetails/Responders.tsx
@@ -49,7 +49,7 @@ export function Responders({ incident, className, ...props }: RespondersProps) {
     <div className={clsx(className)} {...props}>
       <IncidentDetailsRow
         title="Responders"
-        className="mt-4 px-4"
+        className=""
         value={
           <div className="relative flex items-center">
             <div className="flex items-center bg-white rounded-md group">

--- a/src/components/IncidentDetails/Responders.tsx
+++ b/src/components/IncidentDetails/Responders.tsx
@@ -1,25 +1,23 @@
+import clsx from "clsx";
 import { useState } from "react";
 import { BsTrash } from "react-icons/bs";
-import { MdOutlineQuickreply } from "react-icons/md";
 import { useIncidentRespondersQuery } from "../../api/query-hooks/useIncidentRespondersQuery";
 import { Incident } from "../../api/services/incident";
 import { deleteResponder } from "../../api/services/responder";
-import { Badge } from "../Badge";
 import { ClickableSvg } from "../ClickableSvg/ClickableSvg";
-import CollapsiblePanel from "../CollapsiblePanel";
 import { ConfirmationPromptDialog } from "../Dialogs/ConfirmationPromptDialog";
 import { IconButton } from "../IconButton";
-import Title from "../Title/title";
 import { toastSuccess, toastError } from "../Toast/toast";
 import { AddResponder } from "./AddResponder";
+import { IncidentDetailsRow } from "./IncidentDetailsRow";
 import { ResponderDetailsDialog } from "./ResponderDetailsDialog";
 import { ResponderDetailsToolTip } from "./ResponderDetailsToolTip";
 
-type RespondersPanelProps = React.HTMLProps<HTMLDivElement> & {
+type RespondersProps = React.HTMLProps<HTMLDivElement> & {
   incident: Incident;
 };
 
-export function RespondersPanel({ incident }: RespondersPanelProps) {
+export function Responders({ incident, className, ...props }: RespondersProps) {
   const { data: responders = [], refetch } = useIncidentRespondersQuery(
     incident.id
   );
@@ -48,29 +46,47 @@ export function RespondersPanel({ incident }: RespondersPanelProps) {
   }
 
   return (
-    <CollapsiblePanel
-      Header={
-        <div className="flex flex-row w-full items-center space-x-2">
-          <Title
-            title="Responders"
-            icon={<MdOutlineQuickreply className="w-6 h-6" />}
-          />
-          <Badge
-            className="w-5 h-5 flex items-center justify-center"
-            roundedClass="rounded-full"
-            text={responders?.length ?? 0}
-          />
-        </div>
-      }
-    >
+    <div className={clsx(className)} {...props}>
+      <IncidentDetailsRow
+        title="Responders"
+        className="mt-4 px-4"
+        value={
+          <div className="relative flex items-center">
+            <div className="flex items-center bg-white rounded-md group">
+              <span className="flex items-center justify-center w-5 h-5 text-gray-400 border-2 border-gray-300 border-dashed rounded-full">
+                <svg
+                  className="w-5 h-5"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z"
+                    clipRule="evenodd"
+                  ></path>
+                </svg>
+              </span>
+              <span className="ml-2 text-sm font-medium text-blue-600 group-hover:text-blue-500">
+                <AddResponder
+                  className="flex justify-end flex-1 w-full"
+                  onSuccess={() => refetch()}
+                  incident={incident}
+                />
+              </span>
+            </div>
+          </div>
+        }
+      />
       <div className="flex flex-col">
         {Boolean(responders.length) && (
-          <div className="px-4">
+          <div className="px-4 space-y-2">
             {responders.map((responder) => {
               return (
                 <div
                   key={responder.json.id}
-                  className="relative flex items-center py-2 mt-1 rounded"
+                  className="relative flex items-center mt-1 rounded"
                 >
                   <div className="flex-1 w-full min-w-0">
                     <ResponderDetailsToolTip
@@ -152,32 +168,6 @@ export function RespondersPanel({ incident }: RespondersPanelProps) {
             })}
           </div>
         )}
-        <div className="relative flex items-center py-2 px-4">
-          <div className="flex items-center bg-white rounded-md group">
-            <span className="flex items-center justify-center w-5 h-5 text-gray-400 border-2 border-gray-300 border-dashed rounded-full">
-              <svg
-                className="w-5 h-5"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z"
-                  clipRule="evenodd"
-                ></path>
-              </svg>
-            </span>
-            <span className="ml-2 text-sm font-medium text-blue-600 group-hover:text-blue-500">
-              <AddResponder
-                className="flex justify-end flex-1 w-full"
-                onSuccess={() => refetch()}
-                incident={incident}
-              />
-            </span>
-          </div>
-        </div>
         <ConfirmationPromptDialog
           isOpen={openDeleteConfirmDialog}
           title="Delete Responder ?"
@@ -197,6 +187,6 @@ export function RespondersPanel({ incident }: RespondersPanelProps) {
           }}
         />
       </div>
-    </CollapsiblePanel>
+    </div>
   );
 }

--- a/src/components/SlidingSideBar/index.tsx
+++ b/src/components/SlidingSideBar/index.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { useEffect, useRef, useState } from "react";
 import { IoChevronBackOutline, IoChevronForwardOutline } from "react-icons/io5";
+import useRunTaskOnPropChange from "../../hooks/useRunTaskOnPropChange";
 
 type Props = React.HTMLProps<HTMLDivElement> & {
   children?: React.ReactNode;
@@ -16,43 +17,71 @@ export default function SlidingSideBar({
   const [open, setOpen] = useState<boolean>(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (contentRef.current?.children) {
-      const totalHeight = contentRef.current.clientHeight;
-      let fixedHeightsTotal = 0;
-      let fixedHeightChildCount = 0;
-      const children = [...contentRef.current?.children];
-      children.forEach((item) => {
-        const panelHeight = item.getAttribute("data-panel-height");
-        let panelHeightRatio = item.getAttribute("data-panel-height-ratio");
-        if (panelHeight && panelHeight !== "auto") {
-          fixedHeightsTotal += parseFloat(panelHeight || "0px");
-          ++fixedHeightChildCount;
-        } else {
-          item.setAttribute("data-panel-height", "auto");
-        }
-        if (!panelHeightRatio) {
-          item.setAttribute("data-panel-height-ratio", "1");
-        }
-      });
-      const childrenWithAutoHeight = children.length - fixedHeightChildCount;
-      const remainingHeight = totalHeight - fixedHeightsTotal;
-      const itemHeight = remainingHeight / childrenWithAutoHeight;
-      children.forEach((item) => {
-        const child = item as HTMLDivElement;
-        const panelHeight = item.getAttribute("data-panel-height");
-        const panelHeightRatio = parseFloat(
-          item.getAttribute("data-panel-height-ratio")!
-        );
-        const height =
-          panelHeight === "auto"
-            ? itemHeight * panelHeightRatio
-            : `${parseFloat(panelHeight!)}`;
-        child.style.setProperty("max-height", `${height}px`);
-        child.style.setProperty("height", `${height}px`);
-      });
+  function configureChildrenHeights() {
+    if (!contentRef.current?.children) {
+      return;
     }
+    const totalHeight = contentRef.current.clientHeight;
+    let fixedHeightsTotal = 0;
+    let fixedHeightChildCount = 0;
+    const children = [...contentRef.current?.children];
+    children.forEach((item) => {
+      let panelHeight = item.getAttribute("data-panel-height");
+      if (item.getAttribute("data-minimized") === "true") {
+        panelHeight = `${item.clientHeight}px`;
+      }
+      let panelHeightRatio = item.getAttribute("data-panel-height-ratio");
+      if (panelHeight && panelHeight !== "auto") {
+        fixedHeightsTotal += parseFloat(panelHeight || "0px");
+        ++fixedHeightChildCount;
+      } else {
+        item.setAttribute("data-panel-height", "auto");
+      }
+      if (!panelHeightRatio) {
+        item.setAttribute("data-panel-height-ratio", "1");
+      }
+    });
+    const childrenWithAutoHeight = children.length - fixedHeightChildCount;
+    const remainingHeight = totalHeight - fixedHeightsTotal;
+    const itemHeight = remainingHeight / childrenWithAutoHeight;
+    children.forEach((item) => {
+      const child = item as HTMLDivElement;
+      let panelHeight = item.getAttribute("data-panel-height");
+      if (item.getAttribute("data-minimized") === "true") {
+        panelHeight = `${item.clientHeight}px`;
+      }
+      const panelHeightRatio = parseFloat(
+        item.getAttribute("data-panel-height-ratio")!
+      );
+      const height =
+        panelHeight === "auto"
+          ? itemHeight * panelHeightRatio
+          : `${parseFloat(panelHeight!)}`;
+      child.style.setProperty("max-height", `${height}px`);
+    });
+  }
+
+  useEffect(() => {
+    configureChildrenHeights();
   }, [children, contentRef]);
+
+  useRunTaskOnPropChange(
+    () => {
+      if (!contentRef.current?.children) {
+        return;
+      }
+      const children = [...contentRef.current?.children];
+      let minimizedChildCount = 0;
+      children.forEach((child) => {
+        minimizedChildCount +=
+          child.getAttribute("data-minimized") === "true" ? 1 : 0;
+      });
+      return minimizedChildCount;
+    },
+    () => {
+      configureChildrenHeights();
+    }
+  );
 
   return (
     <div

--- a/src/components/SlidingSideBar/index.tsx
+++ b/src/components/SlidingSideBar/index.tsx
@@ -17,6 +17,16 @@ export default function SlidingSideBar({
   const [open, setOpen] = useState<boolean>(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
+  function calculateChildHeight(
+    panelHeight: string,
+    itemHeight: number,
+    panelHeightRatio: number
+  ) {
+    return panelHeight === "auto"
+      ? itemHeight * panelHeightRatio
+      : parseFloat(panelHeight!);
+  }
+
   function configureChildrenHeights() {
     if (!contentRef.current?.children) {
       return;
@@ -24,11 +34,14 @@ export default function SlidingSideBar({
     const totalHeight = contentRef.current.clientHeight;
     let fixedHeightsTotal = 0;
     let fixedHeightChildCount = 0;
+    let expandedChildCount = 0;
     const children = [...contentRef.current?.children];
     children.forEach((item) => {
       let panelHeight = item.getAttribute("data-panel-height");
       if (item.getAttribute("data-minimized") === "true") {
         panelHeight = `${item.clientHeight}px`;
+      } else {
+        ++expandedChildCount;
       }
       let panelHeightRatio = item.getAttribute("data-panel-height-ratio");
       if (panelHeight && panelHeight !== "auto") {
@@ -53,10 +66,11 @@ export default function SlidingSideBar({
       const panelHeightRatio = parseFloat(
         item.getAttribute("data-panel-height-ratio")!
       );
-      const height =
-        panelHeight === "auto"
-          ? itemHeight * panelHeightRatio
-          : `${parseFloat(panelHeight!)}`;
+      const height = calculateChildHeight(
+        panelHeight!,
+        itemHeight,
+        expandedChildCount === 1 ? 0.95 : panelHeightRatio
+      );
       child.style.setProperty("max-height", `${height}px`);
     });
   }

--- a/src/components/SlidingSideBar/index.tsx
+++ b/src/components/SlidingSideBar/index.tsx
@@ -24,22 +24,32 @@ export default function SlidingSideBar({
       const children = [...contentRef.current?.children];
       children.forEach((item) => {
         const panelHeight = item.getAttribute("data-panel-height");
+        let panelHeightRatio = item.getAttribute("data-panel-height-ratio");
         if (panelHeight && panelHeight !== "auto") {
-          fixedHeightsTotal += parseInt(panelHeight || "0px", 10);
+          fixedHeightsTotal += parseFloat(panelHeight || "0px");
           ++fixedHeightChildCount;
+        } else {
+          item.setAttribute("data-panel-height", "auto");
+        }
+        if (!panelHeightRatio) {
+          item.setAttribute("data-panel-height-ratio", "1");
         }
       });
-      const itemHeight =
-        (totalHeight - fixedHeightsTotal) /
-        (contentRef.current.children.length - fixedHeightChildCount);
+      const childrenWithAutoHeight = children.length - fixedHeightChildCount;
+      const remainingHeight = totalHeight - fixedHeightsTotal;
+      const itemHeight = remainingHeight / childrenWithAutoHeight;
       children.forEach((item) => {
         const child = item as HTMLDivElement;
         const panelHeight = item.getAttribute("data-panel-height");
+        const panelHeightRatio = parseFloat(
+          item.getAttribute("data-panel-height-ratio")!
+        );
         const height =
-          panelHeight === "auto" || !panelHeight
-            ? itemHeight
-            : `${parseInt(panelHeight, 10)}`;
+          panelHeight === "auto"
+            ? itemHeight * panelHeightRatio
+            : `${parseFloat(panelHeight!)}`;
         child.style.setProperty("max-height", `${height}px`);
+        child.style.setProperty("height", `${height}px`);
       });
     }
   }, [children, contentRef]);


### PR DESCRIPTION
Closes #812 & #966

- [x] Reduce the definition of done and responders panels to half the size of the others.
- [x] arrange incident details in this order:- type, status, priority, commanders, responders, start & duration.
- [x] show empty state block and align it centrally. 
- [x] We should resize all the panels if one of them is collapsed