### PR TITLE
Add MCP resource tab to permissions page

### DIFF
--- a/src/api/types/permissions.ts
+++ b/src/api/types/permissions.ts
@@ -11,7 +11,8 @@ export type PermissionGlobalObject =
   | "canaries"
   | "connection"
   | "playbook"
-  | "topology";
+  | "topology"
+  | "mcp";
 
 type PermissionObjectSelector = {
   playbooks?: Selectors[];

--- a/src/components/Permissions/ManagePermissions/Forms/FormikPermissionSelectResourceFields.tsx
+++ b/src/components/Permissions/ManagePermissions/Forms/FormikPermissionSelectResourceFields.tsx
@@ -1,8 +1,9 @@
 import FormikResourceSelectorDropdown from "@flanksource-ui/components/Forms/Formik/FormikResourceSelectorDropdown";
 import FormikSelectDropdown from "@flanksource-ui/components/Forms/Formik/FormikSelectDropdown";
 import { Switch } from "@flanksource-ui/ui/FormControls/Switch";
+import { Switch as ToggleSwitch } from "@headlessui/react";
 import { useFormikContext } from "formik";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import FormikScopeMultiSelect from "./FormikScopeMultiSelect";
 import FormikViewMultiSelect from "./FormikViewMultiSelect";
 
@@ -33,12 +34,14 @@ export default function FormikPermissionSelectResourceFields() {
     | "View"
     | "Connection"
     | "Global"
-    | "Scope" => {
+    | "Scope"
+    | "MCP" => {
     if (values.playbook_id) return "Playbook";
     if (values.config_id) return "Catalog";
     if (values.component_id) return "Component";
     if (values.connection_id) return "Connection";
     if (values.canary_id) return "Canary";
+    if (values.object === "mcp") return "MCP";
     if (values.object) return "Global";
     if (values.object_selector?.views) return "View";
     if (values.object_selector?.scopes) return "Scope";
@@ -54,7 +57,15 @@ export default function FormikPermissionSelectResourceFields() {
     | "Connection"
     | "Global"
     | "Scope"
+    | "MCP"
   >(getInitialTab());
+
+  // Auto-set action to '*' when object is 'mcp'
+  useEffect(() => {
+    if (values.object === "mcp") {
+      setFieldValue("action", "*");
+    }
+  }, [values.object, setFieldValue]);
 
   return (
     <div className="flex flex-col gap-2">
@@ -70,7 +81,8 @@ export default function FormikPermissionSelectResourceFields() {
               "Playbook",
               "View",
               "Global",
-              "Scope"
+              "Scope",
+              "MCP"
             ]}
             className="w-auto"
             itemsClassName=""
@@ -141,6 +153,26 @@ export default function FormikPermissionSelectResourceFields() {
         )}
 
         {switchOption === "Scope" && <FormikScopeMultiSelect />}
+
+        {switchOption === "MCP" && (
+          <div className="flex flex-col gap-2 py-2">
+            <ToggleSwitch
+              checked={values.object === "mcp"}
+              onChange={(checked) => {
+                setFieldValue("object", checked ? "mcp" : null);
+              }}
+              className="group relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-offset-2 data-[checked]:bg-blue-600"
+            >
+              <span
+                aria-hidden="true"
+                className="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out group-data-[checked]:translate-x-5"
+              />
+            </ToggleSwitch>
+            <p className="text-sm text-gray-600">
+              Allows the user to use the Mission Control MCP
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Permissions/ManagePermissions/Forms/PermissionForm.tsx
+++ b/src/components/Permissions/ManagePermissions/Forms/PermissionForm.tsx
@@ -46,6 +46,7 @@ function PermissionActionDropdown({ isDisabled }: { isDisabled?: boolean }) {
     if (values.component_id) return "component";
     if (values.connection_id) return "connection";
     if (values.canary_id) return "canary";
+    if (values.object === "mcp") return "mcp";
     if (values.object_selector?.views) return "view";
     if (values.object_selector?.scopes) return "global";
     if (values.object) return "global";
@@ -57,7 +58,7 @@ function PermissionActionDropdown({ isDisabled }: { isDisabled?: boolean }) {
     [resourceType]
   );
 
-  if (!resourceType) {
+  if (!resourceType || resourceType === "mcp") {
     return null;
   }
 
@@ -218,7 +219,8 @@ export default function PermissionForm({
       permissionData?.config_id ||
       permissionData?.canary_id ||
       permissionData?.playbook_id ||
-      permissionData?.connection_id
+      permissionData?.connection_id ||
+      permissionData?.object === "mcp"
     );
   }, [permissionData]);
 

--- a/src/components/Permissions/ManagePermissions/Forms/PermissionResource.tsx
+++ b/src/components/Permissions/ManagePermissions/Forms/PermissionResource.tsx
@@ -25,6 +25,11 @@ export default function PermissionResource() {
     enabled: !!canaryId
   });
 
+  if (object === "mcp") {
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    return <>MCP</>;
+  }
+
   if (object) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{permissionObjectList.find((o) => o.value === object)?.label}</>;

--- a/src/components/Permissions/PermissionsTable.tsx
+++ b/src/components/Permissions/PermissionsTable.tsx
@@ -170,6 +170,17 @@ const permissionsTableColumns: MRT_ColumnDef<PermissionsSummary>[] = [
         );
       }
 
+      if (object === "mcp") {
+        return (
+          <div className="flex flex-row items-center gap-3">
+            <div className="flex flex-row items-center gap-2">
+              <span>MCP</span>
+            </div>
+            <PermissionErrorDisplay error={error} />
+          </div>
+        );
+      }
+
       if (object) {
         return (
           <div className="flex flex-row items-center gap-3">

--- a/src/components/Permissions/PermissionsView.tsx
+++ b/src/components/Permissions/PermissionsView.tsx
@@ -48,7 +48,8 @@ export type ResourceType =
   | "connection"
   | "canary"
   | "view"
-  | "global";
+  | "global"
+  | "mcp";
 
 export function getActionsForResourceType(
   resourceType?: ResourceType
@@ -63,6 +64,10 @@ export function getActionsForResourceType(
 
   if (resourceType === "view") {
     return [{ value: "read", label: "read" }];
+  }
+
+  if (resourceType === "mcp") {
+    return [{ value: "*", label: "*" }];
   }
 
   return commonActions;


### PR DESCRIPTION
## Summary
Adds a new MCP tab to the permissions interface for granting Mission Control MCP access with a simple toggle switch.