### PR TITLE
refactor: improve signin and signup page validation errors styling

### DIFF
--- a/src/components/ory/ui/NodeInputDefault.tsx
+++ b/src/components/ory/ui/NodeInputDefault.tsx
@@ -43,9 +43,7 @@ export function NodeInputDefault(props: NodeInputProps) {
           disabled={attributes.disabled || disabled}
         />
         {!!node.messages.length && (
-          <div
-            className={clsx("p-2 mt-2 border", { "border-red-300": hasError })}
-          >
+          <div className={clsx("mt-2", { "text-red-600 text-sm": hasError })}>
             {node.messages.map(({ text, id }, k) => (
               <span key={`${id}-${k}`} data-testid={`ui/message/${id}`}>
                 {text}


### PR DESCRIPTION
closes #985

I have found this form validation in the dashboard.
![Screenshot from 2023-04-12 18-14-58](https://user-images.githubusercontent.com/31247452/231541201-89e6dd25-8451-4d2f-a463-566b43e2fbb4.png)

**Previous style for signin & signup page validation**
![Screenshot from 2023-04-12 18-54-14](https://user-images.githubusercontent.com/31247452/231542932-e987fadc-abc8-4434-a7d0-015d7f52ca61.png)

**current style**
[Loom Video](https://www.loom.com/share/42f57e90f1794d5eb18577a6c67eceff)