### PR TITLE
fix: use topology.health instead of status

### DIFF
--- a/src/api/types/topology.ts
+++ b/src/api/types/topology.ts
@@ -42,6 +42,7 @@ export interface Topology extends Component, CostsData, Agent {
   labels?: Record<string, string>;
   path?: string;
   text?: string;
+  health?: string;
   status?: string;
   status_reason?: string;
   hidden?: boolean;

--- a/src/components/Topology/TopologyCard/index.tsx
+++ b/src/components/Topology/TopologyCard/index.tsx
@@ -17,7 +17,7 @@ import { PropertyDisplay } from "./Property";
 import { TopologyConfigAnalysisLine } from "./TopologyConfigAnalysisLine";
 import { TopologyDropdownMenu } from "./TopologyDropdownMenu";
 
-export enum ComponentStatus {
+export enum ComponentHealth {
   unhealthy = "unhealthy",
   warning = "warning"
 }
@@ -29,9 +29,9 @@ export const CardWidth: Record<keyof typeof Size, string> = {
   [Size.extra_large]: "554px"
 };
 
-export const StatusStyles: Record<keyof typeof ComponentStatus, string> = {
-  [ComponentStatus.unhealthy]: "border-red-300",
-  [ComponentStatus.warning]: "border-orange-300"
+export const StatusStyles: Record<keyof typeof ComponentHealth, string> = {
+  [ComponentHealth.unhealthy]: "border-red-300",
+  [ComponentHealth.warning]: "border-orange-300"
 } as const;
 
 interface IProps {
@@ -123,7 +123,6 @@ export function TopologyCard({
         ? `&refererId=${parentId}`
         : ""
     }`;
-  };
 
   const sortedTopologyComponents = useMemo(
     () =>
@@ -159,7 +158,7 @@ export function TopologyCard({
       style={{ width: CardWidth[size as Size] || size }}
       className={clsx(
         "card relative mb-3 mr-3 rounded-8px border-0 border-t-8 bg-lightest-gray shadow-card",
-        StatusStyles[topology.status as ComponentStatus] || "border-white",
+        StatusStyles[topology.health as ComponentHealth] || "border-white",
         selectionMode ? "cursor-pointer" : ""
       )}
       {...selectionModeRootProps}

--- a/src/components/Topology/TopologyCard/index.tsx
+++ b/src/components/Topology/TopologyCard/index.tsx
@@ -123,6 +123,7 @@ export function TopologyCard({
         ? `&refererId=${parentId}`
         : ""
     }`;
+  };
 
   const sortedTopologyComponents = useMemo(
     () =>


### PR DESCRIPTION
The color of the component card should depend on the `.health` attribute and not status anymore

Let me know if this needs to be changed anywhere else as well