### PR TITLE
fix: ui improvements

### DIFF
--- a/src/api/query-hooks/index.ts
+++ b/src/api/query-hooks/index.ts
@@ -43,7 +43,8 @@ export const useVersionInfo = () => {
 
 export const useIncidentQuery = (id: string) => {
   return useQuery(createIncidentQueryKey(id), () => getIncident(id), {
-    staleTime: defaultStaleTime
+    staleTime: defaultStaleTime,
+    enabled: !!id
   });
 };
 

--- a/src/api/query-hooks/index.ts
+++ b/src/api/query-hooks/index.ts
@@ -43,7 +43,6 @@ export const useVersionInfo = () => {
 
 export const useIncidentQuery = (id: string) => {
   return useQuery(createIncidentQueryKey(id), () => getIncident(id), {
-    staleTime: defaultStaleTime,
     enabled: !!id
   });
 };

--- a/src/api/query-hooks/mutations/evidence.tsx
+++ b/src/api/query-hooks/mutations/evidence.tsx
@@ -4,6 +4,7 @@ import {
   Evidence,
   updateEvidence
 } from "../../services/evidence";
+import { useIncidentState } from "../../../store/incident.state";
 
 /**
  *
@@ -12,9 +13,13 @@ import {
  * Update evidence mutation hook used to update evidence in the database
  *
  */
-export function useUpdateEvidenceMutation(param?: {
-  onSuccess?: (evidence: Evidence[]) => void;
-}) {
+export function useUpdateEvidenceMutation(
+  param: {
+    onSuccess?: (evidence: Evidence[]) => void;
+  },
+  incidentId: string
+) {
+  const { refetchIncident } = useIncidentState(incidentId);
   return useMutation(
     // force id to be defined
     async (evidence: (Partial<Evidence> & { id: string })[]) => {
@@ -32,17 +37,20 @@ export function useUpdateEvidenceMutation(param?: {
         const definedEvidence = evidence.filter(
           (evidence) => evidence
         ) as Evidence[];
-        if (param?.onSuccess) {
-          param.onSuccess(definedEvidence);
-        }
+        param.onSuccess?.(definedEvidence);
+        refetchIncident();
       }
     }
   );
 }
 
-export function useCreateEvidenceMutation(param?: {
-  onSuccess?: (evidence?: Evidence) => void;
-}) {
+export function useCreateEvidenceMutation(
+  param: {
+    onSuccess?: (evidence?: Evidence) => void;
+  },
+  incidentId: string
+) {
+  const { refetchIncident } = useIncidentState(incidentId);
   return useMutation(
     async (
       evidence: Omit<Evidence, "created_by" | "created_at" | "hypothesis_id">
@@ -52,9 +60,8 @@ export function useCreateEvidenceMutation(param?: {
     },
     {
       onSuccess: (evidence) => {
-        if (param?.onSuccess) {
-          param.onSuccess(evidence);
-        }
+        param.onSuccess?.(evidence);
+        refetchIncident();
       }
     }
   );

--- a/src/components/Badge/CountBadge.tsx
+++ b/src/components/Badge/CountBadge.tsx
@@ -1,0 +1,41 @@
+import React, { useMemo } from "react";
+
+type CountBadgeProps = {
+  value?: number;
+  size?: "xs" | "sm" | "md";
+  title?: string;
+  className?: string;
+  colorClass?: string;
+  roundedClass?: string;
+};
+
+export const CountBadge = React.memo(function ({
+  value = 0,
+  size = "sm",
+  title,
+  className,
+  colorClass = "bg-blue-100 text-blue-800",
+  roundedClass = "rounded"
+}: CountBadgeProps) {
+  const spanClassName = size === "sm" ? "text-sm px-1" : "text-xs px-1.5";
+  const widthHeightClassName = useMemo(() => {
+    const length = value.toString().length;
+    if (length === 1) {
+      return `w-5 h-5`;
+    } else if (length === 2) {
+      return `w-6 h-6`;
+    } else if (length === 3) {
+      return `w-7.5 h-8`;
+    }
+    return `w-fit h-5 rounded-sm`;
+  }, [value]);
+
+  return (
+    <span
+      className={`${widthHeightClassName} ${className} ${spanClassName} flex items-center justify-center inline items-center py-0.5 ${roundedClass} font-medium ${colorClass}`}
+      title={title}
+    >
+      {value}
+    </span>
+  );
+});

--- a/src/components/Changelog/IncidentChangelog.tsx
+++ b/src/components/Changelog/IncidentChangelog.tsx
@@ -3,7 +3,7 @@ import { MdRefresh } from "react-icons/md";
 import { RiPlayListAddFill } from "react-icons/ri";
 import { useIncidentsHistoryQuery } from "../../api/query-hooks";
 import { useIncidentState } from "../../store/incident.state";
-import { Badge } from "../Badge";
+import { CountBadge } from "../Badge/CountBadge";
 import { ClickableSvg } from "../ClickableSvg/ClickableSvg";
 import CollapsiblePanel from "../CollapsiblePanel";
 import { Loading } from "../Loading";
@@ -40,10 +40,9 @@ export function IncidentChangelog({
             title="Changelog"
             icon={<RiPlayListAddFill className="w-6 h-6" />}
           />
-          <Badge
-            className="w-5 h-5 flex items-center justify-center"
+          <CountBadge
             roundedClass="rounded-full"
-            text={incidentHistory?.length ?? 0}
+            value={incidentHistory?.length ?? 0}
           />
           <div
             className="relative z-0 inline-flex justify-end ml-5"

--- a/src/components/Changelog/IncidentChangelog.tsx
+++ b/src/components/Changelog/IncidentChangelog.tsx
@@ -64,6 +64,7 @@ export function IncidentChangelog({
       }
       className={className}
       {...props}
+      dataCount={incidentHistory?.length}
     >
       {isLoading || !incidentHistory ? (
         <Loading text="Loading ..." />

--- a/src/components/CollapsiblePanel/index.tsx
+++ b/src/components/CollapsiblePanel/index.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { IoChevronDownOutline, IoChevronUpOutline } from "react-icons/io5";
 import { ClickableSvg } from "../ClickableSvg/ClickableSvg";
 
@@ -8,6 +8,7 @@ type Props = React.HTMLProps<HTMLDivElement> & {
   children: React.ReactNode;
   isClosed?: boolean;
   childrenClassName?: string;
+  dataCount?: number;
 };
 
 export default function CollapsiblePanel({
@@ -16,9 +17,17 @@ export default function CollapsiblePanel({
   isClosed = false,
   className,
   childrenClassName = "transform origin-bottom duration-500",
+  dataCount,
   ...props
 }: Props) {
   const [isOpen, setIsOpen] = useState(!isClosed);
+
+  useEffect(() => {
+    if (dataCount === undefined) {
+      return;
+    }
+    setIsOpen(dataCount > 0);
+  }, [dataCount]);
 
   return (
     <div

--- a/src/components/ConfigChanges/index.tsx
+++ b/src/components/ConfigChanges/index.tsx
@@ -98,6 +98,7 @@ export default function ConfigChanges(props: Props) {
           />
         </div>
       }
+      dataCount={response?.data?.length}
     >
       <ConfigChangesDetails {...props} />
     </CollapsiblePanel>

--- a/src/components/ConfigComponents/index.tsx
+++ b/src/components/ConfigComponents/index.tsx
@@ -69,6 +69,7 @@ export default function ConfigComponents(props: Props) {
           <CountBadge roundedClass="rounded-full" value={components.length} />
         </div>
       }
+      dataCount={components.length}
     >
       <ConfigComponentsDetails {...props} />
     </CollapsiblePanel>

--- a/src/components/ConfigComponents/index.tsx
+++ b/src/components/ConfigComponents/index.tsx
@@ -1,7 +1,7 @@
 import { FaExclamationTriangle } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { useConfigComponentsRelationshipQuery } from "../../api/query-hooks/useConfigComponentsRelationshipQuery";
-import { Badge } from "../Badge";
+import { CountBadge } from "../Badge/CountBadge";
 import CollapsiblePanel from "../CollapsiblePanel";
 import { Icon } from "../Icon";
 import { TopologyIcon } from "../Icons/TopologyIcon";
@@ -66,11 +66,7 @@ export default function ConfigComponents(props: Props) {
         <div className="flex flex-row space-x-2 items-center text-xl font-semibold">
           <TopologyIcon className="text-gray-400 h-5 w-5" />
           <span>Components</span>
-          <Badge
-            className="w-5 h-5 flex items-center justify-center"
-            roundedClass="rounded-full"
-            text={components.length}
-          />
+          <CountBadge roundedClass="rounded-full" value={components.length} />
         </div>
       }
     >

--- a/src/components/ConfigInsights/index.tsx
+++ b/src/components/ConfigInsights/index.tsx
@@ -48,6 +48,7 @@ export default function ConfigInsights({ configID }: Props) {
           />
         </div>
       }
+      dataCount={response.length}
     >
       <InsightsDetails isLoading={isLoading} insights={response ?? []} />
     </CollapsiblePanel>

--- a/src/components/ConfigInsights/index.tsx
+++ b/src/components/ConfigInsights/index.tsx
@@ -3,8 +3,8 @@ import CollapsiblePanel from "../CollapsiblePanel";
 import Title from "../Title/title";
 import { useGetConfigInsights } from "../../api/query-hooks";
 import { ConfigItem } from "../../api/services/configs";
-import { Badge } from "../Badge";
 import InsightsDetails from "../Insights/Insights";
+import { CountBadge } from "../Badge/CountBadge";
 
 export type ConfigTypeInsights = {
   id: string;
@@ -42,10 +42,9 @@ export default function ConfigInsights({ configID }: Props) {
             title="Insights"
             icon={<MdOutlineInsights className="w-6 h-auto" />}
           />
-          <Badge
-            className="w-5 h-5 flex items-center justify-center"
+          <CountBadge
             roundedClass="rounded-full"
-            text={response.length ?? 0}
+            value={response.length ?? 0}
           />
         </div>
       }

--- a/src/components/ConfigSidebar/ConfigDetails.tsx
+++ b/src/components/ConfigSidebar/ConfigDetails.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { FaTags } from "react-icons/fa";
 import { useGetConfigByIdQuery } from "../../api/query-hooks";
 import { relativeDateTime } from "../../utils/date";
-import { Badge } from "../Badge";
+import { CountBadge } from "../Badge/CountBadge";
 import CollapsiblePanel from "../CollapsiblePanel";
 import { DescriptionCard } from "../DescriptionCard";
 import { InfoMessage } from "../InfoMessage";
@@ -68,10 +68,9 @@ export function ConfigDetails({ configId }: Props) {
       Header={
         <div className="flex py-2 flex-row flex-1 items-center space-x-2">
           <Title title="Tags" icon={<FaTags className="w-6 h-auto" />} />
-          <Badge
-            className="w-5 h-5 flex items-center justify-center"
+          <CountBadge
             roundedClass="rounded-full"
-            text={displayDetails?.length ?? 0}
+            value={displayDetails?.length ?? 0}
           />
         </div>
       }

--- a/src/components/ConfigSidebar/ConfigDetails.tsx
+++ b/src/components/ConfigSidebar/ConfigDetails.tsx
@@ -74,6 +74,7 @@ export function ConfigDetails({ configId }: Props) {
           />
         </div>
       }
+      dataCount={displayDetails?.length}
     >
       <div className="flex flex-col space-y-2 py-2 max-w-full">
         {isLoading ? (

--- a/src/components/CostDetails/CostDetails.tsx
+++ b/src/components/CostDetails/CostDetails.tsx
@@ -54,7 +54,7 @@ export function FormatCurrency({
       return 0;
     }
     const parsedValue = typeof value === "string" ? parseInt(value) : value;
-    if (value <= 10) {
+    if (+value <= 10) {
       return parsedValue.toFixed(2);
     }
     return parsedValue.toFixed(0);

--- a/src/components/Hypothesis/EvidenceSection/index.tsx
+++ b/src/components/Hypothesis/EvidenceSection/index.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../../api/query-hooks";
 import { ConfigTypeInsights } from "../../ConfigInsights";
 import { ConfigAnalysisLink } from "../../ConfigAnalysisLink/ConfigAnalysisLink";
+import { CommentEvidence } from "../../IncidentDetails/DefinitionOfDone/EvidenceView";
 
 const ColumnSizes = {
   Time: {
@@ -74,6 +75,8 @@ export function EvidenceItem({
           <HealthEvidenceViewer evidence={evidence} />
         </div>
       );
+    case EvidenceType.Comment:
+      return <CommentEvidence evidence={evidence} />;
     case EvidenceType.ConfigChange:
       return (
         <div className="pt-2">

--- a/src/components/Hypothesis/HypothesisCommentsViewContainer/HypothesisCommentsViewContainer.tsx
+++ b/src/components/Hypothesis/HypothesisCommentsViewContainer/HypothesisCommentsViewContainer.tsx
@@ -189,10 +189,6 @@ export function HypothesisCommentsViewContainer({
       });
   };
 
-  if (!comments.length) {
-    return null;
-  }
-
   return (
     <div className="flex flex-col w-full">
       <div ref={commentRef} className="flex flex-col justify-end">

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -81,9 +81,6 @@ function findByName(name?: string) {
         Icons[prefixes[prefix as keyof typeof prefixes] as keyof typeof Icons];
     }
   }
-  if (icon == null) {
-    console.warn("Icon not found: " + name);
-  }
   return icon;
 }
 
@@ -123,6 +120,9 @@ export const Icon: React.FC<IconProps> = memo(
       if (icon == null && reactIcons[secondary as keyof typeof reactIcons]) {
         const Icon = reactIcons[secondary as keyof typeof reactIcons];
         return <Icon className={`inline-block object-center ${className}`} />;
+      }
+      if (icon == null) {
+        console.warn("Icon not found: " + name);
       }
     }
 

--- a/src/components/IncidentDetails/AddDefinitionOfDone/AddAutoDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/AddDefinitionOfDone/AddAutoDefinitionOfDone.tsx
@@ -84,11 +84,13 @@ type Props = {
   noneDODEvidences: Evidence[];
   onAddDefinitionOfDone: (evidence: Evidence[]) => void;
   onCancel: () => void;
+  incidentId: string;
 };
 
 export default function AddAutoDefinitionOfDoneStepper({
   noneDODEvidences,
-  onAddDefinitionOfDone
+  onAddDefinitionOfDone,
+  incidentId
 }: Props) {
   const [selectDODState, dispatch] = useReducer(
     addDefinitionOfDoneStepsReducer,
@@ -98,11 +100,14 @@ export default function AddAutoDefinitionOfDoneStepper({
     }
   );
 
-  const { isLoading, mutate: updateEvidence } = useUpdateEvidenceMutation({
-    onSuccess: (evidence) => {
-      onAddDefinitionOfDone(evidence);
-    }
-  });
+  const { isLoading, mutate: updateEvidence } = useUpdateEvidenceMutation(
+    {
+      onSuccess: (evidence) => {
+        onAddDefinitionOfDone(evidence);
+      }
+    },
+    incidentId
+  );
 
   const isAddButtonDisabled = useMemo(() => {
     if (selectDODState.currentStep === "selectEvidence") {

--- a/src/components/IncidentDetails/AddDefinitionOfDone/AddDefinitionOfDoneHome.tsx
+++ b/src/components/IncidentDetails/AddDefinitionOfDone/AddDefinitionOfDoneHome.tsx
@@ -13,7 +13,7 @@ type AddDefinitionOfDoneStepperProps = {
   noneDODEvidence: Evidence[];
   onAddDefinitionOfDone: (evidence: Evidence[]) => void;
   onCancel: () => void;
-  rootHypothesis: Pick<Hypothesis, "id">;
+  rootHypothesis: Hypothesis;
 };
 
 export function AddDefinitionOfDoneHome({
@@ -24,7 +24,6 @@ export function AddDefinitionOfDoneHome({
 }: AddDefinitionOfDoneStepperProps) {
   const [selectedDoDOption, setSelectedDoDOption] =
     useState<DefinitionOfDoneOptions>();
-
   return (
     <div className="flex flex-col">
       {selectedDoDOption === "Auto" ? (
@@ -32,11 +31,13 @@ export function AddDefinitionOfDoneHome({
           noneDODEvidences={noneDODEvidence}
           onAddDefinitionOfDone={onAddDefinitionOfDone}
           onCancel={onCancel}
+          incidentId={rootHypothesis.incident_id}
         />
       ) : selectedDoDOption === "Manual" ? (
         <AddManualDefinitionOfDone
           hypothesisId={rootHypothesis.id}
           onSuccess={onCancel}
+          incidentId={rootHypothesis.incident_id}
         />
       ) : (
         <div className="flex flex-col space-y-2 p-4">
@@ -68,7 +69,7 @@ type AddDefinitionOfDoneModalProps = {
   noneDODEvidence: Evidence[];
   onCloseModal: () => void;
   onAddDefinitionOfDone: () => void;
-  rootHypothesis: Pick<Hypothesis, "id">;
+  rootHypothesis: Hypothesis;
 };
 
 export default function AddDefinitionOfDoneModal({

--- a/src/components/IncidentDetails/AddDefinitionOfDone/AddManualDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/AddDefinitionOfDone/AddManualDefinitionOfDone.tsx
@@ -22,16 +22,22 @@ export function ManualDoDInput({ value, onChange }: ManualDoDInputProps) {
 
 type Props = {
   hypothesisId: string;
+  incidentId: string;
   onSuccess: (evidence: Evidence[]) => void;
 };
 
 export default function AddManualDefinitionOfDone({
   hypothesisId,
+  incidentId,
   onSuccess
 }: Props) {
   const [value, onChange] = useState<string>();
 
-  const { mutate, isLoading } = useAddCommentAsDoD(hypothesisId, onSuccess);
+  const { mutate, isLoading } = useAddCommentAsDoD(
+    hypothesisId,
+    incidentId,
+    onSuccess
+  );
 
   return (
     <div className="w-full flex flex-col space-y-4 py-4 px-6 overflow-x-hidden">

--- a/src/components/IncidentDetails/AddDefinitionOfDone/useAddCommentAsDoD.tsx
+++ b/src/components/IncidentDetails/AddDefinitionOfDone/useAddCommentAsDoD.tsx
@@ -6,15 +6,19 @@ import { useUser } from "../../../context";
 
 export default function useAddCommentAsDoD(
   hypothesisId: string,
+  incidentId: string,
   onSuccess: (evidence: Evidence[]) => void
 ) {
   const { user } = useUser();
 
-  const { isLoading, mutate } = useCreateEvidenceMutation({
-    onSuccess: (evidence) => {
-      onSuccess([evidence!]);
-    }
-  });
+  const { isLoading, mutate } = useCreateEvidenceMutation(
+    {
+      onSuccess: (evidence) => {
+        onSuccess([evidence!]);
+      }
+    },
+    incidentId
+  );
 
   const addCommentAsDoD = useCallback(
     async (comment: string) => {

--- a/src/components/IncidentDetails/DefinitionOfDone/EditEvidenceDefinitionOfDoneComment.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/EditEvidenceDefinitionOfDoneComment.tsx
@@ -9,23 +9,27 @@ type Props = {
   onCloseModal: () => void;
   isOpen: boolean;
   onSuccess: () => void;
+  incidentId: string;
 };
 
 export default function EditEvidenceDefinitionOfDoneComment({
   evidence,
   onCloseModal,
   isOpen,
+  incidentId,
   onSuccess
 }: Props) {
   const [comment, setComment] = useState<string>();
-
   useEffect(() => {
     setComment(evidence.evidence?.comment || "");
   }, [evidence.evidence?.comment]);
 
-  const { isLoading, mutate } = useUpdateEvidenceMutation({
-    onSuccess
-  });
+  const { isLoading, mutate } = useUpdateEvidenceMutation(
+    {
+      onSuccess
+    },
+    incidentId
+  );
 
   return (
     <Modal

--- a/src/components/IncidentDetails/DefinitionOfDone/EditEvidenceDefinitionOfDoneComment.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/EditEvidenceDefinitionOfDoneComment.tsx
@@ -17,14 +17,15 @@ export default function EditEvidenceDefinitionOfDoneComment({
   isOpen,
   onSuccess
 }: Props) {
-  console.log("evidence", evidence);
   const [comment, setComment] = useState<string>();
 
   useEffect(() => {
-    setComment(evidence.evidence?.comment);
+    setComment(evidence.evidence?.comment || "");
   }, [evidence.evidence?.comment]);
 
-  const { isLoading, mutate } = useUpdateEvidenceMutation();
+  const { isLoading, mutate } = useUpdateEvidenceMutation({
+    onSuccess
+  });
 
   return (
     <Modal
@@ -37,6 +38,7 @@ export default function EditEvidenceDefinitionOfDoneComment({
         <button
           className="px-4 py-2 btn-primary"
           type="button"
+          key="update"
           onClick={async () => {
             mutate([
               {
@@ -48,7 +50,6 @@ export default function EditEvidenceDefinitionOfDoneComment({
                 }
               }
             ]);
-            onSuccess();
           }}
         >
           {isLoading ? "Updating ..." : "Update"}

--- a/src/components/IncidentDetails/DefinitionOfDone/EditEvidenceDefinitionOfDoneScript.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/EditEvidenceDefinitionOfDoneScript.tsx
@@ -23,7 +23,9 @@ export default function EditEvidenceDefinitionOfDoneScript({
     setDodScript(evidence.script);
   }, [evidence.script]);
 
-  const { isLoading, mutateAsync } = useUpdateEvidenceMutation();
+  const { isLoading, mutateAsync } = useUpdateEvidenceMutation({
+    onSuccess
+  });
 
   return (
     <Modal
@@ -45,7 +47,6 @@ export default function EditEvidenceDefinitionOfDoneScript({
                 script: dodScript
               }
             ]);
-            onSuccess();
           }}
         >
           {isLoading ? "Updating ..." : "Update"}

--- a/src/components/IncidentDetails/DefinitionOfDone/EditEvidenceDefinitionOfDoneScript.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/EditEvidenceDefinitionOfDoneScript.tsx
@@ -9,13 +9,15 @@ type Props = {
   onCloseModal: () => void;
   isOpen: boolean;
   onSuccess: () => void;
+  incidentId: string;
 };
 
 export default function EditEvidenceDefinitionOfDoneScript({
   evidence,
   onCloseModal,
   isOpen,
-  onSuccess
+  onSuccess,
+  incidentId
 }: Props) {
   const [dodScript, setDodScript] = useState<string>();
 
@@ -23,9 +25,12 @@ export default function EditEvidenceDefinitionOfDoneScript({
     setDodScript(evidence.script);
   }, [evidence.script]);
 
-  const { isLoading, mutateAsync } = useUpdateEvidenceMutation({
-    onSuccess
-  });
+  const { isLoading, mutateAsync } = useUpdateEvidenceMutation(
+    {
+      onSuccess
+    },
+    incidentId
+  );
 
   return (
     <Modal

--- a/src/components/IncidentDetails/DefinitionOfDone/EvidenceView/index.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/EvidenceView/index.tsx
@@ -58,7 +58,7 @@ function TopologyEvidence({
       {...rest}
     >
       <div className="flex flex-col -mt-1 bg-white divide-y divide-gray-200 w-full">
-        <div className="flex pr-1 pt-2.5 pb-2.5 pl-2 overflow-hidden">
+        <div className="flex pr-1 pt-2.5 pb-2.5 overflow-hidden">
           <div className="text-gray-500 m-auto mr-2.5 flex-initial max-w-1/4 leading-1.21rel">
             <h3 className="text-gray-500 leading-1.21rel">
               <Icon name={topology.icon} />
@@ -116,7 +116,7 @@ function LogEvidence({
   return (
     <div
       className={clsx(
-        "overflow-hidden p-2 font-medium text-gray-500",
+        "overflow-hidden py-2 font-medium text-gray-500",
         className
       )}
       {...rest}
@@ -151,7 +151,7 @@ function ConfigEvidence({
   }
 
   return (
-    <div className={clsx("overflow-hidden p-2", className)} {...rest}>
+    <div className={clsx("overflow-hidden py-2", className)} {...rest}>
       <Icon name={config.external_type} secondary={config.config_type} />{" "}
       <span className="pl-1 text-gray-500 font-medium"> {config.name} </span>{" "}
     </div>
@@ -193,7 +193,7 @@ function HealthEvidence({
   };
 
   return (
-    <div className="overflow-hidden p-2" {...rest}>
+    <div className="overflow-hidden py-2" {...rest}>
       <div className={`flex flex-row`} {...rest}>
         <div className={clsx("flex-shrink-0", "pr-2")}>
           <Icon name={check?.icon || check?.type} />
@@ -229,7 +229,7 @@ function CommentEvidence({
   ...rest
 }: EvidenceViewProps) {
   return (
-    <div className="overflow-hidden p-2" {...rest}>
+    <div className="overflow-hidden py-2" {...rest}>
       <div className={`flex flex-row items-center`} {...rest}>
         <div className="flex flex-row">
           <div className={clsx("flex-shrink-0", "pr-2")}>

--- a/src/components/IncidentDetails/DefinitionOfDone/EvidenceView/index.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/EvidenceView/index.tsx
@@ -222,7 +222,7 @@ function HealthEvidence({
   );
 }
 
-function CommentEvidence({
+export function CommentEvidence({
   evidence,
   size,
   className,
@@ -252,7 +252,7 @@ export function EvidenceView({
 }: EvidenceViewProps) {
   switch (evidence.type) {
     case EvidenceType.Log:
-      return <LogEvidence evidence={evidence} />;
+      return <LogEvidence evidence={evidence} {...rest} />;
     case EvidenceType.Topology:
       return (
         <TopologyEvidence className={className} evidence={evidence} {...rest} />

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
@@ -143,6 +143,7 @@ export function IncidentsDefinitionOfDone({
       className={clsx(className)}
       childrenClassName=""
       {...props}
+      dataCount={dodEvidences?.length}
     >
       <div className="flex flex-col">
         <div className="flex overflow-x-hidden w-full pb-6">

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
@@ -153,7 +153,7 @@ export function IncidentsDefinitionOfDone({
       dataCount={dodEvidences?.length}
     >
       <div className="flex flex-col">
-        <div className="flex overflow-x-hidden w-full pb-6">
+        <div className="flex overflow-x-hidden w-full pb-6 pt-2">
           <div className="w-full space-y-1">
             {isLoading && !incident ? (
               <div className="flex items-start pl-2 pr-2">

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
@@ -14,6 +14,7 @@ import { ClickableSvg } from "../../ClickableSvg/ClickableSvg";
 import { useIncidentState } from "../../../store/incident.state";
 import EmptyState from "../../EmptyState";
 import { CountBadge } from "../../Badge/CountBadge";
+import { dateSortHelper } from "../../../utils/date";
 
 type DefinitionOfDoneProps = React.HTMLProps<HTMLDivElement> & {
   incidentId: string;
@@ -80,7 +81,13 @@ export function IncidentsDefinitionOfDone({
       });
     });
     setNonDODEvidences(data.filter((evidence) => !evidence.definition_of_done));
-    setDODEvidences(data.filter((evidence) => evidence.definition_of_done));
+    setDODEvidences(
+      data
+        .filter((evidence) => evidence.definition_of_done)
+        .sort((a, b) => {
+          return dateSortHelper("asc", a.created_at, b.created_at);
+        })
+    );
   }, [incident]);
 
   const rootHypothesis = useMemo(() => {

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
@@ -11,9 +11,9 @@ import { MdRefresh } from "react-icons/md";
 import { RiFullscreenLine } from "react-icons/ri";
 import { BsCardChecklist } from "react-icons/bs";
 import { ClickableSvg } from "../../ClickableSvg/ClickableSvg";
-import { Badge } from "../../Badge";
 import { useIncidentState } from "../../../store/incident.state";
 import EmptyState from "../../EmptyState";
+import { CountBadge } from "../../Badge/CountBadge";
 
 type DefinitionOfDoneProps = React.HTMLProps<HTMLDivElement> & {
   incidentId: string;
@@ -113,10 +113,9 @@ export function IncidentsDefinitionOfDone({
             title="Definition of done"
             icon={<BsCardChecklist className="w-6 h-6" />}
           />
-          <Badge
-            className="w-5 h-5 flex items-center justify-center"
+          <CountBadge
             roundedClass="rounded-full"
-            text={dodEvidences?.length ?? 0}
+            value={dodEvidences?.length ?? 0}
           />
           <div
             className="relative z-0 inline-flex justify-end ml-5"

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDone.tsx
@@ -168,7 +168,7 @@ export function IncidentsDefinitionOfDone({
                   evidence={evidence}
                   setEvidenceBeingRemoved={setEvidenceBeingRemoved}
                   setOpenDeleteConfirmDialog={setOpenDeleteConfirmDialog}
-                  refetch={refetchIncident}
+                  incidentId={incidentId}
                 />
               ))
             )}

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDoneItem.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDoneItem.tsx
@@ -67,18 +67,17 @@ export default function IncidentsDefinitionOfDoneItem({
   return (
     <>
       <div className="relative flex items-center">
-        {isLoading ? (
-          <MdRefresh className="animate-spin" />
-        ) : evidence.done ? (
-          <AiFillCheckCircle className="mr-1 fill-green-500" />
-        ) : (
-          <BsHourglassSplit className="mr-1" />
-        )}
-
         <div className="min-w-0 flex-1 text-sm">
           <EvidenceView evidence={evidence} size={Size.small} />
         </div>
         <div className="flex items-center">
+          {isLoading ? (
+            <MdRefresh className="animate-spin" />
+          ) : evidence.done ? (
+            <AiFillCheckCircle className="mr-1 fill-green-500" />
+          ) : (
+            <BsHourglassSplit className="mr-1" />
+          )}
           <Menu>
             <div className="" ref={dropdownMenuStylesCalc}>
               <Menu.VerticalIconButton />

--- a/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDoneItem.tsx
+++ b/src/components/IncidentDetails/DefinitionOfDone/IncidentsDefinitionOfDoneItem.tsx
@@ -23,14 +23,14 @@ type Props = {
   evidence: Evidence;
   setOpenDeleteConfirmDialog: Dispatch<SetStateAction<boolean>>;
   setEvidenceBeingRemoved: Dispatch<SetStateAction<Evidence | undefined>>;
-  refetch: () => void;
+  incidentId: string;
 };
 
 export default function IncidentsDefinitionOfDoneItem({
   evidence,
   setEvidenceBeingRemoved,
   setOpenDeleteConfirmDialog,
-  refetch
+  incidentId
 }: Props) {
   const [isEditingDoDScriptModalOpen, setIsEditingDoDScriptModalOpen] =
     useState(false);
@@ -40,9 +40,7 @@ export default function IncidentsDefinitionOfDoneItem({
 
   const [isTogglingAsResolved, setIsTogglingAsResolved] = useState(false);
 
-  const { isLoading, mutate } = useUpdateEvidenceMutation({
-    onSuccess: () => refetch()
-  });
+  const { isLoading, mutate } = useUpdateEvidenceMutation({}, incidentId);
 
   const [dropDownMenuStyles, setDropDownMenuStyles] = useState<CSSProperties>();
 
@@ -158,9 +156,9 @@ export default function IncidentsDefinitionOfDoneItem({
           onCloseModal={() => setIsEditingDoDScriptModalOpen(false)}
           onSuccess={() => {
             setIsEditingDoDScriptModalOpen(false);
-            refetch();
           }}
           key={`script_${evidence.id}`}
+          incidentId={incidentId}
         />
       ) : (
         <EditEvidenceDefinitionOfDoneComment
@@ -169,9 +167,9 @@ export default function IncidentsDefinitionOfDoneItem({
           onCloseModal={() => setIsEditingDoDCommentModalOpen(false)}
           onSuccess={() => {
             setIsEditingDoDCommentModalOpen(false);
-            refetch();
           }}
           key={`comment_${evidence.id}`}
+          incidentId={incidentId}
         />
       )}
 

--- a/src/components/Sidebars/incidents.tsx
+++ b/src/components/Sidebars/incidents.tsx
@@ -10,7 +10,7 @@ import { Link } from "react-router-dom";
 import { IncidentStatusTag } from "../IncidentStatusTag";
 import { IncidentTypeIcon } from "../incidentTypeTag";
 import { DetailsTable } from "../DetailsTable/DetailsTable";
-import { Badge } from "../Badge";
+import { CountBadge } from "../Badge/CountBadge";
 
 type Props = {
   topologyId?: string;
@@ -88,10 +88,9 @@ export default function Incidents({ topologyId, configId }: Props) {
             title="Incidents"
             icon={<ImLifebuoy className="w-6 h-auto" />}
           />
-          <Badge
-            className="w-5 h-5 flex items-center justify-center"
+          <CountBadge
             roundedClass="rounded-full"
-            text={incidents?.length ?? 0}
+            value={incidents?.length ?? 0}
           />
           <div className="ml-5 text-right grow">
             <IncidentsFilterBar

--- a/src/components/Sidebars/incidents.tsx
+++ b/src/components/Sidebars/incidents.tsx
@@ -100,6 +100,7 @@ export default function Incidents({ topologyId, configId }: Props) {
           </div>
         </div>
       }
+      dataCount={incidents?.length}
     >
       <div className="flex flex-col">
         <div className="flex flex-col space-y-1">

--- a/src/components/SlidingSideBar/SlidingSideBar.stories.tsx
+++ b/src/components/SlidingSideBar/SlidingSideBar.stories.tsx
@@ -1,0 +1,87 @@
+import CollapsiblePanel from "../CollapsiblePanel";
+import SlidingSideBar from "./index";
+
+const data = Array.from(Array(100).keys());
+
+export default {};
+
+const Template = () => (
+  <SlidingSideBar>
+    <CollapsiblePanel Header={<div>First Panel</div>}>
+      {data.map((item) => {
+        return <div key={item}>{item}</div>;
+      })}
+    </CollapsiblePanel>
+    <CollapsiblePanel Header={<div>Second Panel</div>}>
+      {data.map((item) => {
+        return <div key={item}>{item}</div>;
+      })}
+    </CollapsiblePanel>
+    <CollapsiblePanel Header={<div>Third Panel</div>}>
+      {data.map((item) => {
+        return <div key={item}>{item}</div>;
+      })}
+    </CollapsiblePanel>
+  </SlidingSideBar>
+);
+
+export const EqualAutoHeight = Template.bind({});
+
+const RatioBasedHeightTemplate = () => (
+  <SlidingSideBar>
+    <CollapsiblePanel
+      Header={<div>First Panel</div>}
+      data-panel-height-ratio="0.5"
+    >
+      {data.map((item) => {
+        return <div key={item}>{item}</div>;
+      })}
+    </CollapsiblePanel>
+    <CollapsiblePanel
+      Header={<div>Second Panel</div>}
+      data-panel-height-ratio="0.75"
+    >
+      {data.map((item) => {
+        return <div key={item}>{item}</div>;
+      })}
+    </CollapsiblePanel>
+    <CollapsiblePanel
+      Header={<div>Third Panel</div>}
+      data-panel-height-ratio="1.75"
+    >
+      {data.map((item) => {
+        return <div key={item}>{item}</div>;
+      })}
+    </CollapsiblePanel>
+  </SlidingSideBar>
+);
+
+export const RatioBasedHeight = RatioBasedHeightTemplate.bind({});
+
+const FixedAndAutoHeightTemplate = () => (
+  <SlidingSideBar>
+    <CollapsiblePanel Header={<div>First Panel</div>} data-panel-height="150px">
+      {data.map((item) => {
+        return <div key={item}>{item}</div>;
+      })}
+    </CollapsiblePanel>
+    <CollapsiblePanel
+      Header={<div>Second Panel</div>}
+      data-panel-height-ratio="0.75"
+    >
+      {data.map((item) => {
+        return <div key={item}>{item}</div>;
+      })}
+    </CollapsiblePanel>
+    <CollapsiblePanel
+      Header={<div>Third Panel</div>}
+      data-panel-height-ratio="1.25"
+    >
+      {data.map((item) => {
+        return <div key={item}>{item}</div>;
+      })}
+    </CollapsiblePanel>
+  </SlidingSideBar>
+);
+
+export const FixedAndAutoHeight = FixedAndAutoHeightTemplate.bind({});

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -85,7 +85,7 @@ export function Tabs({
   return (
     <>
       <div
-        className={`flex flex-wrap border-b border-gray-300 ${className}`}
+        className={clsx(`flex flex-wrap`, className)}
         aria-label="Tabs"
         {...rest}
       >
@@ -99,6 +99,7 @@ export function Tabs({
             onClick={tab.props?.onClick!}
           />
         ))}
+        <div className="flex-grow border-b border-gray-300"></div>
       </div>
       <div className={contentClassName}>{content}</div>
     </>

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -22,13 +22,10 @@ function TabItem({
         onClick?.(event);
         onSelectTab?.();
       }}
-      style={{
-        marginBottom: "-1px",
-        borderColor: value === activeTab ? "" : "transparent",
-        borderBottomColor: value === activeTab ? "white" : ""
-      }}
       className={clsx(
-        value === activeTab ? "text-gray-900 bg-white" : "text-gray-500",
+        value === activeTab
+          ? "text-gray-900 bg-white border-b-0"
+          : "text-gray-500 border-0 border-b",
         "cursor-pointer px-4 py-2 font-medium text-sm rounded-t-md border border-gray-300 hover:text-gray-900"
       )}
     >

--- a/src/components/TopologyConfigChanges/index.tsx
+++ b/src/components/TopologyConfigChanges/index.tsx
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import { GoDiff } from "react-icons/go";
 import { Link } from "react-router-dom";
 import { useComponentConfigChanges } from "../../api/query-hooks/useComponentConfigChanges";
-import { Badge } from "../Badge";
+import { CountBadge } from "../Badge/CountBadge";
 import CollapsiblePanel from "../CollapsiblePanel";
 import ConfigLink from "../ConfigLink/ConfigLink";
 import EmptyState from "../EmptyState";
@@ -69,10 +69,9 @@ export default function (props: Props) {
       Header={
         <div className="flex flex-row w-full items-center space-x-2">
           <Title title="Changes" icon={<GoDiff className="w-6 h-auto" />} />
-          <Badge
-            className="w-5 h-5 flex items-center justify-center"
+          <CountBadge
             roundedClass="rounded-full"
-            text={componentConfigChanges.length}
+            value={componentConfigChanges.length}
           />
         </div>
       }

--- a/src/components/TopologyConfigChanges/index.tsx
+++ b/src/components/TopologyConfigChanges/index.tsx
@@ -75,6 +75,7 @@ export default function (props: Props) {
           />
         </div>
       }
+      dataCount={componentConfigChanges.length}
     >
       <div className="flex flex-col">
         <TopologyConfigChanges {...props} />

--- a/src/components/TopologySidebar/ComponentTeams.tsx
+++ b/src/components/TopologySidebar/ComponentTeams.tsx
@@ -29,6 +29,7 @@ export function ComponentTeams({ componentId }: Props) {
           />
         </div>
       }
+      dataCount={componentTeams?.length}
     >
       <div className="flex flex-col space-y-4 py-2 w-full">
         {isLoading ? (

--- a/src/components/TopologySidebar/ComponentTeams.tsx
+++ b/src/components/TopologySidebar/ComponentTeams.tsx
@@ -5,7 +5,7 @@ import CollapsiblePanel from "../CollapsiblePanel";
 import EmptyState from "../EmptyState";
 import { ComponentTeamLink } from "./ComponentTeamLink";
 import TextSkeletonLoader from "../SkeletonLoader/TextSkeletonLoader";
-import { Badge } from "../Badge";
+import { CountBadge } from "../Badge/CountBadge";
 
 type Props = {
   componentId: string;
@@ -23,10 +23,9 @@ export function ComponentTeams({ componentId }: Props) {
             title="Teams"
             icon={<AiOutlineTeam className="w-6 h-auto" />}
           />
-          <Badge
-            className="w-5 h-5 flex items-center justify-center"
+          <CountBadge
             roundedClass="rounded-full"
-            text={componentTeams?.length ?? 0}
+            value={componentTeams?.length ?? 0}
           />
         </div>
       }

--- a/src/components/TopologySidebar/TopologyActionBar.tsx
+++ b/src/components/TopologySidebar/TopologyActionBar.tsx
@@ -208,7 +208,7 @@ export default function TopologyActionBar({
     <>
       <div className="flex flex-wrap justify-between py-4 px-1">
         {topologyActionItems.map(
-          ({ icon: Icon, isShown, label, ContainerComponent }) => {
+          ({ icon: Icon, isShown, label, ContainerComponent }, index) => {
             if (isShown(topology, "TopologySidebar")) {
               return (
                 <ContainerComponent
@@ -218,6 +218,7 @@ export default function TopologyActionBar({
                   child={ActionLink}
                   icon={<Icon />}
                   text={label}
+                  key={index}
                   openModalAction={
                     label === "Snapshot"
                       ? () => setIsDownloadComponentSnapshotModalOpen(true)

--- a/src/components/TopologySidebar/TopologySidebar.tsx
+++ b/src/components/TopologySidebar/TopologySidebar.tsx
@@ -31,12 +31,12 @@ export default function TopologySidebar({
     <SlidingSideBar hideToggle>
       <TopologyActionBar topology={topology} onRefresh={onRefresh} />
       <TopologyDetails topology={topology} refererId={refererId} />
-      <Configs topologyId={id} />
-      <Incidents topologyId={id} />
       <TopologyCost topology={topology} />
-      <TopologyConfigChanges topologyID={id} />
       <ComponentTeams componentId={id} />
       <TopologyInsights topologyId={id} />
+      <Incidents topologyId={id} />
+      <Configs topologyId={id} />
+      <TopologyConfigChanges topologyID={id} />
     </SlidingSideBar>
   );
 }


### PR DESCRIPTION
- add count badge component do display counts and to adjust style based on the value.
- topology sidebar menu items are re arranged.
- definition done item views ui/ux fixes.
- sorted definition of done items before displaying.
- auto collapse collapsible panel when there is no data based on the dataCount property.
- fixed the issue of comment box on comments view of incidents details is hidden when there are no hypothesis.
- fixed the styling issues of tab in active state.
- sliding sidebar storybook changes.
- fixed the issue of manually added definition of done item not being shown until refresh is clicked. 