### PR TITLE
fix: show last runtime for catalog/topologies/health checks

### DIFF
--- a/src/components/Settings/ResourceTable.tsx
+++ b/src/components/Settings/ResourceTable.tsx
@@ -194,7 +194,8 @@ const columns: MRT_ColumnDef<
     Cell: ({ row }) => <MRTJobHistoryStatusColumn row={row} />
   },
   {
-    accessorKey: "last_runtime",
+    id: "last_runtime",
+    accessorFn: (row) => row.last_runtime ?? row.job_time_start,
     header: "Last Run",
     enableResizing: true,
     Cell: MRTDateCell,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Last Run column in the resource table to properly display timing information when available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->