### PR TITLE
fix: resolve TypeScript errors in test files

### DIFF
--- a/src/components/Canary/CanaryPopup/__tests__/CheckRunNow.unit.test.tsx
+++ b/src/components/Canary/CanaryPopup/__tests__/CheckRunNow.unit.test.tsx
@@ -37,6 +37,7 @@ describe("CheckRunNow", () => {
           value={{
             refresh: jest.fn(),
             isAdmin: true,
+            isViewer: false,
             hasResourceAccess: jest.fn(),
             hasAnyResourceAccess: jest.fn(),
             roles: ["admin"]
@@ -77,6 +78,7 @@ describe("CheckRunNow", () => {
           value={{
             refresh: jest.fn(),
             isAdmin: true,
+            isViewer: false,
             hasResourceAccess: jest.fn(),
             hasAnyResourceAccess: jest.fn(),
             roles: ["guest"]

--- a/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
+++ b/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
@@ -3,24 +3,55 @@ import PlaybooksRunActionsResults from "../PlaybooksActionsResults";
 
 describe("PlaybooksRunActionsResults", () => {
   it("renders 'No result' when result is falsy", () => {
-    render(<PlaybooksRunActionsResults action={{}} />);
+    render(
+      <PlaybooksRunActionsResults
+        action={{
+          id: "1",
+          name: "test",
+          status: "completed",
+          playbook_run_id: "1",
+          start_time: "2024-01-01"
+        }}
+      />
+    );
     expect(screen.getByText("No result")).toBeInTheDocument();
   });
 
   it("renders stdout when result has stdout", () => {
-    const action = { result: { stdout: "Hello, world!" } };
+    const action = {
+      id: "1",
+      name: "test",
+      status: "completed" as const,
+      playbook_run_id: "1",
+      start_time: "2024-01-01",
+      result: { stdout: "Hello, world!" }
+    };
     render(<PlaybooksRunActionsResults action={action} />);
     expect(screen.getByText("Hello, world!")).toBeInTheDocument();
   });
 
   it("renders logs when result has logs", () => {
-    const action = { result: { logs: "Hello, world!" } };
+    const action = {
+      id: "1",
+      name: "test",
+      status: "completed" as const,
+      playbook_run_id: "1",
+      start_time: "2024-01-01",
+      result: { logs: "Hello, world!" }
+    };
     render(<PlaybooksRunActionsResults action={action} />);
     expect(screen.getByText("Hello, world!")).toBeInTheDocument();
   });
 
   it("renders JSON when result has neither stdout nor logs", () => {
-    const action = { result: { foo: "bar" } };
+    const action = {
+      id: "1",
+      name: "test",
+      status: "completed" as const,
+      playbook_run_id: "1",
+      start_time: "2024-01-01",
+      result: { foo: "bar" }
+    };
     render(<PlaybooksRunActionsResults action={action} />);
     expect(
       screen.getByText("foo", {
@@ -31,6 +62,11 @@ describe("PlaybooksRunActionsResults", () => {
 
   it("shows stdout as the first tab", () => {
     const action = {
+      id: "1",
+      name: "test",
+      status: "completed" as const,
+      playbook_run_id: "1",
+      start_time: "2024-01-01",
       result: { stdout: "Hello, world!", stderr: "Goodbye, world!" }
     };
     render(<PlaybooksRunActionsResults action={action} />);
@@ -38,7 +74,14 @@ describe("PlaybooksRunActionsResults", () => {
   });
 
   it("renders error when action has error", () => {
-    const action = { error: "Something went wrong" };
+    const action = {
+      id: "1",
+      name: "test",
+      status: "failed" as const,
+      playbook_run_id: "1",
+      start_time: "2024-01-01",
+      error: "Something went wrong"
+    };
     render(<PlaybooksRunActionsResults action={action} />);
     expect(
       screen.getByText("Something went wrong", {

--- a/src/components/Playbooks/Runs/Submit/__tests__/SubmitPlaybookRunForm.unit.test.tsx
+++ b/src/components/Playbooks/Runs/Submit/__tests__/SubmitPlaybookRunForm.unit.test.tsx
@@ -27,6 +27,7 @@ const playbook: RunnablePlaybook & {
   updated_at: "2021-09-01T00:00:00Z",
   spec: {
     icon: "playbook.svg",
+    actions: [],
     components: [
       {
         types: ["kubernetes"]

--- a/src/components/Playbooks/Settings/__tests__/PlaybookSpecCard.unit.test.tsx
+++ b/src/components/Playbooks/Settings/__tests__/PlaybookSpecCard.unit.test.tsx
@@ -16,6 +16,7 @@ const mockPlaybook: PlaybookSpec = {
   spec: {
     actions: [
       {
+        name: "test-action",
         exec: {
           script: 'echo "{{.}}"'
         }


### PR DESCRIPTION
## Summary
- Fixed TypeScript errors in test files by adding missing required properties
- Added `isViewer` property to UserAccessState mocks in CheckRunNow tests
- Added required properties (`id`, `name`, `status`, `playbook_run_id`, `start_time`) to CategorizedPlaybookRunAction mocks
- Added missing `actions` array to Playbook spec
- Added missing `name` property to PlaybookAction

## Test plan
- [x] `npm run typecheck` passes with no errors