### PR TITLE
fix(ui): remove setSearchParams from useEffect deps to break infinite render loop

### DIFF
--- a/src/components/Forms/FormikFilterForm.tsx
+++ b/src/components/Forms/FormikFilterForm.tsx
@@ -98,7 +98,8 @@ function FormikChangesListener({
 
       return nextParams;
     });
-  }, [filterFields, paramsToReset, setSearchParams, values]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterFields, paramsToReset, values]);
 
   // Sync URL params to form values
   useEffect(() => {


### PR DESCRIPTION
React Router's setSearchParams is not referentially stable — it
depends on searchParams in its useCallback deps, so it's recreated
on every URL change 

resolves: https://github.com/flanksource/flanksource-ui/issues/2859

Reverts: https://github.com/flanksource/flanksource-ui/commit/3cbeafb5d870c902475c159e0b641d79e5f1e7d7#diff-cc88bafad38be29277f5b003d393d46464e4e547f6effda1ba28978ff8d3f0b8L33-L36