### PR TITLE
chore:  run npx update-browserslist-db@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15922,9 +15922,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001409",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
-      "integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==",
+      "version": "1.0.30001474",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz",
+      "integrity": "sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -15933,6 +15933,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -53698,9 +53702,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001409",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
-      "integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ=="
+      "version": "1.0.30001474",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz",
+      "integrity": "sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
updates caniuse version to remove unnecessary pollyfills as new browsers
gain adoption
https://github.com/browserslist/update-db#why-you-need-to-call-it-regularly