### PR TITLE
chore: use ingress.ingressClassName in helm chart over ingress.className

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.className }}
+  ingressClassName: {{ coalesce .Values.ingress.ingressClassName .Values.ingress.className }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -88,6 +88,10 @@
           "default": "",
           "title": "className"
         },
+        "ingressClassName": {
+          "default": "",
+          "title": "ingressClassName"
+        },
         "enabled": {
           "default": "false",
           "title": "enabled"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -118,6 +118,12 @@ ingress:
   # @schema
   # required: false
   # @schema
+  ingressClassName: ""
+
+  # Deprecated: use ingressClassName instead
+  # @schema
+  # required: false
+  # @schema
   className: ""
   # @schema
   # required: false


### PR DESCRIPTION
Fixes: https://github.com/flanksource/flanksource-ui/issues/2252