### PR TITLE
chore: add limit support + sorting in notification silence preview

### DIFF
--- a/src/api/services/notifications.ts
+++ b/src/api/services/notifications.ts
@@ -430,8 +430,8 @@ export const getNotificationSilencePreview = async ({
   if (recursive) {
     params.append("recursive", "true");
   }
-  if (limit != null) {
-    params.append("limit", limit.toString());
+  if (Number.isFinite(limit) && Number.isInteger(limit) && limit! > 0) {
+    params.append("limit", limit!.toString());
   }
 
   const res = await NotificationAPI.get(

--- a/src/components/Notifications/SilenceNotificationForm/NotificationSilenceForm.tsx
+++ b/src/components/Notifications/SilenceNotificationForm/NotificationSilenceForm.tsx
@@ -264,7 +264,8 @@ export default function NotificationSilenceForm({
         }
 
         const data = await getNotificationSilencePreview(params);
-        const sorted = (data || []).sort(
+        const previewItems = Array.isArray(data) ? data : [];
+        const sorted = [...previewItems].sort(
           (
             a: NotificationSendHistorySummary,
             b: NotificationSendHistorySummary
@@ -440,7 +441,7 @@ export default function NotificationSilenceForm({
                               <>
                                 <div className="mb-2 text-sm text-gray-600">
                                   {previewData.length} notification(s) will be
-                                  silenced :
+                                  silenced:
                                 </div>
                                 <div className="space-y-2">
                                   {previewData.map((notification, index) => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added an optional preview limit when fetching notification silence previews.
  * Previews now show notifications sorted by most recent first for better visibility.

* **Bug Fixes**
  * Improved error handling and clearer error display when generating silence previews.
  * Ensured loading state is correctly cleared after preview fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->