### PR TITLE
fix: remove schedule field from health check resource form

### DIFF
--- a/src/api/schemaResources.ts
+++ b/src/api/schemaResources.ts
@@ -10,7 +10,7 @@ import { JobHistoryStatus } from "../components/JobsHistory/JobsHistoryTable";
 export interface SchemaResourceI {
   id: string;
   name: string;
-  spec: string | object;
+  spec: { spec: string | undefined } & Record<string, any>;
   namespace: string;
   labels: { [key: string]: any };
   schedule?: string;

--- a/src/components/SchemaResourcePage/SchemaResourceList.tsx
+++ b/src/components/SchemaResourcePage/SchemaResourceList.tsx
@@ -41,6 +41,7 @@ export function SchemaResourceList({ items, baseUrl, table }: Props) {
                 table={table}
                 key={item.id}
                 {...item}
+                schedule={item.spec?.schedule}
                 baseUrl={baseUrl}
               />
             ))}

--- a/src/components/SchemaResourcePage/resourceTypes.tsx
+++ b/src/components/SchemaResourcePage/resourceTypes.tsx
@@ -165,10 +165,6 @@ export const schemaResourceTypes = [
       {
         name: "spec",
         default: {}
-      },
-      {
-        name: "schedule",
-        default: undefined
       }
     ]
   }


### PR DESCRIPTION
Closes #1086

### Test Plan
- login with your credentials
- go to health check create page by clicking on the health sub menu item fo setting menu item on the sidebar
- you will be shown list of health checks and schedule column value of that table is read from spec
- click on the plus icon on the navbar and observe there is no separate schedule option in the health check form.

### Feature changes screenshot
<img width="1680" alt="Screenshot 2023-04-20 at 4 14 45 PM" src="https://user-images.githubusercontent.com/7310975/233343336-77d67a7e-01e3-41ad-ba99-a89669ebdad0.png">
