### PR TITLE
feat: use orange shade for dormant status

### DIFF
--- a/src/components/Status/index.tsx
+++ b/src/components/Status/index.tsx
@@ -40,8 +40,8 @@ function getStatusColorConfig(
     };
   }
 
-  // Orange: warning, warn, or mixed=true
-  if (status === "warning" || status === "warn") {
+  // Orange: warning, warn, dormant, or mixed=true
+  if (status === "warning" || status === "warn" || status === "dormant") {
     return {
       badge:
         "bg-orange-100 text-orange-800 dark:bg-orange-400/10 dark:text-orange-500",

--- a/src/pages/audit-report/components/View/panels/utils.ts
+++ b/src/pages/audit-report/components/View/panels/utils.ts
@@ -172,6 +172,7 @@ export const getSeverityOfText = (status: string): Severity => {
     case "high":
     case "unschedulable":
     case "sourcenotready":
+    case "dormant":
       return "high";
 
     case "active":


### PR DESCRIPTION
Updates the `Status` component and audit report utilities to display the `dormant` status using an orange shade (#FF8C00).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of "dormant" status to display with appropriate visual indicators and severity classification in reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->