### PR TITLE
fix: make the config row clickable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,12 @@ node_modules
 dist/
 # testing
 /coverage
-.cursor/
 # production
 /build
+
+# AI
+.cursor/
+.aider*
 
 # misc
 .DS_Store

--- a/src/components/Configs/ConfigList/ConfigsTable.tsx
+++ b/src/components/Configs/ConfigList/ConfigsTable.tsx
@@ -1,8 +1,8 @@
 import { ConfigItem } from "@flanksource-ui/api/types/configs";
 import MRTDataTable from "@flanksource-ui/ui/MRTDataTable/MRTDataTable";
 import { MRT_ColumnDef } from "mantine-react-table";
-import { useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useMemo, useCallback } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import { mrtConfigListColumns } from "./MRTConfigListColumn";
 
 export interface Props {
@@ -28,6 +28,7 @@ export default function ConfigsTable({
     sortBy: "type",
     sortOrder: "asc"
   });
+  const navigate = useNavigate();
 
   const groupByUserInput = queryParams.get("groupBy") ?? undefined;
 
@@ -90,6 +91,16 @@ export default function ConfigsTable({
     return [...virtualColumn, ...mrtConfigListColumns];
   }, [groupByColumns]);
 
+  const handleRowClick = useCallback(
+    (row?: ConfigItem) => {
+      const id = row?.id;
+      if (id) {
+        navigate(`/catalog/${id}`);
+      }
+    },
+    [navigate]
+  );
+
   return (
     <MRTDataTable
       columns={virtualColumns}
@@ -103,6 +114,7 @@ export default function ConfigsTable({
       totalRowCount={totalRecords}
       manualPageCount={pageCount}
       enableGrouping
+      onRowClick={handleRowClick}
     />
   );
 }


### PR DESCRIPTION
resolves: https://github.com/flanksource/flanksource-ui/issues/2532

The right click still needs to happen right on the config name though.