### PR TITLE
feat(view | gauge cell): Display max and percentage on hover

### DIFF
--- a/src/pages/audit-report/components/GaugeCell.tsx
+++ b/src/pages/audit-report/components/GaugeCell.tsx
@@ -1,19 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 import { GaugeConfig } from "../types";
 import { generateGaugeData } from "./View/panels/utils";
 import { formatBytes } from "../../../utils/common";
-import {
-  useFloating,
-  autoUpdate,
-  offset,
-  flip,
-  shift,
-  useHover,
-  useDismiss,
-  useRole,
-  useInteractions,
-  FloatingPortal
-} from "@floating-ui/react";
+import { Tooltip } from "react-tooltip";
 
 interface GaugeCellProps {
   value: number | { min: number; max: number; value: number };
@@ -21,8 +10,6 @@ interface GaugeCellProps {
 }
 
 const GaugeCell: React.FC<GaugeCellProps> = ({ value, gauge }) => {
-  const [isOpen, setIsOpen] = useState(false);
-
   const gaugeValue = typeof value === "number" ? value : value.value;
   const gaugeConfig =
     typeof value === "number"
@@ -32,23 +19,6 @@ const GaugeCell: React.FC<GaugeCellProps> = ({ value, gauge }) => {
   const gaugeData = generateGaugeData({ value: gaugeValue }, gaugeConfig);
   const percentage = gaugeData.value;
   const color = gaugeData.color;
-
-  const { refs, floatingStyles, context } = useFloating({
-    open: isOpen,
-    onOpenChange: setIsOpen,
-    middleware: [offset(10), flip(), shift()],
-    whileElementsMounted: autoUpdate
-  });
-
-  const hover = useHover(context);
-  const dismiss = useDismiss(context);
-  const role = useRole(context, { role: "tooltip" });
-
-  const { getReferenceProps, getFloatingProps } = useInteractions([
-    hover,
-    dismiss,
-    role
-  ]);
 
   // Format display value based on unit
   const formatDisplayValue = (value: number, unit?: string): string => {
@@ -73,44 +43,36 @@ const GaugeCell: React.FC<GaugeCellProps> = ({ value, gauge }) => {
     ? formatDisplayValue(maxValue, gaugeConfig?.unit)
     : undefined;
 
-  return (
-    <>
-      <div
-        className="flex w-full items-center gap-2"
-        ref={refs.setReference}
-        {...getReferenceProps()}
-      >
-        {/* Progress bar */}
-        <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-200">
-          <div
-            className="h-full rounded-full transition-all duration-500 ease-out"
-            style={{
-              width: `${percentage}%`,
-              backgroundColor: color
-            }}
-          />
-        </div>
+  const tooltipId = `gauge-tooltip-${Math.random().toString(36).slice(2, 9)}`;
 
-        {/* Value text */}
-        <span className="min-w-fit text-xs font-medium text-gray-700">
-          {displayValue}
-        </span>
+  return (
+    <div
+      className="flex w-full items-center gap-2"
+      data-tooltip-id={maxDisplayValue ? tooltipId : undefined}
+      data-tooltip-html={
+        maxDisplayValue
+          ? `${percentage.toFixed(2)}% of ${maxDisplayValue}`
+          : undefined
+      }
+    >
+      {/* Progress bar */}
+      <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-200">
+        <div
+          className="h-full rounded-full transition-all duration-500 ease-out"
+          style={{
+            width: `${percentage}%`,
+            backgroundColor: color
+          }}
+        />
       </div>
 
-      {isOpen && maxDisplayValue && (
-        <FloatingPortal>
-          <div
-            className="z-50 rounded bg-gray-900 px-2 py-1 text-xs font-medium text-white shadow-lg"
-            ref={refs.setFloating}
-            style={floatingStyles}
-            {...getFloatingProps()}
-          >
-            <p>Max: {maxDisplayValue}</p>
-            <p>Percent: {percentage.toFixed(2)}%</p>
-          </div>
-        </FloatingPortal>
-      )}
-    </>
+      {/* Value text */}
+      <span className="min-w-fit text-xs font-medium text-gray-700">
+        {displayValue}
+      </span>
+
+      {maxDisplayValue && <Tooltip id={tooltipId} style={{ zIndex: 9999 }} />}
+    </div>
   );
 };
 


### PR DESCRIPTION
<img width="272" height="257" alt="image" src="https://github.com/user-attachments/assets/ab438e05-8a3f-416b-9c91-c83b2ae15140" />
<img width="275" height="158" alt="image" src="https://github.com/user-attachments/assets/46c53c7f-f8d6-486e-9f6a-2cacb88302a3" />

resolves: https://github.com/flanksource/flanksource-ui/issues/2615
