### PR TITLE
fix: helm schema json to allow global.labels

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -31,7 +31,7 @@
           "title": "imageRegistry"
         },
         "labels": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "title": "labels"
         },
         "nodeSelector": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,6 +15,7 @@ global:
   imagePrefix: flanksource
   # @schema
   # required: false
+  # additionalProperties: true
   # @schema
   labels: {}
   # @schema


### PR DESCRIPTION
Public demo releases were failing due to this

```
    Observed Generation:   9
    Reason:                UpgradeFailed
    Status:                False
    Type:                  Ready
    Last Transition Time:  2024-09-24T17:47:57Z
    Message:               Helm upgrade failed for release default/default-mission-control-demo-mission-control-tenant with chart mission-control@0.1.192: values don't meet the specifications of the schema(s) in the following chart(s):
flanksource-ui:
- global.labels: Additional property flanksource.com/clerk-org-id is not allowed
    Observed Generation:  9
```
    
    @moshloop Also, when I ran the schema.json in Makefile, it gave the following 

```diff
    diff --git a/chart/values.schema.json b/chart/values.schema.json
index 3a618f37..3e3be600 100644
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1,53 +1,66 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "affinity": {
-      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity"
+      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+      "required": []
     },
     "backendURL": {
       "default": "",
+      "required": [],
       "title": "backendURL"
     },
     "enabled": {
       "default": true,
+      "required": [],
       "title": "enabled"
     },
     "fullnameOverride": {
       "default": "flanksource-ui",
+      "required": [],
       "title": "fullnameOverride"
     },
     "global": {
       "additionalProperties": true,
       "properties": {
         "affinity": {
-          "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity"
+          "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+          "required": []
         },
         "imagePrefix": {
           "default": "flanksource",
+          "required": [],
           "title": "imagePrefix"
         },
         "imageRegistry": {
           "default": "docker.io",
+          "required": [],
           "title": "imageRegistry"
         },
         "labels": {
           "additionalProperties": true,
+          "required": [],
           "title": "labels"
         },
         "nodeSelector": {
           "additionalProperties": true,
           "description": "node's labels for the pod to be scheduled on that node. See [Node Selector](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)",
+          "required": [],
           "title": "nodeSelector",
           "type": "object"
         },
         "tolerations": {
           "items": {
-            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration",
+            "required": []
           },
+          "required": [],
           "title": "tolerations",
           "type": "array"
         }
       },
+      "required": [],
       "title": "global"
     },
     "image": {
@@ -55,26 +68,32 @@
       "properties": {
         "name": {
           "default": "{{.Values.global.imagePrefix}}/incident-manager-ui",
+          "required": [],
           "title": "name",
           "type": "string"
         },
         "pullPolicy": {
           "default": "IfNotPresent",
+          "required": [],
           "title": "pullPolicy"
         },
         "tag": {
           "default": "latest",
           "description": "Overrides the image tag whose default is the chart appVersion.",
+          "required": [],
           "title": "tag"
         }
       },
-      "title": "image",
       "required": [
         "name"
-      ]
+      ],
+      "title": "image"
     },
     "imagePullSecrets": {
-      "items": {},
+      "items": {
+        "required": []
+      },
+      "required": [],
       "title": "imagePullSecrets"
     },
     "ingress": {
@@ -82,89 +101,109 @@
       "properties": {
         "annotations": {
           "additionalProperties": true,
+          "required": [],
           "title": "annotations"
         },
         "className": {
           "default": "",
           "description": "Deprecated: use ingressClassName instead",
+          "required": [],
           "title": "className"
         },
         "enabled": {
           "default": "false",
+          "required": [],
           "title": "enabled"
         },
         "host": {
           "default": "incident-commander-ui.local",
+          "required": [],
           "title": "host"
         },
         "ingressClassName": {
           "default": "",
+          "required": [],
           "title": "ingressClassName"
         },
         "tls": {
           "items": {
-            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.networking.v1.IngressTLS"
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.networking.v1.IngressTLS",
+            "required": []
           },
+          "required": [],
           "title": "tls",
           "type": "array"
         }
       },
+      "required": [],
       "title": "ingress"
     },
     "nameOverride": {
       "default": "flanksource-ui",
+      "required": [],
       "title": "nameOverride"
     },
     "nodeSelector": {
       "additionalProperties": true,
       "description": "node's labels for the pod to be scheduled on that node. See [Node Selector](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)",
+      "required": [],
       "title": "nodeSelector",
       "type": "object"
     },
     "oryKratosURL": {
       "default": "",
+      "required": [],
       "title": "oryKratosURL"
     },
     "podAnnotations": {
       "additionalProperties": true,
+      "required": [],
       "title": "podAnnotations"
     },
     "podSecurityContext": {
-      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext"
+      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+      "required": []
     },
     "replicas": {
       "default": 1,
+      "required": [],
       "title": "replicas"
     },
     "resources": {
-      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+      "required": []
     },
     "securityContext": {
-      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
+      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+      "required": []
     },
     "service": {
       "additionalProperties": false,
       "properties": {
         "type": {
           "default": "ClusterIP",
-          "title": "type",
           "enum": [
             "ClusterIP",
             "NodePort",
             "LoadBalancer"
-          ]
+          ],
+          "required": [],
+          "title": "type"
         }
       },
+      "required": [],
       "title": "service"
     },
     "tolerations": {
       "items": {
-        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"
+        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration",
+        "required": []
       },
+      "required": [],
       "title": "tolerations",
       "type": "array"
     }
   },
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "required": [],
   "type": "object"
-}
+}
\ No newline at end of file

    ```