### PR TITLE
fix: combine user search text with existing resource selector search terms

### DIFF
--- a/src/components/Forms/Formik/FormikResourceSelectorDropdown.tsx
+++ b/src/components/Forms/Formik/FormikResourceSelectorDropdown.tsx
@@ -46,7 +46,7 @@ export default function FormikResourceSelectorDropdown({
   disabled = false
 }: FormikConfigsDropdownProps) {
   const [inputText, setInputText] = useState<string>("");
-  const [searchText, setSearchText] = useState<string>();
+  const [searchText, setSearchText] = useState<string>("");
   const [isTouched, setIsTouched] = useState(false);
 
   const [field, meta] = useField<string | string[]>({
@@ -63,13 +63,22 @@ export default function FormikResourceSelectorDropdown({
     )
   });
 
+  // Combine user search input with predefined search terms from resource selector
+  const combineSearchTerms = useCallback(
+    (predefinedSearch?: string) => {
+      const parts = [searchText, predefinedSearch].filter(Boolean);
+      return parts.join(" ").trim();
+    },
+    [searchText]
+  );
+
   const resourceSelector: SearchResourcesRequest = useMemo(
     () => ({
       checks: checkResourceSelector
         ? [
             ...checkResourceSelector.map((r) => ({
               ...r,
-              search: searchText,
+              search: combineSearchTerms(r.search),
               agent: r.agent || "all"
             }))
           ]
@@ -78,7 +87,7 @@ export default function FormikResourceSelectorDropdown({
         ? [
             ...canaryResourceSelector.map((r) => ({
               ...r,
-              search: searchText,
+              search: combineSearchTerms(r.search),
               agent: r.agent || "all"
             }))
           ]
@@ -87,7 +96,7 @@ export default function FormikResourceSelectorDropdown({
         ? [
             ...componentResourceSelector.map((r) => ({
               ...r,
-              search: searchText,
+              search: combineSearchTerms(r.search),
               agent: r.agent || "all"
             }))
           ]
@@ -96,7 +105,7 @@ export default function FormikResourceSelectorDropdown({
         ? [
             ...configResourceSelector.map((r) => ({
               ...r,
-              search: searchText,
+              search: combineSearchTerms(r.search),
               agent: r.agent || "all"
             }))
           ]
@@ -105,7 +114,7 @@ export default function FormikResourceSelectorDropdown({
         ? [
             ...connectionResourceSelector.map((r) => ({
               ...r,
-              search: searchText,
+              search: combineSearchTerms(r.search),
               name: r.name || "*"
             }))
           ]
@@ -114,7 +123,7 @@ export default function FormikResourceSelectorDropdown({
         ? [
             ...playbookResourceSelector.map((r) => ({
               ...r,
-              search: searchText,
+              search: combineSearchTerms(r.search),
               name: r.name || "*"
             }))
           ]
@@ -127,7 +136,7 @@ export default function FormikResourceSelectorDropdown({
       canaryResourceSelector,
       connectionResourceSelector,
       playbookResourceSelector,
-      searchText
+      combineSearchTerms
     ]
   );
 


### PR DESCRIPTION
When a playbook defines a resource selector with search terms, the user's
input should be combined with those predefined terms rather than replacing them.

For example, given a playbook config:
```yaml
configs:
  - search: tags.cluster=kind
    types:
      - Kubernetes::Deployment
```

If the user types "nginx" in the search box, the final search should be
"nginx tags.cluster=kind" to filter both by user input and predefined criteria.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search functionality in resource selectors (checks, canaries, components, configs, connections, and playbooks) to provide more accurate results by better combining user input with predefined search terms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->