### PR TITLE
fix: "warning" should be orange for config status

### DIFF
--- a/src/components/Status/index.tsx
+++ b/src/components/Status/index.tsx
@@ -18,6 +18,10 @@ function getStatusColor(
     return "bg-gray-400";
   }
 
+  if (status === "warning" || status === "warn") {
+    return "bg-light-orange";
+  }
+
   if (mixed !== undefined && mixed) {
     return "bg-light-orange";
   }
@@ -42,7 +46,6 @@ export function Status({
   className = "",
   hideText = false
 }: StatusProps) {
-
   if (!status && good === undefined && mixed === undefined) {
     return null;
   }


### PR DESCRIPTION
- [x] Need a config item for testing purpose (with warning status)

Fixes #2047