### PR TITLE
fix: make three dot menu visible for the bottom topologies

### DIFF
--- a/src/pages/TopologyPage.tsx
+++ b/src/pages/TopologyPage.tsx
@@ -376,11 +376,8 @@ export function TopologyPage() {
                 setSearchParams={setSearchParams}
               />
             </div>
-            <div
-              className="px-6 pt-4 flex leading-1.21rel w-fulll overflow-y-auto"
-              style={{ maxHeight: "calc(100vh - 9rem)" }}
-            >
-              <div className="flex flex-wrap w-ful">
+            <div className="px-6 pt-4 flex leading-1.21rel w-fulll overflow-y-auto h-full">
+              <div className="flex flex-wrap w-ful h-fit">
                 {getSortedTopology(
                   topology,
                   getSortBy(sortLabels || []),


### PR DESCRIPTION
Closes issue [#1006](https://github.com/flanksource/flanksource-ui/issues/1006)

[Loom Video](https://www.loom.com/share/8b723cbead254503aab445d5662b0fc3)

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
