### PR TITLE
Add Bucket Field to GCS Connection Form

### DIFF
--- a/src/components/Connections/connectionTypes.tsx
+++ b/src/components/Connections/connectionTypes.tsx
@@ -624,8 +624,30 @@ export const connectionTypes: ConnectionType[] = [
         type: ConnectionsFieldTypes.EnvVarSource,
         variant: variants.large,
         required: true
+      },
+      {
+        label: "Bucket",
+        key: "bucket",
+        type: ConnectionsFieldTypes.input,
+        required: true
       }
-    ]
+    ],
+    convertToFormSpecificValue: (data: Record<string, any>) => {
+      return {
+        ...data,
+        bucket: data?.properties?.bucket
+      } as Connection;
+    },
+    preSubmitConverter: (data: Record<string, string>) => {
+      return {
+        name: data.name,
+        url: data.url,
+        certificate: data.certificate,
+        properties: {
+          bucket: data.bucket
+        }
+      };
+    }
   },
   {
     title: "SFTP",


### PR DESCRIPTION
This pull request addresses issue #2510 by adding a 'Bucket' field to the GCS connection form. The new field is required and allows users to specify the bucket name when creating a GCS connection. 

Changes made include:
- Added a new input field for 'Bucket' in the connection types definition.
- Updated the `convertToFormSpecificValue` function to include the bucket property from the data.
- Modified the `preSubmitConverter` function to ensure the bucket value is included in the submitted data.

These changes enhance the GCS connection form by ensuring that users can provide all necessary information for a successful connection.

---

> This pull request was co-created with Cosine Genie

Original Task: [flanksource-ui/pke2aixfi98i](https://cosine.sh/nj07chgz8ro0/flanksource-ui/task/pke2aixfi98i)
Author: Moshe Immerman
