### PR TITLE
fix(audit-report): color inactive status as light red

### DIFF
--- a/src/components/Status/index.tsx
+++ b/src/components/Status/index.tsx
@@ -16,6 +16,7 @@ function getStatusColorConfig(
     status === "missing" ||
     status === "unhealthy" ||
     status === "failed" ||
+    status === "inactive" ||
     (good !== undefined && !good)
   ) {
     return {

--- a/src/pages/audit-report/components/View/panels/utils.ts
+++ b/src/pages/audit-report/components/View/panels/utils.ts
@@ -139,7 +139,6 @@ type Severity = "critical" | "high" | "medium" | "low" | "info" | "unknown";
  */
 export const getSeverityOfText = (status: string): Severity => {
   const statusLower = status.toLowerCase();
-
   // Specific status mappings
   switch (statusLower) {
     case "diff":
@@ -174,6 +173,9 @@ export const getSeverityOfText = (status: string): Severity => {
     case "unschedulable":
     case "sourcenotready":
       return "high";
+
+    case "active":
+      return "info";
   }
 
   // Dynamic heuristics for substring matches
@@ -193,8 +195,7 @@ export const getSeverityOfText = (status: string): Severity => {
     statusLower.includes("error") ||
     statusLower.includes("fail") ||
     statusLower.includes("reject") ||
-    statusLower.includes("deny") ||
-    statusLower.includes("inactive")
+    statusLower.includes("deny")
   ) {
     return "critical";
   } else if (


### PR DESCRIPTION
- Add 'inactive' to critical severity mapping for exact matches
- Add 'inactive' substring check in dynamic heuristics

This ensures inactive statuses display with red color scheme instead of gray.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved severity classification in audit reports: items marked "inactive" are now treated as critical.
  * Fixed status badge behavior: "inactive" states now render with error/red styling alongside other degraded statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->