### PR TITLE
fix: piechart colors

### DIFF
--- a/src/pages/audit-report/components/StatusBadge.tsx
+++ b/src/pages/audit-report/components/StatusBadge.tsx
@@ -43,6 +43,11 @@ const STATUS_COLORS: Record<string, { bg: string; dot: string; text: string }> =
       bg: "bg-red-100 text-red-800",
       dot: "bg-red-600",
       text: "text-red-700"
+    },
+    unknown: {
+      bg: "bg-gray-100 text-gray-800",
+      dot: "bg-gray-600",
+      text: "text-gray-700"
     }
   };
 

--- a/src/pages/audit-report/components/View/panels/utils.ts
+++ b/src/pages/audit-report/components/View/panels/utils.ts
@@ -131,7 +131,7 @@ export const formatDisplayLabel = (name: string): string => {
     .replace(/\b\w/g, (l) => l.toUpperCase()); // Capitalize first letter of each word
 };
 
-type Severity = "critical" | "high" | "medium" | "low" | "info";
+type Severity = "critical" | "high" | "medium" | "low" | "info" | "unknown";
 
 /**
  * Determines the severity level for a status string using heuristic matching.
@@ -198,18 +198,96 @@ export const getSeverityOfText = (status: string): Severity => {
     return "info";
   }
 
-  return "info";
+  return "unknown";
 };
 
 /**
  * Maps severity levels to arrays of hex colors derived from Tailwind CSS.
  */
 export const severityToHex: Record<Severity, string[]> = {
-  info: ["#16a34a", "#22c55e", "#15803d", "#059669"],
-  low: ["#2563eb", "#0891b2", "#3b82f6", "#1d4ed8", "#0d9488"],
-  medium: ["#eab308", "#f59e0b", "#d97706"],
-  high: ["#ea580c", "#f97316", "#d97706"],
-  critical: ["#dc2626", "#ef4444", "#991b1b"]
+  info: [
+    "#16a34a",
+    "#22c55e",
+    "#4ade80",
+    "#15803d",
+    "#059669",
+    "#10b981",
+    "#34d399",
+    "#047857",
+    "#065f46",
+    "#14532d"
+  ],
+  low: [
+    "#2563eb",
+    "#0891b2",
+    "#3b82f6",
+    "#60a5fa",
+    "#1d4ed8",
+    "#0d9488",
+    "#06b6d4",
+    "#0ea5e9",
+    "#38bdf8",
+    "#1e40af",
+    "#14b8a6",
+    "#2dd4bf"
+  ],
+  medium: [
+    "#eab308",
+    "#f59e0b",
+    "#fbbf24",
+    "#d97706",
+    "#fcd34d",
+    "#ca8a04",
+    "#b45309",
+    "#a16207",
+    "#facc15",
+    "#f5d500"
+  ],
+  high: [
+    "#ea580c",
+    "#f97316",
+    "#fb923c",
+    "#c2410c",
+    "#fdba74",
+    "#9a3412",
+    "#ed6c02",
+    "#ff8c00",
+    "#e65100",
+    "#bf360c"
+  ],
+  critical: [
+    "#dc2626",
+    "#ef4444",
+    "#f87171",
+    "#991b1b",
+    "#b91c1c",
+    "#7f1d1d",
+    "#fca5a5",
+    "#e11d48",
+    "#be123c",
+    "#9f1239"
+  ],
+  unknown: [
+    "#8b5cf6",
+    "#06b6d4",
+    "#ec4899",
+    "#84cc16",
+    "#6366f1",
+    "#db2777",
+    "#22d3ee",
+    "#7c3aed",
+    "#f43f5e",
+    "#a855f7",
+    "#c026d3",
+    "#a3e635",
+    "#4f46e5",
+    "#f472b6",
+    "#d946ef",
+    "#fb7185",
+    "#6b7280",
+    "#9ca3af",
+    "#4b5563"
+  ]
 };
 
 /** Default color palette for charts, combining all colors from COLOR_INDEX_TO_HEX flattened */


### PR DESCRIPTION
Before
<img width="401" height="349" alt="image" src="https://github.com/user-attachments/assets/09ac5cf4-3e60-4ba0-91bb-6f3c95285bb5" />


After:
<img width="405" height="355" alt="image" src="https://github.com/user-attachments/assets/80c4584e-ae14-4850-8097-300ad8bb5bc2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for unknown severity status in audit reports, enabling the system to properly categorize and display items when severity cannot be determined, with distinct gray-based visual styling to differentiate from other severity levels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->