### PR TITLE
fix: prevent title overlap with headerRight metrics on small screens

### DIFF
--- a/src/pages/audit-report/components/View/ViewCard.tsx
+++ b/src/pages/audit-report/components/View/ViewCard.tsx
@@ -131,8 +131,8 @@ const ViewCard: React.FC<ViewCardProps> = ({ columns, row, columnsCount }) => {
     <Card className="transition-shadow hover:shadow-lg">
       <CardHeader className="p-4 pb-3">
         {/* Header with title on left and headerRight on right */}
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0 flex-1 basis-full sm:basis-auto">
             {/* Card Title */}
             {titleColumns.map((col) => {
               const value = row[col.name];


### PR DESCRIPTION
<img width="834" height="604" alt="image" src="https://github.com/user-attachments/assets/bc5818f8-dacc-42a3-92d1-4cdc7375840d" />

resolves: https://github.com/flanksource/flanksource-ui/issues/2753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated header layout to improve responsive wrapping on smaller viewports.
  * Title now expands to full width on narrow screens while reverting to compact sizing on larger screens, improving line breaks and the flow of title, subtitle and deck content for better readability on mobile.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->