### PR TITLE
chore: remove hardcoded agent from resource selector

### DIFF
--- a/src/components/Forms/Formik/FormikResourceSelectorDropdown.tsx
+++ b/src/components/Forms/Formik/FormikResourceSelectorDropdown.tsx
@@ -59,8 +59,8 @@ export default function FormikResourceSelectorDropdown({
         ? [
             ...checkResourceSelector.map((r) => ({
               ...r,
-              agent: "all",
-              search: searchText
+              search: searchText,
+              agent: r.agent || "all"
             }))
           ]
         : undefined,
@@ -68,8 +68,8 @@ export default function FormikResourceSelectorDropdown({
         ? [
             ...componentResourceSelector.map((r) => ({
               ...r,
-              agent: "all",
-              search: searchText
+              search: searchText,
+              agent: r.agent || "all"
             }))
           ]
         : undefined,
@@ -77,8 +77,8 @@ export default function FormikResourceSelectorDropdown({
         ? [
             ...configResourceSelector.map((r) => ({
               ...r,
-              agent: "all",
-              search: searchText
+              search: searchText,
+              agent: r.agent || "all"
             }))
           ]
         : undefined


### PR DESCRIPTION
@moshloop @adityathebe Do we know why `agent: "all"` is hard-coded here ? Its messing up with the agent filter in playbook params