### PR TITLE
feat: add manual component config linking support

### DIFF
--- a/src/api/query-hooks/useComponentConfigRelationshipQuery.ts
+++ b/src/api/query-hooks/useComponentConfigRelationshipQuery.ts
@@ -1,0 +1,60 @@
+import { useQuery } from "@tanstack/react-query";
+import { ConfigItem, getConfigsBy } from "../services/configs";
+
+export const componentConfigRelationshipQueryKey = ({
+  topologyId,
+  configId
+}: {
+  topologyId?: string;
+  configId?: string;
+}) => {
+  if (topologyId) {
+    return ["component", "config", "relationships", topologyId];
+  }
+  return ["config", "relationships", configId];
+};
+
+export function useComponentConfigRelationshipQuery({
+  topologyId,
+  configId
+}: {
+  topologyId?: string;
+  configId?: string;
+}) {
+  return useQuery(
+    componentConfigRelationshipQueryKey({ topologyId, configId }),
+    () => {
+      if (topologyId) {
+        return getConfigsBy({ topologyId })?.then((res) => {
+          return res?.data?.map((item) => {
+            return item.configs as ConfigItem;
+          });
+        });
+      }
+      if (configId) {
+        return getConfigsBy({ configId })?.then((res) => {
+          let items: ConfigItem[] = [];
+          res?.data?.forEach((item) => {
+            if (!item.related) {
+              return;
+            }
+            const configs = item.configs as ConfigItem;
+            const related = item.related as ConfigItem;
+            if (configs?.id !== configId) {
+              items.push(configs);
+            }
+            if (related?.id !== configId) {
+              items.push(configs);
+            }
+          });
+          items = items.sort((ent: ConfigItem) => (ent.deleted_at ? 1 : -1));
+          return items;
+        });
+      }
+      return Promise.resolve([]);
+    },
+    {
+      enabled: !!topologyId || !!configId
+    }
+  );
+}

--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -173,6 +173,30 @@ export const getConfigsBy = ({ topologyId, configId }: ConfigParams) => {
   }
 };
 
+export const addManuallyAddedComponentConfigRelationship = (
+  topologyId: string,
+  configId: string
+) => {
+  return resolve(
+    ConfigDB.post(`/config_component_relationships`, {
+      component_id: topologyId,
+      config_id: configId,
+      selector_id: "manual"
+    })
+  );
+};
+
+export const removeComponentConfigRelationship = (
+  topologyId: string,
+  configId: string
+) => {
+  return resolve(
+    ConfigDB.delete(
+      `/config_component_relationships?component_id=eq.${topologyId}&config_id=eq.${configId}&selector_id=eq.manual`
+    )
+  );
+};
+
 export const searchConfigs = (type: string, input: string) => {
   const orCondition = input
     ? `&or=(name.ilike.*${input}*,external_id.ilike.*${input}*)`

--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -3,7 +3,7 @@
 import { ConfigTypeChanges } from "../../components/ConfigChanges";
 import { ConfigTypeInsights } from "../../components/ConfigInsights";
 import { Config, ConfigDB, IncidentCommander } from "../axios";
-import { resolve } from "../resolve";
+import { ApiResp, resolve } from "../resolve";
 
 export interface ConfigItem {
   name: string;
@@ -164,16 +164,22 @@ export const getConfigsBy = ({ topologyId, configId }: ConfigParams) => {
         `/config_component_relationships?component_id=eq.${topologyId}&select=configs!config_component_relationships_config_id_fkey(*)`
       )
     );
-  } else if (configId) {
+  }
+  if (configId) {
     return resolve(
       ConfigDB.get<Pick<ConfigTypeRelationships, "configs" | "related">[]>(
         `/config_relationships?or=(related_id.eq.${configId},config_id.eq.${configId})&select=configs:configs!config_relationships_config_id_fkey(*),related:configs!config_relationships_related_id_fkey(*)`
       )
     );
   }
