### PR TITLE
fix: Gauge cell color when max value isn't present

### DIFF
--- a/src/pages/audit-report/components/View/panels/utils.ts
+++ b/src/pages/audit-report/components/View/panels/utils.ts
@@ -50,9 +50,13 @@ export const generateGaugeData = (
   }
   const clampedPercentage = Math.max(0, Math.min(100, percentage));
 
-  const color = gauge?.thresholds
+  let color = gauge?.thresholds
     ? getGaugeColor(clampedPercentage, gauge.thresholds)
     : COLOR_PALETTE[0];
+
+  if (!gauge?.max) {
+    color = "";
+  }
 
   return {
     value: clampedPercentage,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gauge color assignment to properly clear when maximum values are unavailable in audit reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->