### PR TITLE
feat: move pie chart legend right and use info tooltips

### DIFF
--- a/src/pages/audit-report/components/View/panels/BarGaugePanel.tsx
+++ b/src/pages/audit-report/components/View/panels/BarGaugePanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { PanelResult, BarGaugeConfig } from "../../../types";
+import PanelHeader from "./PanelHeader";
 import { getGaugeColor, formatDisplayValue } from "./utils";
 
 interface BarGaugePanelProps {
@@ -61,10 +62,7 @@ const BarGaugePanel: React.FC<BarGaugePanelProps> = ({ summary }) => {
 
   return (
     <div className="flex h-full w-full flex-col rounded-lg border border-gray-200 bg-white p-4">
-      <h4 className="mb-2 text-sm font-medium text-gray-600">{summary.name}</h4>
-      {summary.description && (
-        <p className="mb-3 text-xs text-gray-500">{summary.description}</p>
-      )}
+      <PanelHeader title={summary.name} description={summary.description} />
 
       <div className="flex flex-col gap-3">
         {summary.rows.map((row, rowIndex) => {

--- a/src/pages/audit-report/components/View/panels/DurationPanel.tsx
+++ b/src/pages/audit-report/components/View/panels/DurationPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { formatDuration } from "@flanksource-ui/utils/date";
 import { PanelResult } from "../../../types";
+import PanelHeader from "./PanelHeader";
 
 interface DurationPanelProps {
   summary: PanelResult;
@@ -27,14 +28,11 @@ const DurationPanel: React.FC<DurationPanelProps> = React.memo(
               key={`${summary.name}-${rowIndex}`}
               className="flex h-full w-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4"
             >
-              <h4 className="mb-2 text-sm font-medium capitalize text-gray-600">
-                {label || summary.name}
-              </h4>
-              {summary.description && (
-                <p className="mb-3 text-xs text-gray-500">
-                  {summary.description}
-                </p>
-              )}
+              <PanelHeader
+                title={label || summary.name}
+                description={summary.description}
+                titleClassName="capitalize"
+              />
               <div className="flex flex-1 items-center justify-center">
                 <p className="text-2xl font-semibold text-teal-600 md:text-3xl lg:text-4xl">
                   {formattedDuration}

--- a/src/pages/audit-report/components/View/panels/GaugePanel.tsx
+++ b/src/pages/audit-report/components/View/panels/GaugePanel.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from "react";
 import GaugeComponent, { SubArc } from "react-gauge-component";
 import { PanelResult, GaugeThreshold } from "../../../types";
+import PanelHeader from "./PanelHeader";
 import { formatDisplayValue } from "./utils";
 
 interface GaugePanelProps {
@@ -92,10 +93,7 @@ const GaugeItem: React.FC<GaugeItemProps> = ({ summary, row, rowIndex }) => {
       key={`${summary.name}-${rowIndex}`}
       className="flex h-full w-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4"
     >
-      <h4 className="mb-1 text-sm font-medium text-gray-600">{summary.name}</h4>
-      {summary.description && (
-        <p className="mb-3 text-xs text-gray-500">{summary.description}</p>
-      )}
+      <PanelHeader title={summary.name} description={summary.description} />
       <div
         ref={containerRef}
         className="flex flex-1 items-center justify-center overflow-hidden"

--- a/src/pages/audit-report/components/View/panels/NumberPanel.tsx
+++ b/src/pages/audit-report/components/View/panels/NumberPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { PanelResult } from "../../../types";
+import PanelHeader from "./PanelHeader";
 import { formatDisplayValue } from "./utils";
 
 interface NumberPanelProps {
@@ -23,14 +24,11 @@ const NumberPanel: React.FC<NumberPanelProps> = ({ summary }) => {
             key={`${summary.name}-${rowIndex}`}
             className="flex h-full w-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4"
           >
-            <h4 className="mb-2 text-sm font-medium capitalize text-gray-600">
-              {label || summary.name}
-            </h4>
-            {summary.description && (
-              <p className="mb-3 text-xs text-gray-500">
-                {summary.description}
-              </p>
-            )}
+            <PanelHeader
+              title={label || summary.name}
+              description={summary.description}
+              titleClassName="capitalize"
+            />
             <div className="flex flex-1 items-center justify-center">
               <p className="text-6xl font-bold sm:text-6xl md:text-6xl lg:text-6xl">
                 {summary.number

--- a/src/pages/audit-report/components/View/panels/PanelHeader.tsx
+++ b/src/pages/audit-report/components/View/panels/PanelHeader.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@flanksource-ui/components/ui/tooltip";
+import { cn } from "@flanksource-ui/lib/utils";
+
+interface PanelHeaderProps {
+  title: React.ReactNode;
+  description?: string;
+  className?: string;
+  titleClassName?: string;
+}
+
+const PanelHeader: React.FC<PanelHeaderProps> = ({
+  title,
+  description,
+  className,
+  titleClassName
+}) => {
+  return (
+    <div className={cn("mb-2 flex items-center gap-1.5", className)}>
+      <h4 className={cn("text-sm font-medium text-gray-600", titleClassName)}>
+        {title}
+      </h4>
+
+      {description ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="Show panel description"
+              className="inline-flex h-4 w-4 items-center justify-center text-gray-400 transition-colors hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <Info className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent
+            side="top"
+            className="max-w-xs whitespace-pre-wrap break-words bg-slate-900 text-white"
+          >
+            {description}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
+    </div>
+  );
+};
+
+export default PanelHeader;

--- a/src/pages/audit-report/components/View/panels/PieChartPanel.tsx
+++ b/src/pages/audit-report/components/View/panels/PieChartPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { PieChart, Pie, Cell } from "recharts";
 import { PanelResult } from "../../../types";
+import PanelHeader from "./PanelHeader";
 import { COLOR_PALETTE, getSeverityOfText, severityToHex } from "./utils";
 import {
   ChartConfig,
@@ -99,16 +100,13 @@ const PieChartPanel: React.FC<PieChartPanelProps> = ({ summary }) => {
 
   return (
     <div className="flex h-full min-h-[300px] w-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4">
-      <h4 className="mb-2 text-sm font-medium text-gray-600">{summary.name}</h4>
-      {summary.description && (
-        <p className="mb-3 text-xs text-gray-500">{summary.description}</p>
-      )}
+      <PanelHeader title={summary.name} description={summary.description} />
       <div className="flex flex-1 items-center justify-center">
         <ChartContainer
           config={chartConfig}
           className="flex h-full min-h-[240px] w-full flex-1 items-center justify-center"
         >
-          <PieChart>
+          <PieChart margin={{ top: 8, right: 80, bottom: 8, left: 8 }}>
             <ChartTooltip content={<ChartTooltipContent nameKey="name" />} />
             <Pie
               data={chartData}
@@ -125,7 +123,17 @@ const PieChartPanel: React.FC<PieChartPanelProps> = ({ summary }) => {
                 <Cell key={`cell-${entryIndex}`} fill={entry.fill} />
               ))}
             </Pie>
-            <ChartLegend content={<ChartLegendContent nameKey="name" />} />
+            <ChartLegend
+              layout="vertical"
+              align="right"
+              verticalAlign="middle"
+              content={
+                <ChartLegendContent
+                  nameKey="name"
+                  className="!w-auto !flex-col !items-start !gap-2 !pt-0"
+                />
+              }
+            />
           </PieChart>
         </ChartContainer>
       </div>

--- a/src/pages/audit-report/components/View/panels/PropertiesPanel.tsx
+++ b/src/pages/audit-report/components/View/panels/PropertiesPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { PanelResult } from "../../../types";
+import PanelHeader from "./PanelHeader";
 
 interface PropertiesPanelProps {
   summary: PanelResult;
@@ -8,12 +9,11 @@ interface PropertiesPanelProps {
 const PropertiesPanel: React.FC<PropertiesPanelProps> = ({ summary }) => {
   return (
     <div className="flex h-full w-full flex-col rounded-lg border border-gray-200 bg-white p-4">
-      <h4 className="mb-2 text-sm font-medium capitalize text-gray-600">
-        {summary.name}
-      </h4>
-      {summary.description && (
-        <p className="mb-3 text-xs text-gray-500">{summary.description}</p>
-      )}
+      <PanelHeader
+        title={summary.name}
+        description={summary.description}
+        titleClassName="capitalize"
+      />
       <div className="flex-1 space-y-3 overflow-y-auto">
         {summary.rows?.map((row, rowIndex) => {
           const { value, ...rest } = row;

--- a/src/pages/audit-report/components/View/panels/TablePanel.tsx
+++ b/src/pages/audit-report/components/View/panels/TablePanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { PanelResult } from "../../../types";
+import PanelHeader from "./PanelHeader";
 
 interface TablePanelProps {
   summary: PanelResult;
@@ -8,12 +9,11 @@ interface TablePanelProps {
 const TablePanel: React.FC<TablePanelProps> = React.memo(({ summary }) => {
   return (
     <div className="flex h-full w-full flex-col rounded-lg border border-gray-200 bg-white p-4">
-      <h4 className="mb-2 text-sm font-medium capitalize text-gray-600">
-        {summary.name}
-      </h4>
-      {summary.description && (
-        <p className="mb-3 text-xs text-gray-500">{summary.description}</p>
-      )}
+      <PanelHeader
+        title={summary.name}
+        description={summary.description}
+        titleClassName="capitalize"
+      />
       <div className="flex-1 overflow-y-auto">
         {summary.rows?.map((row, rowIndex) => {
           return (

--- a/src/pages/audit-report/components/View/panels/TextPanel.tsx
+++ b/src/pages/audit-report/components/View/panels/TextPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { PanelResult } from "../../../types";
+import PanelHeader from "./PanelHeader";
 
 interface TextPanelProps {
   summary: PanelResult;
@@ -16,14 +17,11 @@ const TextPanel: React.FC<TextPanelProps> = ({ summary }) => {
             key={`${summary.name}-${rowIndex}`}
             className="flex h-full w-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4"
           >
-            <h4 className="mb-2 text-sm font-medium capitalize text-gray-600">
-              {summary.name}
-            </h4>
-            {summary.description && (
-              <p className="mb-3 text-xs text-gray-500">
-                {summary.description}
-              </p>
-            )}
+            <PanelHeader
+              title={summary.name}
+              description={summary.description}
+              titleClassName="capitalize"
+            />
             <div className="overflow-hidden text-sm font-medium text-gray-800">
               {value}
             </div>

--- a/src/pages/audit-report/components/View/panels/TimeseriesPanel.tsx
+++ b/src/pages/audit-report/components/View/panels/TimeseriesPanel.tsx
@@ -20,6 +20,7 @@ import {
 import { formatTick, parseTimestamp } from "@flanksource-ui/lib/timeseries";
 import { getSeriesColor } from "./utils";
 import { buildEvenlySpacedRange } from "./timeRange";
+import PanelHeader from "./PanelHeader";
 
 interface TimeseriesPanelProps {
   summary: PanelResult;
@@ -203,10 +204,7 @@ const TimeseriesPanel: React.FC<TimeseriesPanelProps> = ({ summary }) => {
 
   return (
     <div className="flex h-full min-h-[250px] w-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4">
-      <h4 className="mb-2 text-sm font-medium text-gray-600">{summary.name}</h4>
-      {summary.description && (
-        <p className="mb-3 text-xs text-gray-500">{summary.description}</p>
-      )}
+      <PanelHeader title={summary.name} description={summary.description} />
 
       {hasNoRows || hasNoSeries ? (
         <div className="flex flex-1 items-center justify-center text-sm text-gray-500">


### PR DESCRIPTION
- add a shared panel header with an info icon tooltip for panel descriptions
- replace inline description text with the shared header across all view panel types
- move pie chart legend to a right-side vertical layout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified panel headers across the audit report for consistent title presentation and capitalization.
* **New Features**
  * Panel descriptions now appear as accessible info-tooltips on headers.
  * Pie charts receive improved spacing and a right-aligned vertical legend for clearer visualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->