+  return Promise.resolve({
+    totalEntries: 0,
+    data: [],
+    error: null
+  });
 };
 
-export const addManuallyAddedComponentConfigRelationship = (
+export const addManualComponentConfigRelationship = (
   topologyId: string,
   configId: string
 ) => {
@@ -186,7 +192,7 @@ export const addManuallyAddedComponentConfigRelationship = (
   );
 };
 
-export const removeComponentConfigRelationship = (
+export const removeManualComponentConfigRelationship = (
   topologyId: string,
   configId: string
 ) => {

--- a/src/components/ConfigLink/ConfigLink.tsx
+++ b/src/components/ConfigLink/ConfigLink.tsx
@@ -8,22 +8,32 @@ type ConfigLinkProps = {
   configType?: string;
   className?: string;
   configTypeSecondary?: string;
+  variant?: "label" | "link";
 };
 export default function ConfigLink({
   configId,
   configName,
   configType,
   configTypeSecondary,
+  variant = "link",
   className
 }: ConfigLinkProps) {
+  if (variant === "link") {
+    return (
+      <Link
+        to={{
+          pathname: `/configs/${configId}`
+        }}
+      >
+        <Icon name={configType || configTypeSecondary} className="w-5 mr-1" />
+        <span className={className}>{configName}</span>
+      </Link>
+    );
+  }
   return (
-    <Link
-      to={{
-        pathname: `/configs/${configId}`
-      }}
-    >
+    <>
       <Icon name={configType || configTypeSecondary} className="w-5 mr-1" />
       <span className={className}>{configName}</span>
-    </Link>
+    </>
   );
 }

--- a/src/components/Dropdown/DropdownWithActions.tsx
+++ b/src/components/Dropdown/DropdownWithActions.tsx
@@ -18,6 +18,7 @@ interface IDropdownWithActionsProps<T> {
   value?: T;
   setValue: any;
   dependentValue?: any;
+  disabled?: boolean;
 }
 
 export function DropdownWithActions<T extends IItem>({
@@ -28,6 +29,7 @@ export function DropdownWithActions<T extends IItem>({
   value = { value: null, description: "" } as T,
   displayOption,
   setValue,
+  disabled,
   dependentValue
 }: IDropdownWithActionsProps<T>) {
   const [lastNoResultsQuery, setLastNoResultsQuery] = useState("");
@@ -122,8 +124,16 @@ export function DropdownWithActions<T extends IItem>({
               {displayOption({ option: props.data } as any)}
             </components.Option>
           );
+        },
+        SingleValue: (props: any) => {
+          return (
+            <components.SingleValue {...props}>
+              {displayOption({ option: props.data } as any)}
+            </components.SingleValue>
+          );
         }
       }}
+      isDisabled={disabled}
     />
   ) : (
     <AsyncSelect
@@ -151,8 +161,16 @@ export function DropdownWithActions<T extends IItem>({
               {displayOption({ option: props.data } as any)}
             </components.Option>
           );
+        },
+        SingleValue: (props: any) => {
+          return (
+            <components.SingleValue {...props}>
+              {displayOption({ option: props.data } as any)}
+            </components.SingleValue>
+          );
         }
       }}
+      isDisabled={disabled}
     />
   );
 }

