### PR TITLE
Fix-auth-mishaps

### DIFF
--- a/.env
+++ b/.env
@@ -15,5 +15,4 @@ NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/organizations/create
 # CLERK_SECRET_KEY=sk_test_EeUiC56XXbSKiMZQULyhD7FZk8RGMpcLW7pVEO7emD
 
 # replace this with the actual domain where clerk based backend is hosted
-NEXT_PUBLIC_CLERK_BACKEND_DOMAIN=azure.lab.flanksource.com
 # NEXT_PUBLIC_INTERCOM_APP_ID=

--- a/pages/api/[...paths].ts
+++ b/pages/api/[...paths].ts
@@ -7,7 +7,6 @@ const API_URL = process.env.BACKEND_URL;
 const isCanary = process.env.NEXT_PUBLIC_APP_DEPLOYMENT === "CANARY_CHECKER";
 const env = process.env.ENV;
 const isClerkAuth = process.env.NEXT_PUBLIC_AUTH_IS_CLERK === "true";
-const clerkDomain = process.env.NEXT_PUBLIC_CLERK_BACKEND_DOMAIN;
 
 const canaryPrefix = isCanary ? "" : "/canary";
 
@@ -23,11 +22,10 @@ async function getTargetURL(req: NextApiRequest) {
     const org = await clerkClient.organizations.getOrganization({
       organizationId: user.sessionClaims?.org_id!
     });
-    const organizationSlug = user.sessionClaims?.org_slug;
     const backendURL = org?.publicMetadata?.backend_url;
     // for now, lets fallback to the old way of doing things, if the backend_url
     // is not set in the org metadata
-    const target = backendURL ?? `https://${organizationSlug}.${clerkDomain}/`;
+    const target = backendURL;
     return target;
   }
   return API_URL;

--- a/pages/api/[...paths].ts
+++ b/pages/api/[...paths].ts
@@ -6,7 +6,7 @@ import { clerkClient } from "@clerk/nextjs";
 const API_URL = process.env.BACKEND_URL;
 const isCanary = process.env.NEXT_PUBLIC_APP_DEPLOYMENT === "CANARY_CHECKER";
 const env = process.env.ENV;
-const isClerkAuth = process.env.NEXT_PUBLIC_AUTH_IS_CLERK;
+const isClerkAuth = process.env.NEXT_PUBLIC_AUTH_IS_CLERK === "true";
 const clerkDomain = process.env.NEXT_PUBLIC_CLERK_BACKEND_DOMAIN;
 
 const canaryPrefix = isCanary ? "" : "/canary";

--- a/pages/auth-state-checker.tsx
+++ b/pages/auth-state-checker.tsx
@@ -15,7 +15,7 @@ export function ClerkAuthStateChecker() {
     if (isLoaded && !isSignedIn) {
       push(`/login?return_to=${returnURL}`);
     } else {
-      push("/error?code=BAD_SESSION");
+      push("/error?error_code=BAD_SESSION");
     }
   }, [isLoaded, isSignedIn, push, returnURL]);
 


### PR DESCRIPTION
Removing the fallback (default) URL, which was created using org slug, and solely relying on the backend_url in the public metadata, will return a 500 error when backend_url hasn't been set.