### PR TITLE
feat(chat): add "Always Allow" option for tool approval per session

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -148,7 +148,11 @@ export async function POST(req: Request) {
     status: "started"
   };
 
-  const { messages }: { messages?: UIMessage[] } = await req.json();
+  const {
+    messages,
+    alwaysAllowedTools = []
+  }: { messages?: UIMessage[]; alwaysAllowedTools?: string[] } =
+    await req.json();
   if (!Array.isArray(messages)) {
     return new Response("Invalid request body", { status: 400 });
   }
@@ -180,7 +184,7 @@ export async function POST(req: Request) {
         }
       }
     });
-    const tools = await buildChatTools(mcpClient);
+    const tools = await buildChatTools(mcpClient, alwaysAllowedTools);
 
     const loadedSkillTool = await loadSkillTool();
     wideEvent.skills = {

--- a/app/api/chat/tools.ts
+++ b/app/api/chat/tools.ts
@@ -86,11 +86,16 @@ const PLAYBOOK_MCP_TOOLS_WITH_NO_APPROVAL_REQUIRED: string[] = [
 type McpTool = Record<string, any>;
 type McpTools = Record<string, McpTool>;
 
-function wrapMcpToolsWithApproval(mcpTools: McpTools): McpTools {
+function wrapMcpToolsWithApproval(
+  mcpTools: McpTools,
+  alwaysAllowedTools: string[] = []
+): McpTools {
+  const alwaysAllowed = new Set(alwaysAllowedTools);
   const tools = Object.entries(mcpTools).map(
     ([name, toolDefinition]: [string, McpTool]) => {
       const noApproval =
         NATIVE_TOOLS_WITH_NO_APPROVAL_REQUIRED.includes(name) ||
+        alwaysAllowed.has(name) ||
         (toolDefinition["title"] &&
           PLAYBOOK_MCP_TOOLS_WITH_NO_APPROVAL_REQUIRED.includes(
             toolDefinition["title"]
@@ -152,11 +157,17 @@ function createPlotTimeseriesTool() {
   });
 }
 
-export async function buildChatTools(mcpClient: {
-  tools: () => Promise<McpTools>;
-}) {
+export async function buildChatTools(
+  mcpClient: {
+    tools: () => Promise<McpTools>;
+  },
+  alwaysAllowedTools: string[] = []
+) {
   const mcpTools = await mcpClient.tools();
-  const toolsWithApproval = wrapMcpToolsWithApproval(mcpTools);
+  const toolsWithApproval = wrapMcpToolsWithApproval(
+    mcpTools,
+    alwaysAllowedTools
+  );
 
   return {
     ...toolsWithApproval,

--- a/src/components/ai/AiChat.tsx
+++ b/src/components/ai/AiChat.tsx
@@ -66,7 +66,7 @@ import {
 import { cn } from "@flanksource-ui/lib/utils";
 import type { FileUIPart, ReasoningUIPart, UIMessage } from "ai";
 import { getToolName, isToolUIPart } from "ai";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ErrorViewer } from "@flanksource-ui/components/ErrorViewer";
 import ConfigLink from "@flanksource-ui/components/Configs/ConfigLink/ConfigLink";
 import { CartesianGrid, Line, ComposedChart, XAxis, YAxis } from "recharts";
@@ -266,9 +266,18 @@ export function AIChat({
   onConversationPersisted,
   storageScopeKey
 }: AIChatProps) {
+  // Tools the user has "always allowed" for this chat session.
+  // Sent to the backend so subsequent requests build those tools
+  // with needsApproval: false — no stream pause, no round-trip.
+  const [alwaysAllowedTools, setAlwaysAllowedTools] = useState<Set<string>>(
+    new Set()
+  );
+  const alwaysAllowedRef = useRef(alwaysAllowedTools);
+  alwaysAllowedRef.current = alwaysAllowedTools;
+
   const {
     messages,
-    sendMessage,
+    sendMessage: rawSendMessage,
     stop,
     status,
     addToolApprovalResponse,
@@ -288,6 +297,23 @@ export function AIChat({
     void saveAIConversation(chat.id, messages, storageScopeKey);
     onConversationPersisted?.(chat.id, messages);
   }, [chat.id, messages, onConversationPersisted, storageScopeKey]);
+
+  // Wrap sendMessage to automatically inject alwaysAllowedTools in the body.
+  // The `chat` prop causes useChat to ignore transport/body options, so we
+  // inject via the per-request options instead.
+  const sendMessage = useCallback(
+    (...args: Parameters<typeof rawSendMessage>) => {
+      const [message, options] = args;
+      return rawSendMessage(message, {
+        ...options,
+        body: {
+          ...options?.body,
+          alwaysAllowedTools: Array.from(alwaysAllowedRef.current)
+        }
+      });
+    },
+    [rawSendMessage]
+  );
 
   // Auto-send when chat mounts with a pre-seeded user message (e.g. from setChatMessages).
   const hasSentOnMount = useRef(false);
@@ -318,6 +344,19 @@ export function AIChat({
       }
     },
     [addToolApprovalResponse, sendMessage, status]
+  );
+
+  const handleToolAlwaysAllow = useCallback(
+    async (toolName: string, approvalId: string) => {
+      // Eagerly update the ref so the transport body() reads the new set
+      // when sendMessage() fires inside handleToolApproval — React won't
+      // have re-rendered yet at that point.
+      const next = new Set(alwaysAllowedRef.current).add(toolName);
+      alwaysAllowedRef.current = next;
+      setAlwaysAllowedTools(next);
+      await handleToolApproval(approvalId, true);
+    },
+    [handleToolApproval]
   );
 
   const handleSubmit = useCallback(
@@ -507,8 +546,20 @@ export function AIChat({
                     onClick={() =>
                       approvalId && handleToolApproval(approvalId, true)
                     }
+                    variant="outline"
                   >
-                    Approve
+                    Allow
+                  </ConfirmationAction>
+                  <ConfirmationAction
+                    disabled={!approvalId}
+                    onClick={() => {
+                      const name = getToolName(part);
+                      if (approvalId && name) {
+                        handleToolAlwaysAllow(name, approvalId);
+                      }
+                    }}
+                  >
+                    Always Allow
                   </ConfirmationAction>
                 </ConfirmationActions>
               </ConfirmationRequest>


### PR DESCRIPTION
resolves: https://github.com/flanksource/flanksource-ui/issues/2879



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can mark chat tools as "Always Allow" so they're permanently permitted within a chat.
  * Always-allowed selections persist per chat and are included with outgoing chat requests to keep behavior consistent.

* **UI**
  * Tool approval UI now includes "Always Allow" and an intermediate "Allow" option; approval labels updated for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->