### PR TITLE
fix: don't show empty headline properties

### DIFF
--- a/src/components/Topology/TopologyCard/index.tsx
+++ b/src/components/Topology/TopologyCard/index.tsx
@@ -149,8 +149,7 @@ export function TopologyCard({
 
   const allProperties = topology.properties || [];
   const properties = allProperties.filter((i) => !i.headline);
-  const heading = allProperties.filter((i) => i.headline);
-
+  const heading = allProperties.filter((i) => i.headline && !!i.value);
   return (
     <div
       style={{ width: CardWidth[size as Size] || size }}


### PR DESCRIPTION
Fixes #1835