### PR TITLE
fix(auth): filter proxy.disable property client-side

### DIFF
--- a/src/api/query-hooks/useFeatureFlags.tsx
+++ b/src/api/query-hooks/useFeatureFlags.tsx
@@ -50,7 +50,6 @@ export function useGetFeatureFlagsFromAPI() {
       const res = await fetchFeatureFlagsAPI();
       return res.data ?? [];
     },
-    enabled: true,
     cacheTime: 0,
     staleTime: 0
   });

--- a/src/hooks/useClerkAttachAuthInterceptorsToAxios.tsx
+++ b/src/hooks/useClerkAttachAuthInterceptorsToAxios.tsx
@@ -1,6 +1,5 @@
 import { useAuth, useOrganization } from "@clerk/nextjs";
 import {
-  apiBase,
   Auth,
   CanaryChecker,
   Config,
@@ -11,8 +10,8 @@ import {
   redirectToLoginPageOnSessionExpiry,
   Snapshot
 } from "@flanksource-ui/api/axios";
+import { useGetFeatureFlagsFromAPI } from "@flanksource-ui/api/query-hooks/useFeatureFlags";
 import { toastError } from "@flanksource-ui/components/Toast/toast";
-import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 
 const allAxiosInstances = [
@@ -53,16 +52,10 @@ export default function useClerkAttachAuthInterceptorsToAxios() {
 
   // Fetch the proxy.disable property from backend properties to allow
   // toggling direct mode without changing Clerk org metadata
-  const { data: proxyDisableProperty } = useQuery({
-    queryKey: ["properties", "proxy.disable"],
-    queryFn: async () => {
-      const response = await apiBase.get<{ name: string; value: string }[]>(
-        "/properties?name=eq.proxy.disable"
-      );
-      return response.data;
-    },
-    enabled: !!backendUrl
-  });
+  const { data: allProperties } = useGetFeatureFlagsFromAPI();
+  const proxyDisableProperty = allProperties?.filter(
+    (p) => p.name === "proxy.disable"
+  );
 
   // Property overrides org metadata; fall back to org metadata if property
   // doesn't exist


### PR DESCRIPTION
The backend GET /properties endpoint ignores PostgREST-style query
params (name=eq.proxy.disable) and returns all properties. The code
then checked if the array was non-empty and took the first item's
value, causing direct mode to activate incorrectly when any property
with value "true" existed.

Reuse useGetFeatureFlagsFromAPI and filter for proxy.disable
client-side instead of a separate query.

Ammends: https://github.com/flanksource/flanksource-ui/pull/2856

---

Ran into an issue where some of the queries were hitting direct backend while some were via proxy

<img width="1005" height="211" alt="image" src="https://github.com/user-attachments/assets/059d4846-6904-42ad-b4f4-e10ea3f98757" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal feature flag retrieval mechanism to consolidate API calls and improve code maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->