### PR TITLE
fix: width on the playbooks page

### DIFF
--- a/src/pages/playbooks/PlaybookRunsDetails.tsx
+++ b/src/pages/playbooks/PlaybookRunsDetails.tsx
@@ -115,7 +115,7 @@ export default function PlaybookRunsDetailsPage() {
         contentClass="flex flex-col p-0 h-full overflow-y-hidden"
       >
         <TabbedLinks activeTabName={`Runs`} tabLinks={playbookRunsPageTabs}>
-          <div className={`mx-auto flex h-full flex-col p-4`}>
+          <div className={`mx-auto flex h-full w-full flex-col p-4`}>
             {playbookRunsWithActions ? (
               <PlaybookRunsActions
                 data={playbookRunsWithActions}


### PR DESCRIPTION
Not sure how this broke. There were no recent changes to the related files.

<img width="2560" height="1296" alt="image" src="https://github.com/user-attachments/assets/2dd86eec-2f37-471c-b957-5eeb2069455e" />


after

<img width="2560" height="1301" alt="image" src="https://github.com/user-attachments/assets/af34d9ed-edac-4fb6-99b7-bd8e29bd57e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout of the Playbook Runs Details page to utilize full-width display, improving the visual presentation and spacing of the content area.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->