### PR TITLE
fix(notifications): show in_progress count separately from suppressed in summary table

### DIFF
--- a/src/api/types/notifications.ts
+++ b/src/api/types/notifications.ts
@@ -160,6 +160,7 @@ export type NotificationSendHistorySummary = {
   total: number;
   sent: number;
   error: number;
+  in_progress: number;
   suppressed: number;
   in_progress?: number;
 };

--- a/src/api/types/notifications.ts
+++ b/src/api/types/notifications.ts
@@ -162,7 +162,6 @@ export type NotificationSendHistorySummary = {
   error: number;
   in_progress: number;
   suppressed: number;
-  in_progress?: number;
 };
 
 export type NotificationSendHistoryApiResponse = NotificationSendHistory & {

--- a/src/components/Notifications/NotificationSendHistorySummary.tsx
+++ b/src/components/Notifications/NotificationSendHistorySummary.tsx
@@ -117,6 +117,12 @@ const notificationSendHistoryColumns: MRT_ColumnDef<NotificationSendHistorySumma
                 statusText={`${row.original.error} failed`}
               />
             )}
+            {row.original.in_progress > 0 && (
+              <Status
+                status="unknown"
+                statusText={`${row.original.in_progress} in progress`}
+              />
+            )}
             {row.original.suppressed > 0 && (
               <Status
                 status="suppressed"

--- a/src/components/Notifications/NotificationSendHistorySummary.tsx
+++ b/src/components/Notifications/NotificationSendHistorySummary.tsx
@@ -129,12 +129,6 @@ const notificationSendHistoryColumns: MRT_ColumnDef<NotificationSendHistorySumma
                 statusText={`${row.original.suppressed} suppressed`}
               />
             )}
-            {(row.original.in_progress ?? 0) > 0 && (
-              <Status
-                status="unknown"
-                statusText={`${row.original.in_progress} in progress`}
-              />
-            )}
           </div>
         );
       }


### PR DESCRIPTION
Depends on https://github.com/flanksource/duty/pull/1791

Previously, notifications with pending statuses (`pending`, `pending_playbook_run`, `pending_playbook_completion`, `evaluating-waitfor`, `attempting_fallback`) were bucketed into `suppressed` by the backend and displayed as "Suppressed" in the table.

- Added `in_progress` field to `NotificationSendHistorySummary` type
- Renders "X in progress" badge in the Status column alongside sent/error/suppressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification send history summary to properly track and display in-progress notification counts with enhanced accuracy. Status indicators now reliably show the number of notifications currently being processed, providing improved visibility into real-time delivery progress and operational status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->