### PR TITLE
fix: update semantic release workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,12 +16,9 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          token: ${{ secrets.FLANKBOT }}
-      - name: Release
-        run: |
-          npm i
-          npx semantic-release --debug
+      
+      - uses: codfish/semantic-release-action@cbd853afe12037afb1306caca9d6b1ab6a58cf2a # v1.10.0
+        id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
CI builds are being skipped due to a filter and we use an untagged latest version of semantic release here directly.

Using the github action from other repos