### PR TITLE
fix: fix build failing due to TS error from transition component

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,3 @@
-
 name: Lint
 on:
   push:
@@ -6,20 +5,22 @@ on:
       - main
   pull_request:
     paths:
-      - 'Makefile'
-      - '**.jsx?'
-      - '**.tsx?'
-      - '**/.babelrc'
-      - '**/.eslint*'
-      - '**/.prettierrc*'
-      - '**/package.json'
-      - '**/github/workflows/lint.yml'
+      - "Makefile"
+      - "**.jsx?"
+      - "**.tsx?"
+      - "**/.babelrc"
+      - "**/.eslint*"
+      - "**/.prettierrc*"
+      - "**/package.json"
+      - "**/github/workflows/lint.yml"
 jobs:
   eslint:
     runs-on: ubuntu-latest
-    container:
-      image: node:16-alpine
     steps:
       - uses: actions/checkout@master
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: "npm"
       - run: npm i
       - run: npm run lint:eslint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,12 @@ name: Test
 jobs:
   test:
     runs-on: ubuntu-latest
-    container:
-      image: node:16-alpine
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: "npm"
       - run: npm i
       - run: npm run test:ci
 
@@ -32,11 +34,14 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
+
   production-build:
     runs-on: ubuntu-latest
-    container:
-      image: node:16-alpine
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: "npm"
       - run: npm i
       - run: npm run build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,4 +44,6 @@ jobs:
           node-version: 20
           cache: "npm"
       - run: npm i
-      - run: npm run build
+      - run: |
+          export NODE_OPTIONS=--max_old_space_size=4096
+          npm run build

--- a/src/components/Playbooks/Runs/Submit/PlaybooksDropdownMenu.tsx
+++ b/src/components/Playbooks/Runs/Submit/PlaybooksDropdownMenu.tsx
@@ -51,8 +51,9 @@ export default function PlaybooksDropdownMenu({
             />
           </Menu.Button>
         </div>
+        {/* @ts-ignore */}
         <Transition
-          as={Fragment}
+          as={Fragment as any}
           enter="transition ease-out duration-100"
           enterFrom="transform opacity-0 scale-95"
           enterTo="transform opacity-100 scale-100"


### PR DESCRIPTION
- Transition component was breaking netlfiy build errors
- Switched node to v20 (current Long Term Support, and enabled caching of NPM dependencies) in Github Action as this was also failing in this PR, while increasing memory for production build to 4gb.