### PR TITLE
fix: hide personal workspace on default org switcher

### DIFF
--- a/pages/organizations/switcher/[[...organization-switcher]].tsx
+++ b/pages/organizations/switcher/[[...organization-switcher]].tsx
@@ -27,6 +27,7 @@ export default function ClerkOrganizationSwitcher() {
                 createOrganizationUrl={clerkUrls.createOrganization}
                 createOrganizationMode="navigation"
                 afterSwitchOrganizationUrl={redirectUrl}
+                hidePersonal
               />
             </div>
           </div>


### PR DESCRIPTION
This is the page you land in after signup