### PR TITLE
Fix Docker container shutdown by using exec in startup script

### DIFF
--- a/scripts/nextjs-standalone-startup.sh
+++ b/scripts/nextjs-standalone-startup.sh
@@ -4,4 +4,4 @@ cp .next/routes-manifest.orig.json .next/routes-manifest.json
 # TODO check that BACKEND_URL is set and a url
 # https://linuxhint.com/environment-variables-sed-command/
 sed -i "s#/__BACKEND_URL__#${BACKEND_URL}#g" .next/routes-manifest.json
-node server.js
+exec node server.js


### PR DESCRIPTION
This pull request addresses issue #2491, which reported that the Docker container does not shut down gracefully. The change made in the `scripts/nextjs-standalone-startup.sh` file replaces the command to start the Node.js server with `exec node server.js`. This modification ensures that the Node.js process replaces the shell process, allowing for proper signal handling and graceful shutdown of the Docker container.

---

> This pull request was co-created with Cosine Genie

Original Task: [flanksource-ui/if92bzgk1fxf](https://cosine.sh/flanksource/flanksource-ui/task/if92bzgk1fxf)
Author: Moshe Immerman
