### PR TITLE
fix: Improve view refresh error handling

### DIFF
--- a/src/pages/config/details/ConfigDetailsViewPage.tsx
+++ b/src/pages/config/details/ConfigDetailsViewPage.tsx
@@ -1,12 +1,17 @@
 import { ConfigDetailsTabs } from "@flanksource-ui/components/Configs/ConfigDetailsTabs";
 import { getViewDataById } from "@flanksource-ui/api/services/views";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 import { Loading } from "@flanksource-ui/ui/Loading";
 import View from "@flanksource-ui/pages/audit-report/components/View/View";
+import { useRef } from "react";
+import { toastError } from "@flanksource-ui/components/Toast/toast";
 
 // Displays the view as a tab in the config details page
 export function ConfigDetailsViewPage() {
+  const queryClient = useQueryClient();
+  const forceRefreshRef = useRef(false);
+
   const { id: configId, viewId } = useParams<{
     id: string;
     viewId: string;
@@ -15,29 +20,48 @@ export function ConfigDetailsViewPage() {
   const {
     data: viewResult,
     isLoading,
-    error
+    error,
+    refetch
   } = useQuery({
     queryKey: ["viewDataById", viewId, configId],
     queryFn: () => {
       if (!viewId) {
         throw new Error("View ID is required");
       }
-      return getViewDataById(viewId);
+      const headers = forceRefreshRef.current
+        ? { "cache-control": "max-age=1" }
+        : undefined;
+      return getViewDataById(viewId, undefined, headers);
     },
     enabled: !!viewId && !!configId
   });
 
-  if (!viewResult) {
-    return <div>View not found</div>;
-  }
+  const handleRefresh = async () => {
+    forceRefreshRef.current = true;
+    const result = await refetch();
+    forceRefreshRef.current = false;
 
-  const displayName = viewResult.title || viewResult.name;
+    if (result.isError) {
+      toastError(
+        result.error instanceof Error
+          ? result.error.message
+          : "Failed to refresh view"
+      );
+    } else if (result.data?.namespace && result.data?.name) {
+      await queryClient.invalidateQueries({
+        queryKey: ["view-table", result.data.namespace, result.data.name]
+      });
+    }
+  };
+
+  const displayName = viewResult?.title || viewResult?.name || "";
 
   return (
     <ConfigDetailsTabs
       pageTitlePrefix={`Config View - ${displayName}`}
       isLoading={isLoading}
-      activeTabName={displayName ?? ""}
+      activeTabName={displayName}
+      refetch={handleRefresh}
     >
       <div className="flex h-full flex-1 flex-col overflow-auto p-4">
         {isLoading ? (


### PR DESCRIPTION
## Summary
Refactored view refresh logic to use React Query's refetch method with proper error handling via toast notifications.


resolves: https://github.com/flanksource/flanksource-ui/issues/2686