### PR TITLE
fix: broken View table in config details page

### DIFF
--- a/src/pages/audit-report/components/ApplicationsSection.tsx
+++ b/src/pages/audit-report/components/ApplicationsSection.tsx
@@ -421,15 +421,16 @@ const ApplicationsSection: React.FC<ApplicationsSectionProps> = ({
         <MonitoringSection application={application} />
         <VersionSection application={application} />
 
-        {application.sections?.map((section) => (
+        {application.sections?.map((viewResult) => (
           <View
-            key={section.title}
-            title={section.title}
-            namespace={section.namespace}
-            name={section.name}
-            columns={section.columns}
-            panels={section.panels}
-            columnOptions={section.columnOptions}
+            key={viewResult.title}
+            title={viewResult.title}
+            namespace={viewResult.namespace}
+            name={viewResult.name}
+            columns={viewResult.columns}
+            panels={viewResult.panels}
+            columnOptions={viewResult.columnOptions}
+            requestFingerprint={viewResult.requestFingerprint}
           />
         ))}
 

--- a/src/pages/audit-report/components/View/View.tsx
+++ b/src/pages/audit-report/components/View/View.tsx
@@ -34,7 +34,7 @@ interface ViewProps {
   columns?: ViewColumnDef[];
   columnOptions?: Record<string, string[]>;
   variables?: ViewVariable[];
-  viewResult?: ViewResult;
+  requestFingerprint: string;
   currentVariables?: Record<string, string>;
 }
 
@@ -46,7 +46,7 @@ const View: React.FC<ViewProps> = ({
   columnOptions,
   panels,
   variables,
-  viewResult,
+  requestFingerprint,
   currentVariables
 }) => {
   const { pageSize } = useReactTablePaginationState();
@@ -85,7 +85,7 @@ const View: React.FC<ViewProps> = ({
       namespace,
       name,
       tableSearchParams.toString(),
-      viewResult?.requestFingerprint
+      requestFingerprint
     ],
     queryFn: () =>
       queryViewTable(
@@ -93,7 +93,7 @@ const View: React.FC<ViewProps> = ({
         name ?? "",
         columns ?? [],
         tableSearchParams,
-        viewResult?.requestFingerprint || ""
+        requestFingerprint
       ),
     enabled: !!namespace && !!name && !!columns && columns.length > 0,
     staleTime: 5 * 60 * 1000

--- a/src/pages/config/details/ConfigDetailsViewPage.tsx
+++ b/src/pages/config/details/ConfigDetailsViewPage.tsx
@@ -13,7 +13,7 @@ export function ConfigDetailsViewPage() {
   }>();
 
   const {
-    data: view,
+    data: viewResult,
     isLoading,
     error
   } = useQuery({
@@ -27,11 +27,11 @@ export function ConfigDetailsViewPage() {
     enabled: !!viewId && !!configId
   });
 
-  if (!view) {
+  if (!viewResult) {
     return <div>View not found</div>;
   }
 
-  const displayName = view.title || view.name;
+  const displayName = viewResult.title || viewResult.name;
 
   return (
     <ConfigDetailsTabs
@@ -55,14 +55,15 @@ export function ConfigDetailsViewPage() {
               </p>
             </div>
           </div>
-        ) : view ? (
+        ) : viewResult ? (
           <View
             title=""
-            namespace={view.namespace}
-            name={view.name}
-            panels={view.panels}
-            columns={view.columns}
-            columnOptions={view.columnOptions}
+            namespace={viewResult.namespace}
+            name={viewResult.name}
+            panels={viewResult.panels}
+            columns={viewResult.columns}
+            requestFingerprint={viewResult.requestFingerprint}
+            columnOptions={viewResult.columnOptions}
           />
         ) : (
           <div className="flex flex-1 flex-col items-center justify-center">

--- a/src/pages/views/components/SingleView.tsx
+++ b/src/pages/views/components/SingleView.tsx
@@ -185,7 +185,7 @@ const SingleView: React.FC<SingleViewProps> = ({ id }) => {
           columnOptions={viewResult?.columnOptions}
           panels={viewResult?.panels}
           variables={viewResult?.variables}
-          viewResult={viewResult}
+          requestFingerprint={viewResult.requestFingerprint}
           currentVariables={currentViewVariables}
         />
       </div>


### PR DESCRIPTION
## Summary
The View component wasn't receiving the required requestFingerprint prop in the config details page, causing the table to fail loading. Updated the View component to accept requestFingerprint as a direct prop instead of extracting it from an optional viewResult object.

Fixes #2684