### PR TITLE
937 config changes panel add virtual paging

### DIFF
--- a/src/api/query-hooks/index.ts
+++ b/src/api/query-hooks/index.ts
@@ -6,7 +6,7 @@ import {
   getAllConfigsMatchingQuery,
   getConfig,
   getConfigAnalysis,
-  getConfigChange,
+  getConfigChanges,
   getConfigInsight,
   getConfigInsights,
   getConfigTagsList,
@@ -278,19 +278,20 @@ export function useGetAllConfigsChangesQuery(
   );
 }
 
-export function useGetConfigChangesQueryById(id: string) {
-  return useQuery(["configs", "changes", id], () => getConfigChange(id), {
-    select: (res) => {
-      if (res.error) {
-        throw res.error;
-      }
-      return res?.data?.length === 0 ? [] : res?.data;
-    },
-    onError: (err: any) => {
-      toastError(err);
-    },
-    enabled: !!id
-  });
+export function useGetConfigChangesByConfigIdQuery(
+  id: string,
+  pageIndex?: number,
+  pageSize?: number,
+  keepPreviousData?: boolean
+) {
+  return useQuery(
+    ["configs", "changes", id, pageIndex, pageSize],
+    () => getConfigChanges(id, pageIndex, pageSize),
+    {
+      enabled: !!id,
+      keepPreviousData
+    }
+  );
 }
 
 export function useGetConfigByIdQuery(id: string) {

--- a/src/api/query-hooks/index.ts
+++ b/src/api/query-hooks/index.ts
@@ -288,7 +288,7 @@ export function useGetConfigChangesByConfigIdQuery(
     ["configs", "changes", id, pageIndex, pageSize],
     () => getConfigChanges(id, pageIndex, pageSize),
     {
-      enabled: !!id,
+      enabled: !!id && !!pageSize,
       keepPreviousData
     }
   );

--- a/src/api/query-hooks/useGetConfigChangesByConfigChangeIdQuery.ts
+++ b/src/api/query-hooks/useGetConfigChangesByConfigChangeIdQuery.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { getConfigChangeById } from "../services/configs";
+
+export function useGetConfigChangesByConfigChangeIdQuery(
+  id: string,
+  configId: string,
+  { enabled = true }
+) {
+  return useQuery(
+    ["configs", "changes", configId, id],
+    () => getConfigChangeById(id, configId),
+    {
+      enabled: !!id && !!configId && enabled
+    }
+  );
+}

--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -101,12 +101,41 @@ export const getConfigTagsList = () =>
 export const getConfigName = (id: string) =>
   resolve<ConfigItem[]>(ConfigDB.get(`/config_names?id=eq.${id}`));
 
-export const getConfigChange = (id: string) =>
-  resolve(
+export const getConfigChanges = (
+  id: string,
+  pageIndex?: number,
+  pageSize?: number
+) => {
+  let paginationQueryParams = "";
+  if (pageIndex !== undefined && pageSize !== undefined) {
+    paginationQueryParams = `&limit=${pageSize}&offset=${
+      pageIndex! * pageSize
+    }`;
+  }
+  return resolve(
     ConfigDB.get<ConfigTypeChanges[]>(
-      `/config_changes?config_id=eq.${id}&order=created_at.desc`
+      `/config_changes?config_id=eq.${id}&order=created_at.desc${paginationQueryParams}`,
+      {
+        headers: {
+          Prefer: "count=exact"
+        }
+      }
     )
   );
+};
+
+export const getConfigChangeById = (id: string, configId: string) => {
+  return resolve(
+    ConfigDB.get<ConfigTypeChanges[]>(
+      `/config_changes?config_id=eq.${configId}&id=eq.${id}`,
+      {
+        headers: {
+          Prefer: "count=exact"
+        }
+      }
+    )
+  );
+};
 
 type ConfigParams = {
   topologyId?: string;

--- a/src/components/ConfigChangeHistory/index.tsx
+++ b/src/components/ConfigChangeHistory/index.tsx
@@ -16,31 +16,40 @@ const columns: ColumnDef<ConfigTypeChanges>[] = [
     cell: function ConfigChangeTypeCell({ row, column }) {
       const changeType = row?.getValue(column.id) as string;
       return (
-        <>
+        <div className="text-ellipsis overflow-hidden">
           <Icon
             name={changeType}
             secondary="diff"
             className="w-5 h-auto pr-1"
           />
           {changeType}
-        </>
+        </div>
       );
     },
-    size: 16
+    size: 48
   },
   {
     header: "Summary",
-    accessorKey: "summary"
+    accessorKey: "summary",
+    meta: {
+      cellClassName: "text-ellipsis overflow-hidden"
+    }
   },
   {
     header: "Source",
     accessorKey: "source",
+    meta: {
+      cellClassName: "text-ellipsis overflow-hidden"
+    },
     size: 48
   },
   {
     header: "Created",
     accessorKey: "created_at",
-    size: 48,
+    meta: {
+      cellClassName: "text-ellipsis overflow-hidden"
+    },
+    size: 36,
     cell: DateCell
   }
 ];

--- a/src/components/ConfigChanges/Cells/ConfigChangeAgeCell.tsx
+++ b/src/components/ConfigChanges/Cells/ConfigChangeAgeCell.tsx
@@ -1,0 +1,12 @@
+import { CellContext } from "@tanstack/react-table";
+import { ConfigTypeChanges } from "..";
+import { relativeDateTime } from "../../../utils/date";
+
+export default function ConfigChangeAgeCell({
+  row,
+  column,
+  getValue
+}: CellContext<ConfigTypeChanges, unknown>) {
+  const age = relativeDateTime(row.original.created_at);
+  return <span className="flex flex-nowrap py-1">{age}</span>;
+}

--- a/src/components/ConfigChanges/Cells/ConfigChangeNameCell.tsx
+++ b/src/components/ConfigChanges/Cells/ConfigChangeNameCell.tsx
@@ -1,0 +1,23 @@
+import { CellContext } from "@tanstack/react-table";
+import { ConfigTypeChanges } from "..";
+import { ViewType } from "../../../types";
+import { ConfigDetailsChanges } from "../../ConfigDetailsChanges/ConfigDetailsChanges";
+
+export default function ConfigChangeNameCell({
+  row,
+  column,
+  getValue
+}: CellContext<ConfigTypeChanges, unknown>) {
+  const item = row.original;
+  return (
+    <div className="whitespace-nowrap py-1">
+      <ConfigDetailsChanges
+        key={item.id}
+        id={item.id}
+        configId={item.config_id}
+        viewType={ViewType.summary}
+        data={item}
+      />
+    </div>
+  );
+}

--- a/src/components/ConfigChanges/index.tsx
+++ b/src/components/ConfigChanges/index.tsx
@@ -4,7 +4,6 @@ import { GoDiff } from "react-icons/go";
 import { useGetConfigChangesByConfigIdQuery } from "../../api/query-hooks";
 import { ConfigItem } from "../../api/services/configs";
 import { User } from "../../api/services/users";
-import { Badge } from "../Badge";
 import CollapsiblePanel from "../CollapsiblePanel";
 import EmptyState from "../EmptyState";
 import Title from "../Title/title";
@@ -13,6 +12,7 @@ import ConfigChangeAgeCell from "./Cells/ConfigChangeAgeCell";
 import ConfigChangeNameCell from "./Cells/ConfigChangeNameCell";
 import { InfiniteTable } from "../InfiniteTable/InfiniteTable";
 import TextSkeletonLoader from "../SkeletonLoader/TextSkeletonLoader";
+import { CountBadge } from "../Badge/CountBadge";
 
 export type ConfigTypeChanges = {
   id: string;
@@ -117,18 +117,22 @@ export function ConfigChangesDetails({ configID }: Props) {
 }
 
 export default function ConfigChanges(props: Props) {
-  const { data: response } = useGetConfigChangesByConfigIdQuery(props.configID);
-  const count = response?.data?.length ?? 0;
+  const { data: response } = useGetConfigChangesByConfigIdQuery(
+    props.configID,
+    0,
+    50
+  );
+  const count = response?.totalEntries ?? 0;
 
   return (
     <CollapsiblePanel
       Header={
         <div className="flex flex-row w-full items-center space-x-2">
           <Title title="Changes" icon={<GoDiff className="w-6 h-auto" />} />
-          <Badge roundedClass="rounded-full" text={count} />
+          <CountBadge roundedClass="rounded-full" value={count} />
         </div>
       }
-      dataCount={data?.length}
+      dataCount={count}
     >
       <ConfigChangesDetails {...props} />
     </CollapsiblePanel>

--- a/src/components/DataTable/Pagination/Pagination.tsx
+++ b/src/components/DataTable/Pagination/Pagination.tsx
@@ -2,11 +2,16 @@ import clsx from "clsx";
 import { UsePaginationInstanceProps, UsePaginationState } from "react-table";
 import { Loading } from "../../Loading";
 
-type PaginationProps = React.HTMLProps<HTMLDivElement> &
+export type PaginationType = "lean" | "complete" | "virtual";
+
+export type PaginationProps = React.HTMLProps<HTMLDivElement> &
   Omit<UsePaginationInstanceProps<{}>, "page"> & {
     state: UsePaginationState<{}>;
     loading?: boolean;
+    paginationType: PaginationType;
   };
+
+const itemsPerPage = [5, 10, 25, 50, 100, 150, 200, 250, 300, 500, 1000];
 
 export const Pagination = ({
   canPreviousPage,
@@ -19,8 +24,13 @@ export const Pagination = ({
   setPageSize,
   state: { pageIndex, pageSize },
   loading,
+  paginationType,
   className
 }: PaginationProps) => {
+  if (pageOptions.length < 2) {
+    return null;
+  }
+
   return (
     <nav className={clsx("isolate rounded-md", className)}>
       <div className="inline-block pr-2">
@@ -28,7 +38,12 @@ export const Pagination = ({
           <div className="inline-block pr-2 font-bold">
             Page {pageIndex + 1} of {pageOptions.length}
           </div>
-          <div className="mt-1 inline-block rounded-md shadow-sm pr-2">
+          <div
+            className={clsx(
+              "mt-1 inline-block rounded-md shadow-sm pr-2",
+              paginationType === "complete" ? "" : "hidden"
+            )}
+          >
             <span className="px-4 py-2 inline-block items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500">
               Go to page
             </span>
@@ -45,13 +60,16 @@ export const Pagination = ({
             />
           </div>
           <select
-            className="rounded-md w-35 border-gray-300 py-2 pl-3 pr-10 shadow-sm inline-block"
+            className={clsx(
+              "rounded-md w-35 border-gray-300 py-2 pl-3 pr-10 shadow-sm inline-block",
+              paginationType === "complete" ? "" : "hidden"
+            )}
             value={pageSize}
             onChange={(e) => {
               setPageSize(Number(e.target.value));
             }}
           >
-            {[50, 100, 150, 200, 250, 300, 500, 1000].map((pageSize) => (
+            {itemsPerPage.map((pageSize) => (
               <option key={pageSize} value={pageSize}>
                 {pageSize}
               </option>

--- a/src/components/InfiniteTable/InfiniteTable.tsx
+++ b/src/components/InfiniteTable/InfiniteTable.tsx
@@ -1,0 +1,170 @@
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  ColumnDef,
+  Row,
+  flexRender
+} from "@tanstack/react-table";
+import React, { useCallback, useMemo, useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import clsx from "clsx";
+
+type InfiniteTableProps<T> = React.HTMLProps<HTMLDivElement> & {
+  columns: ColumnDef<T, any>[];
+  isFetching: boolean;
+  isLoading: boolean;
+  totalEntries: number;
+  allRows: T[];
+  fetchNextPage: () => void;
+  maxHeight?: string;
+  virtualizedRowEstimatedHeight?: number;
+  loaderView: React.ReactNode;
+  stickyHead?: boolean;
+};
+
+export function InfiniteTable<T>({
+  columns,
+  isFetching,
+  isLoading,
+  totalEntries,
+  allRows,
+  fetchNextPage,
+  maxHeight,
+  loaderView,
+  stickyHead,
+  virtualizedRowEstimatedHeight = 50
+}: InfiniteTableProps<T>) {
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const containerStyle = useMemo(() => {
+    if (!maxHeight) {
+      return {};
+    }
+    return {
+      maxHeight
+    };
+  }, [maxHeight]);
+
+  const fetchMoreOnBottomReached = useCallback(
+    (containerRefElement?: HTMLDivElement | null) => {
+      if (containerRefElement) {
+        const { scrollHeight, scrollTop, clientHeight } = containerRefElement;
+        if (
+          scrollHeight - scrollTop - clientHeight < 300 &&
+          !isFetching &&
+          allRows.length < totalEntries
+        ) {
+          fetchNextPage();
+        }
+      }
+    },
+    [isFetching, allRows, totalEntries, fetchNextPage]
+  );
+
+  const table = useReactTable<T>({
+    data: allRows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    debugTable: true
+  });
+
+  const { rows } = table.getRowModel();
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => tableContainerRef.current,
+    estimateSize: () => virtualizedRowEstimatedHeight,
+    overscan: 10
+  });
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const totalSize = rowVirtualizer.getTotalSize();
+
+  const paddingTop = virtualRows.length > 0 ? virtualRows?.[0]?.start || 0 : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? totalSize - (virtualRows?.[virtualRows.length - 1]?.end || 0)
+      : 0;
+
+  if (isLoading) {
+    return <div className="flex flex-col overflow-y-auto">{loaderView}</div>;
+  }
+
+  return (
+    <div
+      className="flex flex-col overflow-y-auto overflow-x-hidden"
+      onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
+      ref={tableContainerRef}
+      style={containerStyle}
+    >
+      <table
+        className={clsx(
+          `table-auto table-fixed w-full`,
+          stickyHead && "relative"
+        )}
+      >
+        <thead className={`bg-white ${stickyHead ? "sticky top-0 z-01" : ""}`}>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <th
+                    key={header.id}
+                    colSpan={header.colSpan}
+                    style={{ width: header.getSize(), textAlign: "left" }}
+                  >
+                    {header.isPlaceholder ? null : (
+                      <div
+                        {...{
+                          className: header.column.getCanSort()
+                            ? "cursor-pointer select-none"
+                            : "",
+                          onClick: header.column.getToggleSortingHandler()
+                        }}
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                      </div>
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {paddingTop > 0 && (
+            <tr>
+              <td style={{ height: `${paddingTop}px` }} />
+            </tr>
+          )}
+          {virtualRows.map((virtualRow) => {
+            const row = rows[virtualRow.index] as Row<T>;
+            return (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+          {paddingBottom > 0 && (
+            <tr>
+              <td style={{ height: `${paddingBottom}px` }} />
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/Sidebars/configs.tsx
+++ b/src/components/Sidebars/configs.tsx
@@ -64,7 +64,7 @@ export function ConfigsList({
   return (
     <div className="flex flex-col space-y-4 text-sm">
       {isLoading ? (
-        <TextSkeletonLoader />
+        <TextSkeletonLoader className="w-full my-2" />
       ) : configs.length > 0 ? (
         <ol>
           {configs.map((config) => (

--- a/src/components/Tabs/TabbedLinks.tsx
+++ b/src/components/Tabs/TabbedLinks.tsx
@@ -36,7 +36,7 @@ export default function TabbedLinks({
           <NavLink
             className={({ isActive }) =>
               clsx(
-                "cursor-pointer px-4 py-2 font-medium text-sm rounded-t-md border border-gray-300 hover:text-gray-900 mb-[-2px]",
+                "cursor-pointer px-4 py-2 font-medium text-sm rounded-t-md border border-b-0 border-gray-300 hover:text-gray-900 mb-[-2px]",
                 isActive
                   ? "text-gray-900 bg-white"
                   : "text-gray-500 border-transparent"


### PR DESCRIPTION
Closes #937 

### Description
- added a new component `InfiniteTable` which provides virtual paging support.
- modified existing `DataTable` component to add support for virtual paging.
- code refactored to integrate above changes

### Test Plan
- open the [url](https://deploy-preview-1029--goofy-euclid-75956c.netlify.app/configs/0185578e-22c6-1165-1ef1-97f707f264ff)
- login with your credentials
- go to the config changes section in the sidebar
- try scrolling and observe data getting loaded as we scroll to the end.
- when all the data is loaded observe the total count in the config changes header and the sum of all the records returned in the api calls should match.

### Demo
![demo](https://user-images.githubusercontent.com/7310975/233903636-c2be592e-8b92-4978-b988-0b3f25520c41.gif)
