### PR TITLE
fix: make the delete button distinguishable from badge and add tooltip

### DIFF
--- a/src/components/Sidebars/configs.tsx
+++ b/src/components/Sidebars/configs.tsx
@@ -1,22 +1,22 @@
 import clsx from "clsx";
+import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
-import { VscJson } from "react-icons/vsc";
 import { TbTrash, TbTrashOff } from "react-icons/tb";
+import { VscJson } from "react-icons/vsc";
 import ReactTooltip from "react-tooltip";
+import { useComponentConfigRelationshipQuery } from "../../api/query-hooks/useComponentConfigRelationshipQuery";
 import { removeManualComponentConfigRelationship } from "../../api/services/configs";
+import { Badge } from "../Badge";
 import CollapsiblePanel from "../CollapsiblePanel";
 import ConfigLink from "../ConfigLink/ConfigLink";
+import { ConfirmationPromptDialog } from "../Dialogs/ConfirmationPromptDialog";
 import EmptyState from "../EmptyState";
-import Title from "../Title/title";
-import { Badge } from "../Badge";
 import { IconButton } from "../IconButton";
 import TextSkeletonLoader from "../SkeletonLoader/TextSkeletonLoader";
-import { BsTrash } from "react-icons/bs";
-import { toastSuccess, toastError } from "../Toast/toast";
-import { useComponentConfigRelationshipQuery } from "../../api/query-hooks/useComponentConfigRelationshipQuery";
-import { ConfirmationPromptDialog } from "../Dialogs/ConfirmationPromptDialog";
-import { useAtom } from "jotai";
 import { refreshButtonClickedTrigger } from "../SlidingSideBar";
+import Title from "../Title/title";
+import { toastError, toastSuccess } from "../Toast/toast";
+import TopologyConfigsActionsDropdown from "../Topology/Sidebar/Utils/TopologyConfigsActionsDropdown";
 
 type Props = {
   topologyId?: string;
@@ -96,21 +96,9 @@ export function ConfigsList({
                 />
               )}
               {topologyId && (
-                <div className="flex flex-row justify-end items-center">
-                  <IconButton
-                    className="bg-transparent flex items-center"
-                    ovalProps={{
-                      stroke: "blue",
-                      height: "18px",
-                      width: "18px",
-                      fill: "transparent"
-                    }}
-                    icon={<BsTrash />}
-                    onClick={() => {
-                      setDeletedConfigLinkId(config.id);
-                    }}
-                  />
-                </div>
+                <TopologyConfigsActionsDropdown
+                  onUnlinkUser={() => setDeletedConfigLinkId(config.id)}
+                />
               )}
             </li>
           ))}

--- a/src/components/Topology/Sidebar/TopologyActionBar.tsx
+++ b/src/components/Topology/Sidebar/TopologyActionBar.tsx
@@ -187,7 +187,7 @@ export const topologyActionItems: Readonly<TopologyActionItem>[] = [
     }
   },
   {
-    label: "Link to config",
+    label: "Link to catalog",
     icon: BiLink,
     isShown: () => true,
     ContainerComponent: function Container({
@@ -239,7 +239,7 @@ export default function TopologyActionBar({
         return setIsDownloadComponentSnapshotModalOpen(true);
       case "Link to Incident":
         return setAttachAsAsset(true);
-      case "Link to config":
+      case "Link to catalog":
         return setLinkToConfig(true);
       default:
         break;

--- a/src/components/Topology/Sidebar/Utils/TopologyConfigsActionsDropdown.tsx
+++ b/src/components/Topology/Sidebar/Utils/TopologyConfigsActionsDropdown.tsx
@@ -1,0 +1,41 @@
+import { Float } from "@headlessui-float/react";
+import { Menu } from "@headlessui/react";
+import { DotsVerticalIcon } from "@heroicons/react/solid";
+import { Icon } from "../../../Icon";
+
+type Props = {
+  onUnlinkUser: () => void;
+};
+
+export default function TopologyConfigsActionsDropdown({
+  onUnlinkUser = () => {}
+}: Props) {
+  return (
+    <div className="flex flex-row justify-end items-center">
+      <Menu>
+        <Float placement="bottom-end" offset={10} portal>
+          <Menu.Button className="p-0.5 min-w-7 rounded-full text-gray-400 hover:text-gray-500">
+            <DotsVerticalIcon className="h-6 w-6" />
+          </Menu.Button>
+          <Menu.Items className="w-48 bg-white divide-y divide-gray-100 rounded-md shadow-card  focus:outline-none z-10 ">
+            <Menu.Item
+              as="button"
+              className="flex gap-2 items-center w-full text-gray-700 hover:bg-gray-200 px-3 py-1.5 cursor-pointer"
+              onClick={() => {
+                onUnlinkUser();
+              }}
+            >
+              <>
+                <Icon
+                  name="unlink"
+                  className="text-gray-600 border-0 border-gray-200 border-l-1 h-4 align-middles"
+                />
+                <span> Unlink catalog</span>
+              </>
+            </Menu.Item>
+          </Menu.Items>
+        </Float>
+      </Menu>
+    </div>
+  );
+}

--- a/src/components/Topology/Sidebar/Utils/__tests__/TopologyConfigsActionDropdown.unit.test.tsx
+++ b/src/components/Topology/Sidebar/Utils/__tests__/TopologyConfigsActionDropdown.unit.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import TopologyConfigsActionsDropdown from "./../TopologyConfigsActionsDropdown";
+
+describe("TopologyConfigsActionsDropdown", () => {
+  const mockOnUnlinkUser = jest.fn();
+
+  it("renders correctly", () => {
+    render(<TopologyConfigsActionsDropdown onUnlinkUser={mockOnUnlinkUser} />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("calls onUnlinkUser when Unlink user is clicked", () => {
+    render(<TopologyConfigsActionsDropdown onUnlinkUser={mockOnUnlinkUser} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /unlink catalog/i }));
+
+    expect(mockOnUnlinkUser).toHaveBeenCalled();
+  });
+});

--- a/src/components/TopologyCard/TopologyDropdownMenu.tsx
+++ b/src/components/TopologyCard/TopologyDropdownMenu.tsx
@@ -128,7 +128,7 @@ export const TopologyDropdownMenu = ({
                         ? () => setIsDownloadComponentSnapshotModalOpen(true)
                         : label === "Link to Incident"
                         ? () => setAttachAsAsset(true)
-                        : label === "Link to config"
+                        : label === "Link to catalog"
                         ? () => setLinkToConfig(true)
                         : undefined
                     }

--- a/src/components/TopologyConfigLinkModal/TopologyConfigLinkModal.tsx
+++ b/src/components/TopologyConfigLinkModal/TopologyConfigLinkModal.tsx
@@ -108,7 +108,7 @@ export function TopologyConfigLinkModal({
         onCloseModal(false);
         setValue(undefined);
       }}
-      title={`Link to config`}
+      title={`Link to Catalog`}
       open={openModal}
       size="slightly-small"
       containerClassName=""


### PR DESCRIPTION
Me and Yash for a moment visually thought the current delete button was a badge, by making it red, we are making it visually distinguishable and actionable

![image](https://github.com/flanksource/flanksource-ui/assets/12270550/746fb4c5-ba47-41f2-97fa-a00cc472424e)

Closes #1529