--- a/src/components/TopologyConfigLinkModal/TopologyConfigLinkModal.tsx
+++ b/src/components/TopologyConfigLinkModal/TopologyConfigLinkModal.tsx
@@ -1,0 +1,218 @@
+import { useAllConfigsQuery } from "../../api/query-hooks";
+import { Topology } from "../../context/TopologyPageContext";
+import { Modal } from "../Modal";
+import React, { useEffect, useMemo, useState } from "react";
+import { Icon } from "../Icon";
+import {
+  ConfigItem,
+  addManuallyAddedComponentConfigRelationship,
+  getConfigsBy,
+  removeComponentConfigRelationship
+} from "../../api/services/configs";
+import { DropdownWithActions } from "../Dropdown/DropdownWithActions";
+import { delayedPromise } from "../../utils/common";
+import { Badge } from "../Badge";
+import { toastError, toastSuccess } from "../Toast/toast";
+import { BsTrash } from "react-icons/bs";
+import { IconButton } from "../IconButton";
+import clsx from "clsx";
+
+type TopologyConfigLinkModalProps = {
+  topology: Topology;
+  openModal: boolean;
+  onCloseModal: (val: boolean) => void;
+} & React.HTMLProps<HTMLDivElement>;
+
+type ConfigOption = {
+  id: string;
+  value: string;
+  description: string;
+  name: string;
+  icon: React.ReactNode;
+};
+
+export function TopologyConfigLinkModal({
+  topology,
+  openModal,
+  onCloseModal
+}: TopologyConfigLinkModalProps) {
+  const { data: response } = useAllConfigsQuery({}, {});
+  const [value, setValue] = useState<ConfigOption>();
+  const [linkedConfigs, setLinkedConfigs] = useState<ConfigItem[]>([]);
+  const maxResultsShown = 10;
+  const configs = useMemo(() => {
+    const data = response?.data || [];
+    return data?.map((d: ConfigItem) => ({
+      id: d.id,
+      value: d.config_type,
+      description: d.config_type,
+      name: d.config_type,
+      icon: <Icon name={d.external_type} secondary={d.config_type} />
+    }));
+  }, [response]);
+
+  const onSearch = async (query = "") => {
+    const result = configs
+      .filter((config) => {
+        return config.name.toLowerCase().indexOf(query.toLowerCase()) > 0;
+      })
+      .slice(0, maxResultsShown);
+    return await delayedPromise<ConfigOption[]>(result, 1000);
+  };
+
+  const fetchLinkedConfigs = async () => {
+    try {
+      const response = await getConfigsBy({
+        topologyId: topology.id
+      });
+      if (response?.data) {
+        return setLinkedConfigs(
+          response.data?.map((item) => item.configs as ConfigItem) || []
+        );
+      }
+      toastError(response?.error.message);
+    } catch (ex) {
+      toastError((ex as Error).message);
+    }
+  };
+
+  useEffect(() => {
+    if (!topology?.id) {
+      return;
+    }
+    fetchLinkedConfigs();
+  }, [topology]);
+
+  const onSubmit = async () => {
+    if (!topology.id || !value?.id) {
+      return Promise.resolve();
+    }
+    try {
+      const response = await addManuallyAddedComponentConfigRelationship(
+        topology.id,
+        value.id
+      );
+      if (response.data) {
+        toastSuccess("config link successful");
+        setValue(undefined);
+        return fetchLinkedConfigs();
+      }
+      toastError(response.error?.message);
+    } catch (ex) {
+      toastError((ex as Error).message);
+    }
+  };
+
+  const deleteLink = async (configId: string) => {
+    try {
+      const response = await removeComponentConfigRelationship(
+        topology.id,
+        configId
+      );
+      if (response.data) {
+        toastSuccess("Deleted config link successfully");
+        return fetchLinkedConfigs();
+      }
+      toastError(response.error?.message);
+    } catch (ex) {
+      toastError((ex as Error).message);
+    }
+  };
+
+  return (
+    <Modal
+      onClose={() => {
+        onCloseModal(false);
+        setValue(undefined);
+      }}
+      title={`${topology.name} - config relationships`}
+      open={openModal}
+      size="slightly-small"
+      containerClassName=""
+    >
+      <div className="flex flex-col my-2 divide-y divide-gray-200 space-y-4">
+        <div
+          className={clsx(
+            "flex flex-row items-center space-x-2",
+            linkedConfigs.length === 0 ? "mb-4" : ""
+          )}
+        >
+          <div className="text-sm font-bold text-gray-700 inline-block">
+            Config
+          </div>
+          <div className="w-64">
+            <DropdownWithActions<ConfigOption>
+              onQuery={(e) => {
+                return onSearch(e);
+              }}
+              label=""
+              name="config"
+              value={value}
+              setValue={(_: string, val: ConfigOption) => {
+                setValue(val);
+              }}
+              creatable={false}
+              displayOption={({ option }) => {
+                return (
+                  <div className="w-auto max-w-[400px]">
+                    <Icon name={option.name} secondary={option.name} />
+                    {option.name}
+                  </div>
+                );
+              }}
+            />
+          </div>
+          <button className="btn btn-primary" type="submit" onClick={onSubmit}>
+            Link
+          </button>
+        </div>
+        <div
+          className={clsx(
+            "flex flex-col",
+            linkedConfigs.length === 0 ? "hidden" : ""
+          )}
+        >
+          <div className="flex flex-row items-center my-2 space-x-2">
+            <span className="text-sm font-bold text-gray-700 inline-block">
+              Linked to configs
+            </span>
+            <Badge
+              className="w-5 h-5 flex items-center justify-center"
+              roundedClass="rounded-full"
+              text={linkedConfigs.length}
+            />
+          </div>
+          <div className="flex flex-col max-h-36 overflow-y-auto space-y-2">
+            {linkedConfigs.map((linkedConfig) => {
+              return (
+                <div className="flex flex-row space-x-2 py-1 pr-16">
+                  <Icon
+                    key={linkedConfig.id}
+                    name={linkedConfig.external_type}
+                    secondary={linkedConfig.config_type}
+                  />
+                  <span title={linkedConfig.name} className="truncate">
+                    {linkedConfig.name}
+                  </span>
+                  <IconButton
+                    className="bg-transparent flex items-center"
+                    ovalProps={{
+                      stroke: "blue",
+                      height: "18px",
+                      width: "18px",
+                      fill: "transparent"
+                    }}
+                    icon={<BsTrash />}
+                    onClick={() => {
+                      deleteLink(linkedConfig.id);
+                    }}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/TopologyConfigLinkModal/TopologyConfigLinkModal.tsx
+++ b/src/components/TopologyConfigLinkModal/TopologyConfigLinkModal.tsx
@@ -1,21 +1,18 @@
 import { useAllConfigsQuery } from "../../api/query-hooks";
 import { Topology } from "../../context/TopologyPageContext";
 import { Modal } from "../Modal";
-import React, { useEffect, useMemo, useState } from "react";
-import { Icon } from "../Icon";
+import React, { useMemo, useState } from "react";
 import {
   ConfigItem,
-  addManuallyAddedComponentConfigRelationship,
-  getConfigsBy,
-  removeComponentConfigRelationship
+  addManualComponentConfigRelationship
 } from "../../api/services/configs";
 import { DropdownWithActions } from "../Dropdown/DropdownWithActions";
-import { delayedPromise } from "../../utils/common";
-import { Badge } from "../Badge";
+import { delayedPromise, stringSortHelper } from "../../utils/common";
 import { toastError, toastSuccess } from "../Toast/toast";
-import { BsTrash } from "react-icons/bs";
-import { IconButton } from "../IconButton";
 import clsx from "clsx";
+import { queryClient } from "../../query-client";
+import { componentConfigRelationshipQueryKey } from "../../api/query-hooks/useComponentConfigRelationshipQuery";
+import ConfigLink from "../ConfigLink/ConfigLink";
 
 type TopologyConfigLinkModalProps = {
   topology: Topology;
@@ -29,6 +26,8 @@ type ConfigOption = {
   description: string;
   name: string;
   icon: React.ReactNode;
+  external_type?: string;
+  config_type: string;
 };
 
 export function TopologyConfigLinkModal({
@@ -37,86 +36,62 @@ export function TopologyConfigLinkModal({
   onCloseModal
 }: TopologyConfigLinkModalProps) {
   const { data: response } = useAllConfigsQuery({}, {});
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [value, setValue] = useState<ConfigOption>();
-  const [linkedConfigs, setLinkedConfigs] = useState<ConfigItem[]>([]);
   const maxResultsShown = 10;
   const configs = useMemo(() => {
     const data = response?.data || [];
-    return data?.map((d: ConfigItem) => ({
-      id: d.id,
-      value: d.config_type,
-      description: d.config_type,
-      name: d.config_type,
-      icon: <Icon name={d.external_type} secondary={d.config_type} />
-    }));
+    return data
+      ?.map((d: ConfigItem) => ({
+        id: d.id,
+        value: d.name,
+        description: d.name,
+        name: d.name,
+        icon: null,
+        external_type: d.external_type,
+        config_type: d.config_type
+      }))
+      .sort((v1, v2) => stringSortHelper(v1.name, v2.name));
   }, [response]);
 
   const onSearch = async (query = "") => {
     const result = configs
       .filter((config) => {
-        return config.name.toLowerCase().indexOf(query.toLowerCase()) > 0;
+        return config.name.toLowerCase().indexOf(query.toLowerCase()) > -1;
       })
+      .sort((v1, v2) => stringSortHelper(v1.name, v2.name))
       .slice(0, maxResultsShown);
     return await delayedPromise<ConfigOption[]>(result, 1000);
   };
 
-  const fetchLinkedConfigs = async () => {
-    try {
-      const response = await getConfigsBy({
-        topologyId: topology.id
-      });
-      if (response?.data) {
-        return setLinkedConfigs(
-          response.data?.map((item) => item.configs as ConfigItem) || []
-        );
-      }
-      toastError(response?.error.message);
-    } catch (ex) {
-      toastError((ex as Error).message);
-    }
-  };
-
-  useEffect(() => {
-    if (!topology?.id) {
-      return;
-    }
-    fetchLinkedConfigs();
-  }, [topology]);
-
   const onSubmit = async () => {
-    if (!topology.id || !value?.id) {
+    if (!topology.id || !value?.id || isSubmitting) {
+      if (!value?.id) {
+        toastError("Please select a config to link");
+      }
       return Promise.resolve();
     }
+    setIsSubmitting(true);
+    onCloseModal(false);
     try {
-      const response = await addManuallyAddedComponentConfigRelationship(
+      const response = await addManualComponentConfigRelationship(
         topology.id,
         value.id
       );
       if (response.data) {
         toastSuccess("config link successful");
         setValue(undefined);
-        return fetchLinkedConfigs();
+        queryClient.invalidateQueries(
+          componentConfigRelationshipQueryKey({ topologyId: topology.id })
+        );
+        setIsSubmitting(false);
+        return;
       }
       toastError(response.error?.message);
     } catch (ex) {
       toastError((ex as Error).message);
     }
-  };
-
-  const deleteLink = async (configId: string) => {
-    try {
-      const response = await removeComponentConfigRelationship(
-        topology.id,
-        configId
-      );
-      if (response.data) {
-        toastSuccess("Deleted config link successfully");
-        return fetchLinkedConfigs();
-      }
-      toastError(response.error?.message);
-    } catch (ex) {
-      toastError((ex as Error).message);
-    }
+    setIsSubmitting(false);
   };
 
   return (
@@ -125,22 +100,18 @@ export function TopologyConfigLinkModal({
         onCloseModal(false);
         setValue(undefined);
       }}
-      title={`${topology.name} - config relationships`}
+      title={`Link to config`}
       open={openModal}
       size="slightly-small"
       containerClassName=""
+      bodyClass=""
     >
-      <div className="flex flex-col my-2 divide-y divide-gray-200 space-y-4">
-        <div
-          className={clsx(
-            "flex flex-row items-center space-x-2",
-            linkedConfigs.length === 0 ? "mb-4" : ""
-          )}
-        >
+      <div className="flex flex-col divide-y divide-gray-200 space-y-4">
+        <div className={clsx("flex flex-col px-4 py-4")}>
           <div className="text-sm font-bold text-gray-700 inline-block">
             Config
           </div>
-          <div className="w-64">
+          <div className="w-full">
             <DropdownWithActions<ConfigOption>
               onQuery={(e) => {
                 return onSearch(e);
@@ -154,63 +125,27 @@ export function TopologyConfigLinkModal({
               creatable={false}
               displayOption={({ option }) => {
                 return (
-                  <div className="w-auto max-w-[400px]">
-                    <Icon name={option.name} secondary={option.name} />
-                    {option.name}
+                  <div className="w-auto cursor-pointer">
+                    <div className="flex flex-row truncate">
+                      <ConfigLink
+                        configId={option.id}
+                        configName={option.name}
+                        configType={option.external_type}
+                        configTypeSecondary={option.config_type}
+                        variant="label"
+                      />
+                    </div>
                   </div>
                 );
               }}
+              disabled={!Boolean(configs.length)}
             />
           </div>
-          <button className="btn btn-primary" type="submit" onClick={onSubmit}>
-            Link
-          </button>
         </div>
-        <div
-          className={clsx(
-            "flex flex-col",
-            linkedConfigs.length === 0 ? "hidden" : ""
-          )}
-        >
-          <div className="flex flex-row items-center my-2 space-x-2">
-            <span className="text-sm font-bold text-gray-700 inline-block">
-              Linked to configs
-            </span>
-            <Badge
-              className="w-5 h-5 flex items-center justify-center"
-              roundedClass="rounded-full"
-              text={linkedConfigs.length}
-            />
-          </div>
-          <div className="flex flex-col max-h-36 overflow-y-auto space-y-2">
-            {linkedConfigs.map((linkedConfig) => {
-              return (
-                <div className="flex flex-row space-x-2 py-1 pr-16">
-                  <Icon
-                    key={linkedConfig.id}
-                    name={linkedConfig.external_type}
-                    secondary={linkedConfig.config_type}
-                  />
-                  <span title={linkedConfig.name} className="truncate">
-                    {linkedConfig.name}
-                  </span>
-                  <IconButton
-                    className="bg-transparent flex items-center"
-                    ovalProps={{
-                      stroke: "blue",
-                      height: "18px",
-                      width: "18px",
-                      fill: "transparent"
-                    }}
-                    icon={<BsTrash />}
-                    onClick={() => {
-                      deleteLink(linkedConfig.id);
-                    }}
-                  />
-                </div>
-              );
-            })}
-          </div>
+        <div className="flex items-center justify-end p-2 rounded bg-gray-100">
+          <button type="submit" onClick={onSubmit} className="btn-primary">
+            {isSubmitting ? "Linking.." : "Link"}
+          </button>
         </div>
       </div>
     </Modal>

--- a/src/components/TopologySidebar/TopologyActionBar.tsx
+++ b/src/components/TopologySidebar/TopologyActionBar.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { IconType } from "react-icons";
-import { BiShow, BiHide, BiZoomIn } from "react-icons/bi";
+import { BiShow, BiHide, BiZoomIn, BiLink } from "react-icons/bi";
 import { ImTree } from "react-icons/im";
 import { MdAlarmAdd, MdTableRows } from "react-icons/md";
 import { useNavigate } from "react-router-dom";
@@ -10,6 +10,7 @@ import { Topology } from "../../context/TopologyPageContext";
 import { AttachEvidenceDialog } from "../AttachEvidenceDialog";
 import TopologySnapshotModal from "../TopologyCard/TopologySnapshotModal";
 import { ActionLink } from "../ActionLink/ActionLink";
+import { TopologyConfigLinkModal } from "../TopologyConfigLinkModal/TopologyConfigLinkModal";
 
 type TopologyActionItem = {
   label: string;
@@ -181,6 +182,22 @@ export const topologyActionItems: Readonly<TopologyActionItem>[] = [
         <ChildComponent onClick={() => onModalOpen()} icon={icon} text={text} />
       );
     }
+  },
+  {
+    label: "Link to config",
+    icon: BiLink,
+    isShown: () => true,
+    ContainerComponent: function Container({
+      child: ChildComponent,
+      topology,
+      icon,
+      text,
+      openModalAction: onModalOpen = () => {}
+    }) {
+      return (
+        <ChildComponent onClick={() => onModalOpen()} icon={icon} text={text} />
+      );
+    }
   }
 ];
 
@@ -199,6 +216,20 @@ export default function TopologyActionBar({
   ] = useState(false);
 
   const [attachAsAsset, setAttachAsAsset] = useState(false);
+  const [linkToConfig, setLinkToConfig] = useState(false);
+
+  const onOpenModal = (label: string) => {
+    switch (label) {
+      case "Snapshot":
+        return setIsDownloadComponentSnapshotModalOpen(true);
+      case "Link to Incident":
+        return setAttachAsAsset(true);
+      case "Link to config":
+        return setLinkToConfig(true);
+      default:
+        break;
+    }
+  };
 
   if (!topology) {
     return null;
@@ -207,28 +238,23 @@ export default function TopologyActionBar({
   return (
     <>
       <div
+        className="flex flex-wrap py-4"
         data-collapsible="false"
-        className="flex flex-wrap justify-between py-4 px-1"
       >
         {topologyActionItems.map(
           ({ icon: Icon, isShown, label, ContainerComponent }, index) => {
             if (isShown(topology, "TopologySidebar")) {
               return (
-                <ContainerComponent
-                  key={label}
-                  onRefresh={onRefresh}
-                  topology={topology}
-                  child={ActionLink}
-                  icon={<Icon />}
-                  text={label}
-                  openModalAction={
-                    label === "Snapshot"
-                      ? () => setIsDownloadComponentSnapshotModalOpen(true)
-                      : label === "Link to Incident"
-                      ? () => setAttachAsAsset(true)
-                      : undefined
-                  }
-                />
+                <div key={label} className="py-1 px-1">
+                  <ContainerComponent
+                    onRefresh={onRefresh}
+                    topology={topology}
+                    child={ActionLink}
+                    icon={<Icon />}
+                    text={label}
+                    openModalAction={() => onOpenModal(label)}
+                  />
+                </div>
               );
             }
             return null;
@@ -246,6 +272,12 @@ export default function TopologyActionBar({
       <TopologySnapshotModal
         onCloseModal={() => setIsDownloadComponentSnapshotModalOpen(false)}
         isModalOpen={isDownloadComponentSnapshotModalOpen}
+        topology={topology}
+      />
+
+      <TopologyConfigLinkModal
+        onCloseModal={() => setLinkToConfig(false)}
+        openModal={linkToConfig}
         topology={topology}
       />
     </>

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -72,3 +72,13 @@ export const delayedPromise = <T>(val: T, time: number): Promise<T> => {
     }, time);
   });
 };
+
+export const stringSortHelper = (val1: string, val2: string) => {
+  if (val1 > val2) {
+    return 1;
+  }
+  if (val1 < val2) {
+    return -1;
+  }
+  return 0;
+};

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -64,3 +64,11 @@ export const getStartValue = (start: string) => {
     .subtract(+(start.match(/\d/g)?.[0] ?? "1"), "month")
     .toISOString();
 };
+
+export const delayedPromise = <T>(val: T, time: number): Promise<T> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(val);
+    }, time);
+  });
+};


### PR DESCRIPTION
Closes #853

### Description
* adds support for manually linking a config to a component.
* adds support for deleting manually linked config.

### Test Plan
* open [url](https://deploy-preview-1070--goofy-euclid-75956c.netlify.app/topology/01862990-0ae8-0cd9-e57e-9056061f9459?sortBy=status&sortOrder=desc)
* go to the action bar section on the sidebar
* click on `Link to config` action button this will open up a modal
* link any config and observe the recently linked config being shown under `Configs` section on the sidebar.

### Demo
![demo](https://user-images.githubusercontent.com/7310975/233905352-99323cde-b294-46ff-993e-5d8f644df245.gif)
