### PR TITLE
refactor(properties): deduplicate /api/properties fetches

### DIFF
--- a/src/api/query-hooks/useFeatureFlags.tsx
+++ b/src/api/query-hooks/useFeatureFlags.tsx
@@ -50,8 +50,7 @@ export function useGetFeatureFlagsFromAPI() {
       const res = await fetchFeatureFlagsAPI();
       return res.data ?? [];
     },
-    cacheTime: 0,
-    staleTime: 0
+    staleTime: 30 * 1000
   });
 }
 

--- a/src/context/FeatureFlagsContext.tsx
+++ b/src/context/FeatureFlagsContext.tsx
@@ -1,11 +1,5 @@
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState
-} from "react";
+import React, { createContext, useCallback, useContext, useMemo } from "react";
+import { useGetFeatureFlagsFromAPI } from "../api/query-hooks/useFeatureFlags";
 import { features } from "../services/permissions/features";
 import {
   FeatureFlag,
@@ -33,16 +27,15 @@ export const FeatureFlagsContextProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [featureFlags, setFeatureFlags] = useState(initialState.featureFlags);
-  const [featureFlagsLoaded, setFeatureFlagsLoaded] = useState(
-    initialState.featureFlagsLoaded
-  );
+  const {
+    data: featureFlags = [],
+    isSuccess,
+    refetch
+  } = useGetFeatureFlagsFromAPI();
 
-  const refreshFeatureFlags = useCallback(async () => {
-    const { data = [] } = await permissionService.loadProperties();
-    setFeatureFlags(data!);
-    setFeatureFlagsLoaded(true);
-  }, []);
+  const refreshFeatureFlags = useCallback(() => {
+    refetch();
+  }, [refetch]);
 
   const isFeatureDisabled = useCallback(
     (featureName: string) => {
@@ -51,18 +44,14 @@ export const FeatureFlagsContextProvider = ({
     [featureFlags]
   );
 
-  useEffect(() => {
-    refreshFeatureFlags();
-  }, []);
-
   const contextValue = useMemo(
     () => ({
       featureFlags,
-      featureFlagsLoaded,
+      featureFlagsLoaded: isSuccess,
       refreshFeatureFlags,
       isFeatureDisabled
     }),
-    [featureFlags, featureFlagsLoaded, refreshFeatureFlags, isFeatureDisabled]
+    [featureFlags, isSuccess, refreshFeatureFlags, isFeatureDisabled]
   );
 
   return (


### PR DESCRIPTION
FeatureFlagsContextProvider was fetching properties via a direct
useEffect call, bypassing React Query cache. This caused a duplicate
/api/properties request on every page load.

Refactor to use useGetFeatureFlagsFromAPI() so both the context and
the interceptor hook share the same React Query cache entry. Set
staleTime to 30s to prevent redundant refetches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced feature flag caching to reduce API requests and improve application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->