### PR TITLE
chore: move show deleted configs button

### DIFF
--- a/src/components/Configs/Changes/ConfigChangesFilters/ConfigChangesFilters.tsx
+++ b/src/components/Configs/Changes/ConfigChangesFilters/ConfigChangesFilters.tsx
@@ -10,6 +10,7 @@ import { ChangesTypesDropdown } from "./ChangeTypesDropdown";
 import { ConfigChangeSeverity } from "./ConfigChangeSeverity";
 import ConfigChangesDateRangeFilter from "./ConfigChangesDateRangeFIlter";
 import { ConfigTagsDropdown } from "./ConfigTagsDropdown";
+import ShowDeletedConfigs from "../../ConfigsListFilters/ShowDeletedConfigs";
 import ConfigTypesTristateDropdown from "./ConfigTypesTristateDropdown";
 
 type FilterBadgeProps = {
@@ -98,6 +99,7 @@ export function ConfigChangeFilters({
           <ConfigChangeSeverity />
           <ConfigTagsDropdown />
           <ConfigChangesDateRangeFilter paramsToReset={paramsToReset} />
+          <ShowDeletedConfigs />
         </div>
       </FormikFilterForm>
       <div className="flex flex-wrap gap-2">

--- a/src/components/Configs/Changes/ConfigsRelatedChanges/FilterBar/ConfigRelatedChangesFilters.tsx
+++ b/src/components/Configs/Changes/ConfigsRelatedChanges/FilterBar/ConfigRelatedChangesFilters.tsx
@@ -7,6 +7,7 @@ import ConfigChangesDateRangeFilter from "../../ConfigChangesFilters/ConfigChang
 import { FilterBadge } from "../../ConfigChangesFilters/ConfigChangesFilters";
 import { ConfigRelatedChangesToggles } from "../../ConfigChangesFilters/ConfigRelatedChangesToggles";
 import { ConfigTagsDropdown } from "../../ConfigChangesFilters/ConfigTagsDropdown";
+import ShowDeletedConfigs from "../../../ConfigsListFilters/ShowDeletedConfigs";
 import ConfigTypesTristateDropdown from "../../ConfigChangesFilters/ConfigTypesTristateDropdown";
 
 type ConfigChangeFiltersProps = {
@@ -33,6 +34,7 @@ export function ConfigRelatedChangesFilters({
           <ConfigTagsDropdown />
           <ConfigRelatedChangesToggles />
           <ConfigChangesDateRangeFilter paramsToReset={paramsToReset} />
+          <ShowDeletedConfigs />
         </div>
       </FormikFilterForm>
       <div className="flex flex-wrap gap-2">

--- a/src/components/Configs/ConfigRelationshipFilterBar.tsx
+++ b/src/components/Configs/ConfigRelationshipFilterBar.tsx
@@ -5,6 +5,7 @@ import ConfigGraphTableToggle from "./ConfigsListFilters/ConfigGraphTableToggle"
 import { ConfigHealthyDropdown } from "./ConfigsListFilters/ConfigHealthyDropdown";
 import { ConfigLabelsDropdown } from "./ConfigsListFilters/ConfigLabelsDropdown";
 import { ConfigStatusDropdown } from "./ConfigsListFilters/ConfigStatusDropdown";
+import ShowDeletedConfigs from "./ConfigsListFilters/ShowDeletedConfigs";
 
 export default function ConfigRelationshipFilterBar() {
   return (
@@ -24,6 +25,7 @@ export default function ConfigRelationshipFilterBar() {
         <ConfigHealthyDropdown />
         <ConfigStatusDropdown />
         <ConfigRelationshipToggles />
+        <ShowDeletedConfigs />
         <ConfigGraphTableToggle />
       </div>
     </FormikFilterForm>

--- a/src/components/Configs/ConfigsListFilters/ConfigsListFilters.tsx
+++ b/src/components/Configs/ConfigsListFilters/ConfigsListFilters.tsx
@@ -5,6 +5,7 @@ import { ConfigHealthyDropdown } from "./ConfigHealthyDropdown";
 import { ConfigLabelsDropdown } from "./ConfigLabelsDropdown";
 import { ConfigStatusDropdown } from "./ConfigStatusDropdown";
 import { ConfigTypesDropdown } from "./ConfigTypesDropdown";
+import ShowDeletedConfigs from "./ShowDeletedConfigs";
 
 export default function ConfigsListFilters() {
   return (
@@ -29,6 +30,8 @@ export default function ConfigsListFilters() {
         <ConfigStatusDropdown />
 
         <ConfigHealthyDropdown />
+
+        <ShowDeletedConfigs />
 
         <FormikSearchInputClearable
           name="search"

--- a/src/components/Configs/ConfigsListFilters/ShowDeletedConfigs.tsx
+++ b/src/components/Configs/ConfigsListFilters/ShowDeletedConfigs.tsx
@@ -1,0 +1,25 @@
+// ABOUTME: Toggle component to show/hide deleted configs in filter bars.
+// ABOUTME: Syncs state with URL search params (showDeletedConfigs=true).
+
+import { Toggle } from "@flanksource-ui/ui/FormControls/Toggle";
+import { useSearchParams } from "react-router-dom";
+
+export default function ShowDeletedConfigs() {
+  const [params, setParams] = useSearchParams();
+  const showDeleted = params.get("showDeletedConfigs") === "true";
+
+  return (
+    <Toggle
+      label="Show deleted"
+      value={showDeleted}
+      onChange={(value) => {
+        if (value) {
+          params.set("showDeletedConfigs", "true");
+        } else {
+          params.delete("showDeletedConfigs");
+        }
+        setParams(params);
+      }}
+    />
+  );
+}

--- a/src/components/Forms/FormikFilterForm.tsx
+++ b/src/components/Forms/FormikFilterForm.tsx
@@ -65,9 +65,15 @@ function FormikChangesListener({
     valuesRef.current = values;
   }, [values]);
 
+  // Keep a stable ref so the form→URL effect doesn't re-run on every URL
+  // change. React-router recreates setSearchParams on each URL change, which
+  // would cause this effect to fight external navigations with stale values.
+  const setSearchParamsRef = useRef(setSearchParams);
+  setSearchParamsRef.current = setSearchParams;
+
   // Sync form values to URL params
   useEffect(() => {
-    setSearchParams((currentParams) => {
+    setSearchParamsRef.current((currentParams) => {
       let changed = false;
       const nextParams = new URLSearchParams(currentParams);
 

--- a/src/components/Notifications/Filters/NotificationFilterBar.tsx
+++ b/src/components/Notifications/Filters/NotificationFilterBar.tsx
@@ -1,3 +1,4 @@
+import ShowDeletedConfigs from "../../Configs/ConfigsListFilters/ShowDeletedConfigs";
 import FormikFilterForm from "../../Forms/FormikFilterForm";
 import FormikSearchInputClearable from "../../Forms/Formik/FormikSearchInputClearable";
 import NotificationResourceTypeDropdown from "./NotificationResourceTypeDropdown";
@@ -17,6 +18,7 @@ export default function NotificationFilterBar() {
         <NotificationStatusDropdown />
         <NotificationResourceTypeDropdown />
         <NotificationTagsDropdown />
+        <ShowDeletedConfigs />
         <FormikSearchInputClearable
           name="search"
           placeholder="Search by resource name"

--- a/src/store/preference.state.ts
+++ b/src/store/preference.state.ts
@@ -1,5 +1,6 @@
 import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
+import { useSearchParams } from "react-router-dom";
 
 export const datetimePreferenceAtom = atomWithStorage<
   "short" | "medium" | "full" | "timestamp"
@@ -25,16 +26,7 @@ export const cardPreferenceAtom = atomWithStorage<string>(
   }
 );
 
-export const showDeletedItemsPreferenceAtom = atomWithStorage<"yes" | "no">(
-  "show_deleted_items_preference",
-  "no",
-  undefined,
-  {
-    getOnInit: true
-  }
-);
-
 export function useShowDeletedConfigs() {
-  const [showDeletedItems] = useAtom(showDeletedItemsPreferenceAtom);
-  return showDeletedItems === "yes";
+  const [searchParams] = useSearchParams();
+  return searchParams.get("showDeletedConfigs") === "true";
 }

--- a/src/ui/Layout/Preference.tsx
+++ b/src/ui/Layout/Preference.tsx
@@ -3,28 +3,17 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
 
-import { NavigateOptions, URLSearchParamsInit } from "react-router-dom";
 import { Size } from "@flanksource-ui/types";
 import { FaCog } from "react-icons/fa";
 import { LegacyRef } from "react";
-import { useSearchParams } from "react-router-dom";
 import { useOnMouseActivity } from "@flanksource-ui/hooks/useMouseActivity";
 import { ClickableSvg } from "../ClickableSvg/ClickableSvg";
-import { Toggle } from "@flanksource-ui/components";
 import {
   datetimePreferenceAtom,
-  displayTimezonePreferenceAtom,
-  showDeletedItemsPreferenceAtom
+  displayTimezonePreferenceAtom
 } from "@flanksource-ui/store/preference.state";
 import { useAtom } from "jotai";
 import { ReactSelectDropdown } from "@flanksource-ui/components/ReactSelectDropdown";
-
-export type SetURLSearchParams = (
-  nextInit?:
-    | URLSearchParamsInit
-    | ((prev: URLSearchParams) => URLSearchParamsInit),
-  navigateOpts?: NavigateOptions
-) => void;
 
 type PreferencePopOverProps = {
   cardSize: string;
@@ -85,8 +74,6 @@ export const Preference = ({
   cardSize: Size | string;
   setCardWidth: (width: string) => void;
 }) => {
-  const [searchParams, setSearchParams] = useSearchParams();
-
   const [dateTimePreference, setDateTimePreference] = useAtom(
     datetimePreferenceAtom
   );
@@ -95,17 +82,11 @@ export const Preference = ({
     displayTimezonePreferenceAtom
   );
 
-  const [showDeletedConfigsPreference, setShowDeletedConfigsPreference] =
-    useAtom(showDeletedItemsPreferenceAtom);
-
   const {
     ref: popoverRef,
     isActive: isPopoverActive,
     setIsActive: setIsPopoverActive
   } = useOnMouseActivity();
-
-  const showHiddenComponents =
-    searchParams.get("showHiddenComponents") !== "no";
 
   const timezoneOptions: Record<string, { label: string; value: string }> =
     Object.fromEntries(
@@ -171,51 +152,6 @@ export const Preference = ({
           <div className="py-1">
             <div className="flex items-center justify-between px-4 py-2 text-base">
               <span className="font-bold text-gray-700">{title}</span>
-            </div>
-          </div>
-
-          {/* Hidden components */}
-          <div className="py-1" role="none">
-            <div className="flex items-center px-4 py-3">
-              <label
-                htmlFor="showHiddenComponents"
-                className="block text-sm font-medium text-gray-700"
-              >
-                Show hidden components: &nbsp;
-              </label>
-              <Toggle
-                className="inline-flex items-center"
-                label=""
-                name="showHiddenComponents"
-                value={showHiddenComponents}
-                onChange={(val) => {
-                  const newValue = val ? "yes" : "no";
-                  setSearchParams({
-                    ...Object.fromEntries(searchParams),
-                    showHiddenComponents: newValue
-                  });
-                }}
-              />
-            </div>
-          </div>
-
-          <div className="py-1" role="none">
-            <div className="flex items-center px-4 py-3">
-              <label
-                htmlFor="showDeletedConfigs"
-                className="block text-sm font-medium text-gray-700"
-              >
-                Show deleted configs: &nbsp;
-              </label>
-              <Toggle
-                className="inline-flex items-center"
-                label=""
-                name="showDeletedConfigs"
-                value={showDeletedConfigsPreference === "yes"}
-                onChange={(val) => {
-                  setShowDeletedConfigsPreference(val ? "yes" : "no");
-                }}
-              />
             </div>
           </div>
 


### PR DESCRIPTION
Fixes: https://github.com/flanksource/flanksource-ui/issues/2841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Show deleted" filter toggle across configuration and notification views, enabling users to display or hide deleted items.

* **Refactor**
  * Migrated preference storage from internal state to URL parameters for improved consistency and persistence across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->