### PR TITLE
Add status suffix labels to notification send history table

### DIFF
--- a/src/components/Notifications/NotificationSendHistorySummary.tsx
+++ b/src/components/Notifications/NotificationSendHistorySummary.tsx
@@ -96,7 +96,7 @@ const notificationSendHistoryColumns: MRT_ColumnDef<NotificationSendHistorySumma
       }
     },
     {
-      header: "Statistics",
+      header: "Status",
       minSize: 50,
       maxSize: 100,
       Cell: ({ row }) => {
@@ -105,6 +105,7 @@ const notificationSendHistoryColumns: MRT_ColumnDef<NotificationSendHistorySumma
         if (row.original.sent > 0) {
           statusLines.push({
             count: row.original.sent,
+            suffix: "sent",
             color: "bg-green-500/60",
             tooltip: "Sent"
           });
@@ -113,6 +114,7 @@ const notificationSendHistoryColumns: MRT_ColumnDef<NotificationSendHistorySumma
         if (row.original.error > 0) {
           statusLines.push({
             count: row.original.error,
+            suffix: "failed",
             color: "bg-red-500/50",
             tooltip: "Error"
           });
@@ -121,6 +123,7 @@ const notificationSendHistoryColumns: MRT_ColumnDef<NotificationSendHistorySumma
         if (row.original.suppressed > 0) {
           statusLines.push({
             count: row.original.suppressed,
+            suffix: "suppressed",
             color: "bg-gray-400/80",
             tooltip: "Suppressed"
           });

--- a/src/ui/Icons/ChangeCount.tsx
+++ b/src/ui/Icons/ChangeCount.tsx
@@ -75,12 +75,14 @@ function roundedStyleValue(style: "RAG" | "icons", i: number, length: number) {
 
 export type Count = {
   count: number | string;
+  suffix?: string;
   tooltip?: string;
   url?: string;
   target?: string;
   color?: string;
   icon?: React.ReactNode;
 };
+
 export function CountBar({
   items,
   height = "h-6",
@@ -142,7 +144,10 @@ export function CountBar({
                 item.color
               )}
             >
-              <span className="inline p-1">{num(item.count)}</span>
+              <span className="inline p-1">
+                {num(item.count)}
+                {item.suffix && ` ${item.suffix}`}
+              </span>
             </div>
           </>
         );


### PR DESCRIPTION
## Summary
Improves notification send history table by displaying status suffixes (sent, failed, suppressed) in the count bar for better readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced notification send history display with clearer status indicators showing delivery outcomes (sent, failed, suppressed).
  * Updated column header labeling for improved visibility of notification status information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

related: https://github.com/flanksource/flanksource-ui/issues/2722