### PR TITLE
fix: refetch on mount incidents to get latest copy

### DIFF
--- a/src/pages/incident/IncidentListPage.tsx
+++ b/src/pages/incident/IncidentListPage.tsx
@@ -69,6 +69,9 @@ export function IncidentListPage() {
       };
       const res = await getIncidentsSummary(toPostgresqlSearchParam(params));
       return res;
+    },
+    {
+      refetchOnMount: "always"
     }
   );
 


### PR DESCRIPTION
closes #1300