### PR TITLE
feat(ai-chat): persist local conversations and add history UI

### DIFF
--- a/src/components/ai/AiChat.tsx
+++ b/src/components/ai/AiChat.tsx
@@ -5,7 +5,7 @@ import {
   ConversationEmptyState,
   ConversationScrollButton
 } from "@flanksource-ui/components/ai-elements/conversation";
-import { SquarePen, X } from "lucide-react";
+import { Check, History, SquarePen, Trash2, X } from "lucide-react";
 import { Loader } from "@flanksource-ui/components/ai-elements/loader";
 import {
   Confirmation,
@@ -45,6 +45,14 @@ import {
 import { Button } from "@flanksource-ui/components/ui/button";
 import { Card } from "@flanksource-ui/components/ui/card";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@flanksource-ui/components/ui/dropdown-menu";
+import {
   ChartConfig,
   ChartContainer,
   ChartTooltip,
@@ -52,8 +60,8 @@ import {
 } from "@flanksource-ui/components/ui/chart";
 import { formatTick, parseTimestamp } from "@flanksource-ui/lib/timeseries";
 import {
-  clearActiveAIConversation,
-  saveActiveAIConversation
+  saveAIConversation,
+  type AIConversationRecord
 } from "@flanksource-ui/lib/ai-chat-history";
 import { cn } from "@flanksource-ui/lib/utils";
 import type { FileUIPart, ReasoningUIPart, UIMessage } from "ai";
@@ -69,6 +77,45 @@ type PlotTimeseriesOutput = {
   timeseries: TimeseriesPoint[];
   title?: string;
 };
+
+const HISTORY_PREVIEW_MAX_LENGTH = 72;
+
+function getConversationPreview(messages: UIMessage[]): string {
+  for (const message of messages) {
+    if (message.role !== "user") {
+      continue;
+    }
+
+    for (const part of message.parts) {
+      if (part.type !== "text") {
+        continue;
+      }
+
+      const normalizedText = part.text.replace(/\s+/g, " ").trim();
+
+      if (!normalizedText) {
+        continue;
+      }
+
+      if (normalizedText.length <= HISTORY_PREVIEW_MAX_LENGTH) {
+        return normalizedText;
+      }
+
+      return `${normalizedText.slice(0, HISTORY_PREVIEW_MAX_LENGTH - 1)}…`;
+    }
+  }
+
+  return "Untitled conversation";
+}
+
+function formatConversationTime(updatedAt: number): string {
+  return new Date(updatedAt).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
 
 const isPlotTimeseriesOutput = (
   output: unknown
@@ -194,6 +241,15 @@ export type AIChatProps = {
   onClose?: () => void;
   onNewChat?: () => void;
   quickPrompts?: string[];
+  activeConversationId?: string;
+  conversationHistory?: AIConversationRecord[];
+  onSelectConversation?: (conversationId: string) => void;
+  onDeleteConversation?: (conversationId: string) => void;
+  onConversationPersisted?: (
+    conversationId: string,
+    messages: UIMessage[]
+  ) => void;
+  storageScopeKey?: string;
 };
 
 export function AIChat({
@@ -202,7 +258,13 @@ export function AIChat({
   id,
   onClose,
   onNewChat,
-  quickPrompts
+  quickPrompts,
+  activeConversationId,
+  conversationHistory,
+  onSelectConversation,
+  onDeleteConversation,
+  onConversationPersisted,
+  storageScopeKey
 }: AIChatProps) {
   const {
     messages,
@@ -223,8 +285,9 @@ export function AIChat({
       return;
     }
 
-    void saveActiveAIConversation(chat.id, messages);
-  }, [chat.id, messages]);
+    void saveAIConversation(chat.id, messages, storageScopeKey);
+    onConversationPersisted?.(chat.id, messages);
+  }, [chat.id, messages, onConversationPersisted, storageScopeKey]);
 
   // Auto-send when chat mounts with a pre-seeded user message (e.g. from setChatMessages).
   const hasSentOnMount = useRef(false);
@@ -277,8 +340,6 @@ export function AIChat({
   );
 
   const handleNewChat = useCallback(() => {
-    void clearActiveAIConversation();
-
     if (onNewChat) {
       onNewChat();
     } else {
@@ -500,6 +561,10 @@ export function AIChat({
     );
   };
 
+  const visibleConversationHistory = useMemo(() => {
+    return (conversationHistory ?? []).slice(0, 20);
+  }, [conversationHistory]);
+
   const errorMessage = error
     ? error instanceof Error
       ? error.message
@@ -510,6 +575,75 @@ export function AIChat({
     <div className={cn("flex h-full flex-1 flex-col gap-4", className)}>
       <Card className="relative flex h-full flex-1 flex-col bg-card">
         <div className="absolute left-3 top-3 z-10 flex items-center gap-2">
+          {onSelectConversation ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  aria-label="View conversation history"
+                  size="sm"
+                  variant="outline"
+                >
+                  <History className="mr-2 h-3.5 w-3.5" />
+                  History
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-80">
+                <DropdownMenuLabel>Conversation History</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {visibleConversationHistory.length > 0 ? (
+                  visibleConversationHistory.map((conversation) => {
+                    const isActive = activeConversationId === conversation.id;
+
+                    return (
+                      <DropdownMenuItem
+                        className="group"
+                        key={conversation.id}
+                        onSelect={() => onSelectConversation(conversation.id)}
+                      >
+                        <div className="flex min-w-0 flex-1 flex-col">
+                          <span className="truncate font-medium">
+                            {getConversationPreview(conversation.messages)}
+                          </span>
+                          <span className="truncate text-xs text-muted-foreground">
+                            {formatConversationTime(conversation.updatedAt)}
+                          </span>
+                        </div>
+                        <div className="ml-2 flex items-center gap-1">
+                          {isActive ? (
+                            <Check className="h-4 w-4 text-primary" />
+                          ) : null}
+                          {onDeleteConversation ? (
+                            <button
+                              type="button"
+                              aria-label="Delete conversation"
+                              className="rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 group-focus:opacity-100"
+                              title="Delete conversation"
+                              onPointerDown={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                              }}
+                              onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                onDeleteConversation(conversation.id);
+                              }}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          ) : null}
+                        </div>
+                      </DropdownMenuItem>
+                    );
+                  })
+                ) : (
+                  <DropdownMenuItem disabled>
+                    No saved conversations yet
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+
           {onNewChat ? (
             <Button
               aria-label="Start a new conversation"

--- a/src/components/ai/AiChatPopover.tsx
+++ b/src/components/ai/AiChatPopover.tsx
@@ -4,26 +4,53 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode
 } from "react";
 import { Chat, UIMessage } from "@ai-sdk/react";
 import { Resizable } from "re-resizable";
 import { AIChat } from "@flanksource-ui/components/ai/AiChat";
-import { loadActiveAIConversation } from "@flanksource-ui/lib/ai-chat-history";
+import { useUser } from "@flanksource-ui/context";
+import {
+  deleteAIConversation,
+  loadAIConversationStateSnapshot,
+  setActiveAIConversationId,
+  type AIConversationRecord
+} from "@flanksource-ui/lib/ai-chat-history";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger
 } from "@flanksource-ui/components/ui/popover";
 
+const ACTIVE_CONVERSATION_MAX_AGE_MS = 10 * 60 * 1000;
+
+function isConversationRecent(
+  conversation?: AIConversationRecord
+): conversation is AIConversationRecord {
+  if (!conversation) {
+    return false;
+  }
+
+  return Date.now() - conversation.updatedAt <= ACTIVE_CONVERSATION_MAX_AGE_MS;
+}
+
 type AiChatPopoverContextValue = {
   open: boolean;
   setOpen: (open: boolean) => void;
   chat: Chat<UIMessage>;
   chatVersion: number;
+  conversations: AIConversationRecord[];
   resetChat: () => void;
   setChatMessages: (messages: UIMessage[]) => void;
+  selectConversation: (conversationId: string) => void;
+  deleteConversation: (conversationId: string) => void;
+  onConversationPersisted: (
+    conversationId: string,
+    messages: UIMessage[]
+  ) => void;
+  storageScopeKey: string;
   quickPrompts?: string[];
   setQuickPrompts: (prompts?: string[]) => void;
 };
@@ -43,42 +70,111 @@ export function AiChatPopoverProvider({
   initialOpen = false,
   chatId = "ai-popover"
 }: AiChatPopoverProviderProps) {
+  const { user, orgSlug, backendUrl } = useUser();
+
+  const storageScopeKey = useMemo(() => {
+    const normalizedBackendUrl = backendUrl?.trim() || "default";
+    const normalizedOrgSlug = orgSlug?.trim() || "default";
+    const normalizedUserId = user?.id?.trim() || "anonymous";
+
+    return `${normalizedBackendUrl}:${normalizedOrgSlug}:${normalizedUserId}`;
+  }, [backendUrl, orgSlug, user?.id]);
+
   const [open, setOpenState] = useState(initialOpen);
   const [chat, setChat] = useState(() => new Chat<UIMessage>({ id: chatId }));
   const [chatVersion, setChatVersion] = useState(0);
+  const [conversations, setConversations] = useState<AIConversationRecord[]>(
+    []
+  );
+  const [hasHydratedChatState, setHasHydratedChatState] = useState(false);
   const [quickPrompts, setQuickPrompts] = useState<string[] | undefined>(
     undefined
   );
+  const hasUserMutatedChatRef = useRef(false);
 
-  const replaceChat = useCallback((nextChat: Chat<UIMessage>) => {
-    setChat(nextChat);
-    setChatVersion((version) => version + 1);
-  }, []);
+  const replaceChat = useCallback(
+    (
+      nextChat: Chat<UIMessage>,
+      options: { userAction?: boolean } = { userAction: true }
+    ) => {
+      if (options.userAction !== false) {
+        hasUserMutatedChatRef.current = true;
+      }
+
+      setChat(nextChat);
+      setChatVersion((version) => version + 1);
+    },
+    []
+  );
 
   useEffect(() => {
     let cancelled = false;
 
-    const hydrateActiveConversation = async () => {
-      const activeConversation = await loadActiveAIConversation();
+    hasUserMutatedChatRef.current = false;
+    setHasHydratedChatState(false);
+    setConversations([]);
+    setQuickPrompts(undefined);
 
-      if (cancelled || !activeConversation) {
+    const hydrateChatState = async () => {
+      const { activeConversationId, conversations: storedConversations } =
+        await loadAIConversationStateSnapshot(storageScopeKey);
+
+      if (cancelled) {
         return;
       }
 
-      replaceChat(
-        new Chat<UIMessage>({
-          id: activeConversation.conversationId,
-          messages: activeConversation.messages
-        })
-      );
+      setConversations(storedConversations);
+
+      if (hasUserMutatedChatRef.current) {
+        setHasHydratedChatState(true);
+        return;
+      }
+
+      const storedActiveConversation =
+        (activeConversationId
+          ? storedConversations.find(
+              (conversation) => conversation.id === activeConversationId
+            )
+          : undefined) ?? storedConversations[0];
+
+      if (isConversationRecent(storedActiveConversation)) {
+        const nextConversationId =
+          activeConversationId ?? storedActiveConversation.id;
+
+        replaceChat(
+          new Chat<UIMessage>({
+            id: nextConversationId,
+            messages: storedActiveConversation.messages
+          }),
+          { userAction: false }
+        );
+
+        if (!activeConversationId) {
+          void setActiveAIConversationId(nextConversationId, storageScopeKey);
+        }
+      } else {
+        replaceChat(new Chat<UIMessage>({ id: `${chatId}-${Date.now()}` }), {
+          userAction: false
+        });
+      }
+
+      setHasHydratedChatState(true);
     };
 
-    void hydrateActiveConversation();
+    void hydrateChatState();
 
     return () => {
       cancelled = true;
     };
-  }, [replaceChat]);
+  }, [chatId, replaceChat, storageScopeKey]);
+
+  useEffect(() => {
+    if (!hasHydratedChatState) {
+      return;
+    }
+
+    void setActiveAIConversationId(chat.id, storageScopeKey);
+  }, [chat.id, hasHydratedChatState, storageScopeKey]);
 
   const setOpen = useCallback(
     (open: boolean) => {
@@ -104,18 +200,137 @@ export function AiChatPopoverProvider({
     [chatId, replaceChat]
   );
 
+  const selectConversation = useCallback(
+    (conversationId: string) => {
+      const normalizedConversationId = conversationId.trim();
+      if (!normalizedConversationId) {
+        return;
+      }
+
+      const selectedConversation = conversations.find(
+        (conversation) => conversation.id === normalizedConversationId
+      );
+
+      if (!selectedConversation) {
+        return;
+      }
+
+      replaceChat(
+        new Chat<UIMessage>({
+          id: selectedConversation.id,
+          messages: selectedConversation.messages
+        })
+      );
+      setQuickPrompts(undefined);
+    },
+    [conversations, replaceChat, setQuickPrompts]
+  );
+
+  const deleteConversation = useCallback(
+    (conversationId: string) => {
+      const normalizedConversationId = conversationId.trim();
+
+      if (!normalizedConversationId) {
+        return;
+      }
+
+      const remainingConversations = conversations.filter(
+        (conversation) => conversation.id !== normalizedConversationId
+      );
+
+      setConversations(remainingConversations);
+      void deleteAIConversation(normalizedConversationId, storageScopeKey);
+
+      if (chat.id === normalizedConversationId) {
+        const fallbackConversation = remainingConversations[0];
+
+        if (fallbackConversation) {
+          replaceChat(
+            new Chat<UIMessage>({
+              id: fallbackConversation.id,
+              messages: fallbackConversation.messages
+            })
+          );
+        } else {
+          replaceChat(new Chat<UIMessage>({ id: `${chatId}-${Date.now()}` }));
+        }
+
+        setQuickPrompts(undefined);
+      }
+    },
+    [
+      chat.id,
+      chatId,
+      conversations,
+      replaceChat,
+      setQuickPrompts,
+      storageScopeKey
+    ]
+  );
+
+  const onConversationPersisted = useCallback(
+    (conversationId: string, messages: UIMessage[]) => {
+      const normalizedConversationId = conversationId.trim();
+
+      if (!normalizedConversationId || messages.length === 0) {
+        return;
+      }
+
+      const now = Date.now();
+
+      setConversations((previousConversations) => {
+        const existingConversation = previousConversations.find(
+          (conversation) => conversation.id === normalizedConversationId
+        );
+
+        const nextConversation: AIConversationRecord = {
+          id: normalizedConversationId,
+          messages,
+          createdAt: existingConversation?.createdAt ?? now,
+          updatedAt: now
+        };
+
+        return [
+          nextConversation,
+          ...previousConversations.filter(
+            (conversation) => conversation.id !== normalizedConversationId
+          )
+        ];
+      });
+    },
+    []
+  );
+
   const value = useMemo(
     () => ({
       open,
       setOpen,
       chat,
       chatVersion,
+      conversations,
       resetChat,
       setChatMessages,
+      selectConversation,
+      deleteConversation,
+      onConversationPersisted,
+      storageScopeKey,
       quickPrompts,
       setQuickPrompts
     }),
-    [open, setOpen, chat, chatVersion, resetChat, setChatMessages, quickPrompts]
+    [
+      open,
+      setOpen,
+      chat,
+      chatVersion,
+      conversations,
+      resetChat,
+      setChatMessages,
+      selectConversation,
+      deleteConversation,
+      onConversationPersisted,
+      storageScopeKey,
+      quickPrompts
+    ]
   );
 
   return (
@@ -232,6 +447,11 @@ export function AiChatPopover({
     (() =>
       setLocalChat(new Chat<UIMessage>({ id: `ai-popover-${Date.now()}` })));
   const quickPrompts = context?.quickPrompts;
+  const conversationHistory = context?.conversations;
+  const selectConversation = context?.selectConversation;
+  const deleteConversation = context?.deleteConversation;
+  const onConversationPersisted = context?.onConversationPersisted;
+  const storageScopeKey = context?.storageScopeKey;
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
@@ -272,9 +492,15 @@ export function AiChatPopover({
             key={`${chat.id}-${chatVersion}`}
             chat={chat}
             className="h-full"
+            activeConversationId={chat.id}
+            conversationHistory={conversationHistory}
             onClose={() => handleOpenChange(false)}
+            onConversationPersisted={onConversationPersisted}
+            onDeleteConversation={deleteConversation}
             onNewChat={resetChat}
+            onSelectConversation={selectConversation}
             quickPrompts={quickPrompts}
+            storageScopeKey={storageScopeKey}
           />
         </Resizable>
       </PopoverContent>

--- a/src/lib/ai-chat-history.ts
+++ b/src/lib/ai-chat-history.ts
@@ -1,24 +1,38 @@
 import type { UIMessage } from "ai";
 
-const DB_NAME = "flanksource-ai-chat";
+const DB_NAME_PREFIX = "flanksource-ai-chat";
 const DB_VERSION = 1;
-const ACTIVE_STORE = "ai_active_conversation";
-const ACTIVE_KEY = "active";
+const CONVERSATIONS_STORE = "ai_conversations";
+const META_STORE = "ai_meta";
+const ACTIVE_CONVERSATION_KEY = "active_conversation_id";
 
-type ActiveConversationRecord = {
+type ConversationMetaRecord = {
   key: string;
-  conversationId: string;
+  value: string | null;
+};
+
+export type AIConversationRecord = {
+  id: string;
   messages: UIMessage[];
+  createdAt: number;
   updatedAt: number;
 };
 
-export type ActiveAIConversation = {
-  conversationId: string;
-  messages: UIMessage[];
-  updatedAt: number;
+export type AIConversationStateSnapshot = {
+  activeConversationId: string | null;
+  conversations: AIConversationRecord[];
 };
 
-let databasePromise: Promise<IDBDatabase | null> | null = null;
+const databasePromises = new Map<string, Promise<IDBDatabase | null>>();
+
+function normalizeScopeKey(scopeKey?: string): string {
+  const normalizedScopeKey = scopeKey?.trim();
+  return normalizedScopeKey ? normalizedScopeKey : "anonymous";
+}
+
+function getDatabaseName(scopeKey?: string): string {
+  return `${DB_NAME_PREFIX}:${normalizeScopeKey(scopeKey)}`;
+}
 
 function isIndexedDBAvailable() {
   return (
@@ -47,53 +61,91 @@ function transactionDone(transaction: IDBTransaction): Promise<void> {
   });
 }
 
-function toActiveConversation(candidate: unknown): ActiveAIConversation | null {
+function normalizeTimestamp(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return value;
+}
+
+function toConversationRecord(candidate: unknown): AIConversationRecord | null {
   if (!candidate || typeof candidate !== "object") {
     return null;
   }
 
-  const maybeRecord = candidate as Partial<ActiveConversationRecord>;
+  const maybeConversation = candidate as Record<string, unknown>;
+  const id = maybeConversation.id;
 
-  if (typeof maybeRecord.conversationId !== "string") {
+  if (typeof id !== "string" || !id) {
     return null;
   }
 
-  const conversationId = maybeRecord.conversationId.trim();
+  const messages = Array.isArray(maybeConversation.messages)
+    ? (maybeConversation.messages as UIMessage[])
+    : [];
 
-  if (!conversationId) {
-    return null;
-  }
+  const createdAt =
+    normalizeTimestamp(maybeConversation.createdAt) ?? Date.now();
+  const updatedAt =
+    normalizeTimestamp(maybeConversation.updatedAt) ?? createdAt;
 
   return {
-    conversationId,
-    messages: Array.isArray(maybeRecord.messages)
-      ? (maybeRecord.messages as UIMessage[])
-      : [],
-    updatedAt:
-      typeof maybeRecord.updatedAt === "number" &&
-      Number.isFinite(maybeRecord.updatedAt)
-        ? maybeRecord.updatedAt
-        : Date.now()
+    id,
+    messages,
+    createdAt,
+    updatedAt
   };
 }
 
-function openDatabase(): Promise<IDBDatabase | null> {
+function toActiveConversationId(candidate: unknown): string | null {
+  if (!candidate || typeof candidate !== "object") {
+    return null;
+  }
+
+  const maybeMeta = candidate as Partial<ConversationMetaRecord>;
+
+  if (typeof maybeMeta.value !== "string") {
+    return null;
+  }
+
+  const trimmed = maybeMeta.value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function openDatabase(scopeKey?: string): Promise<IDBDatabase | null> {
   if (!isIndexedDBAvailable()) {
     return Promise.resolve(null);
   }
 
-  if (databasePromise) {
-    return databasePromise;
+  const databaseName = getDatabaseName(scopeKey);
+  const existingPromise = databasePromises.get(databaseName);
+
+  if (existingPromise) {
+    return existingPromise;
   }
 
-  databasePromise = new Promise<IDBDatabase>((resolve, reject) => {
-    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+  const nextPromise = new Promise<IDBDatabase>((resolve, reject) => {
+    const request = window.indexedDB.open(databaseName, DB_VERSION);
 
     request.onupgradeneeded = () => {
       const database = request.result;
 
-      if (!database.objectStoreNames.contains(ACTIVE_STORE)) {
-        database.createObjectStore(ACTIVE_STORE, { keyPath: "key" });
+      if (!database.objectStoreNames.contains(CONVERSATIONS_STORE)) {
+        const conversationStore = database.createObjectStore(
+          CONVERSATIONS_STORE,
+          {
+            keyPath: "id"
+          }
+        );
+
+        if (!conversationStore.indexNames.contains("updatedAt")) {
+          conversationStore.createIndex("updatedAt", "updatedAt");
+        }
+      }
+
+      if (!database.objectStoreNames.contains(META_STORE)) {
+        database.createObjectStore(META_STORE, { keyPath: "key" });
       }
     };
 
@@ -102,63 +154,97 @@ function openDatabase(): Promise<IDBDatabase | null> {
       reject(request.error ?? new Error("Failed to open IndexedDB"));
     };
   }).catch((error) => {
-    databasePromise = null;
+    databasePromises.delete(databaseName);
     throw error;
   });
 
-  return databasePromise;
+  databasePromises.set(databaseName, nextPromise);
+
+  return nextPromise;
 }
 
-export async function loadActiveAIConversation(): Promise<ActiveAIConversation | null> {
+export async function loadAIConversationStateSnapshot(
+  scopeKey?: string
+): Promise<AIConversationStateSnapshot> {
+  const fallbackState: AIConversationStateSnapshot = {
+    activeConversationId: null,
+    conversations: []
+  };
+
   try {
-    const database = await openDatabase();
+    const database = await openDatabase(scopeKey);
 
     if (!database) {
-      return null;
+      return fallbackState;
     }
 
-    const transaction = database.transaction(ACTIVE_STORE, "readonly");
+    const transaction = database.transaction(
+      [CONVERSATIONS_STORE, META_STORE],
+      "readonly"
+    );
     const transactionCompleted = transactionDone(transaction);
-    const store = transaction.objectStore(ACTIVE_STORE);
-    const activeRecord = await requestToPromise(store.get(ACTIVE_KEY));
+    const conversationStore = transaction.objectStore(CONVERSATIONS_STORE);
+    const metaStore = transaction.objectStore(META_STORE);
+
+    const [rawConversations, rawActiveConversation] = await Promise.all([
+      requestToPromise(conversationStore.getAll()),
+      requestToPromise(metaStore.get(ACTIVE_CONVERSATION_KEY))
+    ]);
 
     await transactionCompleted;
 
-    return toActiveConversation(activeRecord);
+    const conversations = rawConversations
+      .map(toConversationRecord)
+      .filter(
+        (conversation): conversation is AIConversationRecord =>
+          conversation !== null
+      )
+      .sort((left, right) => right.updatedAt - left.updatedAt);
+
+    return {
+      activeConversationId: toActiveConversationId(rawActiveConversation),
+      conversations
+    };
   } catch {
-    return null;
+    return fallbackState;
   }
 }
 
-export async function saveActiveAIConversation(
-  conversationId: string,
-  messages: UIMessage[]
+export async function saveAIConversation(
+  id: string,
+  messages: UIMessage[],
+  scopeKey?: string
 ): Promise<void> {
-  const normalizedConversationId = conversationId.trim();
+  const conversationId = id.trim();
 
-  if (!normalizedConversationId || messages.length === 0) {
+  if (!conversationId || messages.length === 0) {
     return;
   }
 
   try {
-    const database = await openDatabase();
+    const database = await openDatabase(scopeKey);
 
     if (!database) {
       return;
     }
 
-    const transaction = database.transaction(ACTIVE_STORE, "readwrite");
+    const transaction = database.transaction(CONVERSATIONS_STORE, "readwrite");
     const transactionCompleted = transactionDone(transaction);
-    const store = transaction.objectStore(ACTIVE_STORE);
+    const store = transaction.objectStore(CONVERSATIONS_STORE);
+    const existingConversation = toConversationRecord(
+      await requestToPromise(store.get(conversationId))
+    );
 
-    const nextRecord: ActiveConversationRecord = {
-      key: ACTIVE_KEY,
-      conversationId: normalizedConversationId,
+    const now = Date.now();
+
+    const nextConversation: AIConversationRecord = {
+      id: conversationId,
       messages,
-      updatedAt: Date.now()
+      createdAt: existingConversation?.createdAt ?? now,
+      updatedAt: now
     };
 
-    await requestToPromise(store.put(nextRecord));
+    await requestToPromise(store.put(nextConversation));
 
     await transactionCompleted;
   } catch {
@@ -166,19 +252,79 @@ export async function saveActiveAIConversation(
   }
 }
 
-export async function clearActiveAIConversation(): Promise<void> {
+export async function deleteAIConversation(
+  conversationId: string,
+  scopeKey?: string
+): Promise<void> {
+  const normalizedConversationId = conversationId.trim();
+
+  if (!normalizedConversationId) {
+    return;
+  }
+
   try {
-    const database = await openDatabase();
+    const database = await openDatabase(scopeKey);
 
     if (!database) {
       return;
     }
 
-    const transaction = database.transaction(ACTIVE_STORE, "readwrite");
+    const transaction = database.transaction(
+      [CONVERSATIONS_STORE, META_STORE],
+      "readwrite"
+    );
     const transactionCompleted = transactionDone(transaction);
-    const store = transaction.objectStore(ACTIVE_STORE);
+    const conversationStore = transaction.objectStore(CONVERSATIONS_STORE);
+    const metaStore = transaction.objectStore(META_STORE);
 
-    await requestToPromise(store.delete(ACTIVE_KEY));
+    const activeConversationRecord = await requestToPromise(
+      metaStore.get(ACTIVE_CONVERSATION_KEY)
+    );
+    const activeConversationId = toActiveConversationId(
+      activeConversationRecord
+    );
+
+    await requestToPromise(conversationStore.delete(normalizedConversationId));
+
+    if (activeConversationId === normalizedConversationId) {
+      await requestToPromise(
+        metaStore.put({
+          key: ACTIVE_CONVERSATION_KEY,
+          value: null
+        } satisfies ConversationMetaRecord)
+      );
+    }
+
+    await transactionCompleted;
+  } catch {
+    // Ignore IndexedDB write failures.
+  }
+}
+
+export async function setActiveAIConversationId(
+  conversationId: string | null,
+  scopeKey?: string
+): Promise<void> {
+  try {
+    const database = await openDatabase(scopeKey);
+
+    if (!database) {
+      return;
+    }
+
+    const normalizedConversationId =
+      typeof conversationId === "string" ? conversationId.trim() || null : null;
+
+    const transaction = database.transaction(META_STORE, "readwrite");
+    const transactionCompleted = transactionDone(transaction);
+    const store = transaction.objectStore(META_STORE);
+
+    const nextMetaRecord: ConversationMetaRecord = {
+      key: ACTIVE_CONVERSATION_KEY,
+      value: normalizedConversationId
+    };
+
+    await requestToPromise(store.put(nextMetaRecord));
 
     await transactionCompleted;
   } catch {


### PR DESCRIPTION
- persist active AI conversation across refresh/navigation
- add local conversation history with resume + delete
- make AI chat popover default size viewport-based (50% width, 70% height)

resolves: https://github.com/flanksource/flanksource-ui/issues/2881