### PR TITLE
fix(view): preserve prefixed sort params in table filters

### DIFF
--- a/src/pages/audit-report/components/View/ViewTableFilterForm.tsx
+++ b/src/pages/audit-report/components/View/ViewTableFilterForm.tsx
@@ -17,20 +17,40 @@ function ViewTableFilterListener({
 }: ViewTableFilterFormProps): React.ReactElement {
   const { values, setFieldValue } =
     useFormikContext<Record<string, string | undefined>>();
-  const [tableParams, setTableParams] = usePrefixedSearchParams(tablePrefix);
+  const [tableParams, setTableParams] = usePrefixedSearchParams(
+    tablePrefix,
+    false
+  );
 
   useEffect(() => {
-    setTableParams(() => {
-      const newParams = new URLSearchParams();
+    setTableParams((current) => {
+      const newParams = new URLSearchParams(current);
+      let filtersChanged = false;
 
       filterFields.forEach((field) => {
-        const value = values[field];
-        if (value && value.toLowerCase() !== "all") {
-          newParams.set(field, value);
+        const rawValue = values[field];
+        const value =
+          rawValue && rawValue.toLowerCase() !== "all" ? rawValue : undefined;
+        const currentValue = current.get(field) ?? undefined;
+
+        if (value) {
+          if (currentValue !== value) {
+            newParams.set(field, value);
+            filtersChanged = true;
+          }
+          return;
+        }
+
+        if (currentValue != null) {
+          newParams.delete(field);
+          filtersChanged = true;
         }
       });
 
-      // Note: paramsToReset is handled by the prefixed hook
+      if (filtersChanged) {
+        newParams.delete("pageIndex");
+      }
+
       return newParams;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/audit-report/components/View/__tests__/ViewTableFilterForm.unit.test.tsx
+++ b/src/pages/audit-report/components/View/__tests__/ViewTableFilterForm.unit.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter, Route, Routes, useLocation } from "react-router-dom";
+import ViewTableFilterForm from "../ViewTableFilterForm";
+import { usePrefixedSearchParams } from "../../../../../hooks/usePrefixedSearchParams";
+
+const tablePrefix = "view_default_components";
+const filterField = "status";
+
+function RawSearchProbe() {
+  const location = useLocation();
+  return <div data-testid="raw-search">{location.search}</div>;
+}
+
+function PrefixedTableParamsProbe() {
+  const [params] = usePrefixedSearchParams(tablePrefix, false);
+  return <div data-testid="prefixed-search">{params.toString()}</div>;
+}
+
+function TestPage() {
+  return (
+    <ViewTableFilterForm
+      filterFields={[filterField]}
+      tablePrefix={tablePrefix}
+      defaultFieldValues={{ [filterField]: "healthy" }}
+    >
+      <>
+        <RawSearchProbe />
+        <PrefixedTableParamsProbe />
+      </>
+    </ViewTableFilterForm>
+  );
+}
+
+describe("ViewTableFilterForm", () => {
+  afterEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("preserves prefixed sorting params when default filters sync to the URL", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      `/?${tablePrefix}__sortBy=name&${tablePrefix}__sortOrder=asc&${tablePrefix}__pageIndex=2&${tablePrefix}__pageSize=50`
+    );
+
+    render(
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<TestPage />} />
+        </Routes>
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("prefixed-search")).toHaveTextContent(
+        "status=healthy"
+      );
+    });
+
+    const rawSearch = screen.getByTestId("raw-search").textContent ?? "";
+    const prefixedSearch =
+      screen.getByTestId("prefixed-search").textContent ?? "";
+
+    expect(rawSearch).toContain(`${tablePrefix}__sortBy=name`);
+    expect(rawSearch).toContain(`${tablePrefix}__sortOrder=asc`);
+    expect(rawSearch).not.toContain("?sortBy=name");
+    expect(rawSearch).not.toContain("&sortBy=name");
+    expect(rawSearch).not.toContain("?sortOrder=asc");
+    expect(rawSearch).not.toContain("&sortOrder=asc");
+
+    expect(prefixedSearch).toContain("sortBy=name");
+    expect(prefixedSearch).toContain("sortOrder=asc");
+    expect(prefixedSearch).toContain("pageSize=50");
+    expect(prefixedSearch).toContain("status=healthy");
+    expect(prefixedSearch).not.toContain("pageIndex=2");
+  });
+});


### PR DESCRIPTION
Use prefixed-only search params in ViewTableFilterForm so table filter sync does not rewrite sortBy and sortOrder as global URL params.

Add a router-backed regression test that starts with prefixed sort params in the URL and verifies they remain prefixed after default filters sync.


resolves: https://github.com/flanksource/flanksource-ui/issues/2904
resolves: https://github.com/flanksource/flanksource-ui/issues/2745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter parameter handling in audit reports to correctly preserve existing parameters and reset pagination when filters are modified.

* **Tests**
  * Added unit tests for the audit report filter component to verify filter values synchronize properly with URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->