### PR TITLE
perf(auth): make ory session check non-blocking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,2 @@
 - Do not hand-write Shadcn components. Use the shadcn CLI to add new components.
+- Use npm run build to build

--- a/src/components/Authentication/Kratos/KratosAuthSessionChecker.tsx
+++ b/src/components/Authentication/Kratos/KratosAuthSessionChecker.tsx
@@ -1,6 +1,5 @@
 import ory from "@flanksource-ui/components/Authentication/Kratos/ory/sdk";
 import { FeatureFlagsContextProvider } from "@flanksource-ui/context/FeatureFlagsContext";
-import { Session } from "@ory/client";
 import { AxiosError } from "axios";
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
@@ -10,28 +9,37 @@ type KratosAuthSessionCheckerProps = {
   children: React.ReactNode;
 };
 
+/**
+ * Validates the Ory session in the background without blocking rendering.
+ *
+ * The ory.toSession() call only matters for its HTTP status code (redirect to
+ * login on 401/403/422) — the response body is never used. The actual user
+ * identity, roles, and permissions come from /api/auth/whoami (via
+ * KratosAuthContextProvider). So there's no reason to gate the entire app on
+ * this call completing.
+ */
 export default function KratosAuthSessionChecker({
   children
 }: KratosAuthSessionCheckerProps) {
-  const [session, setSession] = useState<Session | undefined>();
-
+  const [isBrowserEnv, setIsBrowserEnv] = useState(false);
   const { push } = useRouter();
 
   useEffect(() => {
-    const getSession = async () => {
+    setIsBrowserEnv(true);
+  }, []);
+
+  useEffect(() => {
+    const checkSession = async () => {
       if (!isAuthEnabled()) {
         return;
       }
 
       try {
-        const { data } = await ory.toSession();
-        setSession(data);
+        await ory.toSession();
       } catch (err) {
         const url = encodeURIComponent(window.location.href);
         switch ((err as AxiosError).response?.status) {
           case 403:
-            push(`/login?aal=aal2&return_to=${url}`);
-            break;
           case 422:
             push(`/login?aal=aal2&return_to=${url}`);
             break;
@@ -44,10 +52,13 @@ export default function KratosAuthSessionChecker({
       }
     };
 
-    getSession();
+    checkSession();
   }, [push]);
 
-  if (isAuthEnabled() && !session) {
+  // Guard against SSR — BrowserRouter in children requires `document`.
+  // The old `!session` check was accidentally preventing this; now we
+  // gate on client mount explicitly instead of on the ory response.
+  if (!isBrowserEnv) {
     return null;
   }
 


### PR DESCRIPTION
The ory.toSession() call only needs the HTTP status code (to redirect on
401/403/422). The response body is never used — user identity, roles, and
permissions all come from /api/auth/whoami. Remove the render gate so
children mount immediately instead of waiting ~677ms for the session check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added build instructions

* **Refactor**
  * Authentication session validation now occurs without blocking initial page load
  * Enhanced server-side rendering compatibility in authentication flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->