### PR TITLE
feat: set object_selector when playbook is selected in permission form

### DIFF
--- a/src/components/Forms/Formik/FormikResourceSelectorDropdown.tsx
+++ b/src/components/Forms/Formik/FormikResourceSelectorDropdown.tsx
@@ -28,6 +28,10 @@ type FormikConfigsDropdownProps = {
   className?: string;
   valueField?: "id" | "name";
   disabled?: boolean;
+  onValueChange?: (
+    value: any,
+    option: FormikSelectDropdownOption | null
+  ) => void;
 };
 
 export default function FormikResourceSelectorDropdown({
@@ -43,7 +47,8 @@ export default function FormikResourceSelectorDropdown({
   playbookResourceSelector,
   className = "flex flex-col space-y-2 py-2",
   valueField = "id",
-  disabled = false
+  disabled = false,
+  onValueChange
 }: FormikConfigsDropdownProps) {
   const [inputText, setInputText] = useState<string>("");
   const [searchText, setSearchText] = useState<string>();
@@ -262,6 +267,7 @@ export default function FormikResourceSelectorDropdown({
             ),
             value: playbook[valueField],
             search: playbook.name,
+            name: playbook.name,
             label: (
               <div className="flex flex-wrap gap-1">
                 <span className="mr-2"> {playbook.name}</span>
@@ -312,14 +318,18 @@ export default function FormikResourceSelectorDropdown({
         isClearable
         value={value}
         onChange={(value: any) => {
+          const selectedValue = Array.isArray(value)
+            ? value.map((item) => item.value)
+            : value?.value;
+
           field.onChange({
             target: {
               name: field.name,
-              value: Array.isArray(value)
-                ? value.map((item) => item.value)
-                : value?.value
+              value: selectedValue
             }
           });
+
+          onValueChange?.(selectedValue, value);
         }}
         onInputChange={handleInputChange}
         inputValue={inputText ?? value}

--- a/src/components/Permissions/ManagePermissions/Forms/FormikPermissionSelectResourceFields.tsx
+++ b/src/components/Permissions/ManagePermissions/Forms/FormikPermissionSelectResourceFields.tsx
@@ -106,6 +106,16 @@ export default function FormikPermissionSelectResourceFields() {
             required
             name="playbook_id"
             playbookResourceSelector={[{}]}
+            onValueChange={(value, option) => {
+              if (option && (option as any).name) {
+                setFieldValue("object_selector", {
+                  playbooks: [{ name: (option as any).name }],
+                  configs: [{ name: "*" }]
+                });
+              } else {
+                setFieldValue("object_selector", undefined);
+              }
+            }}
           />
         )}
 


### PR DESCRIPTION
## Summary
- Automatically populate `object_selector` field when a playbook is selected in the permission form
- Adds playbook name and wildcard configs selector to enable proper resource-based permissions

## Changes
- Added `onValueChange` callback prop to `FormikResourceSelectorDropdown` to pass the full selected option data
- Enhanced playbook option to include the playbook name in the option object
- Updated `FormikPermissionSelectResourceFields` to set `object_selector` with the format: `{"playbooks": [{"name": "<selected-playbook>"}], "configs": [{"name": "*"}]}`

## Test plan
- [ ] Verify that selecting a playbook in the permission form sets the `object_selector` field correctly
- [ ] Verify that clearing the playbook selection clears the `object_selector` field
- [ ] Verify that the permission is saved with the correct object_selector data