### PR TITLE
fix(view): Don't send global URL params when querying view

### DIFF
--- a/src/hooks/usePrefixedSearchParams.ts
+++ b/src/hooks/usePrefixedSearchParams.ts
@@ -9,6 +9,7 @@ const GLOBAL_PARAM_KEYS = ["sortBy", "sortOrder"] as const;
  * Provides filtered params (without prefix) and a setter that adds the prefix.
  *
  * @param prefix - The prefix to use for this component's params (e.g., 'viewvar', 'view_namespace_name')
+ * @param useGlobalParams - Whether to include global parameters (e.g., sortBy, sortOrder) in the filtered params. Defaults to true.
  */
 export function usePrefixedSearchParams(
   prefix: string,

--- a/src/pages/views/components/SingleView.tsx
+++ b/src/pages/views/components/SingleView.tsx
@@ -70,7 +70,7 @@ const SingleView: React.FC<SingleViewProps> = ({ id }) => {
   const forceRefreshRef = useRef(false);
 
   // Use prefixed search params for view variables
-  // NOTE: Backend uses view variables (template parameters) to partitione the rows in the view table.
+  // NOTE: Backend uses view variables (template parameters) to partition the rows in the view table.
   // We must remove the global query parameters from the URL params.
   const [viewVarParams] = usePrefixedSearchParams(VIEW_VAR_PREFIX, false);
   const currentViewVariables = Object.fromEntries(viewVarParams.entries());


### PR DESCRIPTION
URL params `sortBy` and `sortOrder` were being passed as view variables.
Backend would use them to partition the view table. 

This would cause the view table to be partitioned for every (sort, order) pair.

resolves: https://github.com/flanksource/mission-control/issues/2497