### PR TITLE
feat(table): add MRT row selection and bulk action controls

### DIFF
--- a/src/components/Permissions/PermissionsTable.tsx
+++ b/src/components/Permissions/PermissionsTable.tsx
@@ -4,6 +4,8 @@ import { Icon } from "@flanksource-ui/ui/Icons/Icon";
 import { MRTDateCell } from "@flanksource-ui/ui/MRTDataTable/Cells/MRTDateCells";
 import MRTDataTable from "@flanksource-ui/ui/MRTDataTable/MRTDataTable";
 import { MRT_ColumnDef } from "mantine-react-table";
+import { OnChangeFn, RowSelectionState } from "@tanstack/react-table";
+import type { ChangeEvent } from "react";
 import CanaryLink from "../Canary/CanaryLink";
 import ConfigLink from "../Configs/ConfigLink/ConfigLink";
 import ConnectionIcon from "../Connections/ConnectionIcon";
@@ -33,7 +35,6 @@ const permissionsTableColumns: MRT_ColumnDef<PermissionsSummary>[] = [
     id: "subject",
     accessorFn: (row) => row.subject,
     header: "Subject",
-    size: 80,
     Cell: ({ row }) => {
       const { team, group, person, subject, notification, playbook } =
         row.original;
@@ -112,7 +113,6 @@ const permissionsTableColumns: MRT_ColumnDef<PermissionsSummary>[] = [
     header: "Resource",
     enableHiding: true,
     enableSorting: false,
-    size: 150,
     Cell: ({ row }) => {
       const config = row.original.config_object;
       const playbook = row.original.playbook_object;
@@ -249,7 +249,6 @@ const permissionsTableColumns: MRT_ColumnDef<PermissionsSummary>[] = [
     id: "action",
     accessorFn: (row) => row.action,
     header: "Action",
-    size: 60,
     Cell: ({ row }) => {
       const action = row.original.action;
       const deny = row.original.deny;
@@ -280,19 +279,16 @@ const permissionsTableColumns: MRT_ColumnDef<PermissionsSummary>[] = [
     id: "description",
     header: "Description",
     enableSorting: false,
-    size: 200,
     accessorFn: (row) => row.description
   },
   {
     id: "updated_at",
-    size: 40,
     header: "Updated",
     accessorFn: (row) => row.updated_at,
     Cell: MRTDateCell
   },
   {
     id: "created_at",
-    size: 40,
     header: "Created",
     accessorFn: (row) => row.created_at,
     Cell: MRTDateCell
@@ -301,7 +297,6 @@ const permissionsTableColumns: MRT_ColumnDef<PermissionsSummary>[] = [
     id: "created_by",
     accessorFn: (row) => row.created_by,
     header: "Created By",
-    size: 40,
     Cell: ({ row }) => {
       const createdBy = row.original.created_by;
       const source = row.original.source;
@@ -325,6 +320,10 @@ type PermissionsTableProps = {
   isLoading: boolean;
   pageCount: number;
   totalEntries: number;
+  enableRowSelection?: boolean;
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  onSelectAllChange?: (checked: boolean) => void;
   handleRowClick?: (row: PermissionsSummary) => void;
   hideResourceColumn?: boolean;
 };
@@ -334,19 +333,84 @@ export default function PermissionsTable({
   isLoading,
   pageCount,
   totalEntries,
+  enableRowSelection = false,
+  rowSelection,
+  onRowSelectionChange,
+  onSelectAllChange,
   hideResourceColumn = false,
   handleRowClick = () => {}
 }: PermissionsTableProps) {
   return (
     <MRTDataTable
+      key={
+        enableRowSelection
+          ? "permissions-table-bulk"
+          : "permissions-table-default"
+      }
       columns={permissionsTableColumns}
       data={permissions}
+      defaultPageSize={5}
       isLoading={isLoading}
       manualPageCount={pageCount}
       totalRowCount={totalEntries}
       enableServerSidePagination
       enableServerSideSorting
+      enableRowSelection={enableRowSelection}
+      enableSelectAll={enableRowSelection}
+      getRowId={(row) => row.id}
+      rowSelection={rowSelection}
+      onRowSelectionChange={onRowSelectionChange}
+      mantineSelectCheckboxProps={{
+        size: "xs",
+        radius: "lg",
+        styles: {
+          icon: {
+            display: "none"
+          },
+          input: {
+            opacity: 0.9,
+            borderWidth: 1,
+            borderColor: "#d1d5db",
+            backgroundColor: "#f9fafb",
+            transition:
+              "opacity 120ms ease-in-out, border-color 120ms ease-in-out",
+            "&:hover, &:focus": {
+              opacity: 1,
+              borderColor: "#9ca3af"
+            }
+          }
+        }
+      }}
+      mantineSelectAllCheckboxProps={{
+        size: "xs",
+        radius: "lg",
+        onChange: (event: ChangeEvent<HTMLInputElement>) => {
+          onSelectAllChange?.(event.currentTarget.checked);
+        },
+        styles: {
+          icon: {
+            display: "none"
+          },
+          input: {
+            opacity: 0.9,
+            borderWidth: 1,
+            borderColor: "#d1d5db",
+            backgroundColor: "#f9fafb",
+            transition:
+              "opacity 120ms ease-in-out, border-color 120ms ease-in-out",
+            "&:hover, &:focus": {
+              opacity: 1,
+              borderColor: "#9ca3af"
+            }
+          }
+        }
+      }}
       onRowClick={handleRowClick}
+      displayColumnDefOptions={{
+        "mrt-row-select": {
+          maxSize: 36
+        }
+      }}
       hiddenColumns={hideResourceColumn ? ["Resource"] : []}
     />
   );

--- a/src/components/Permissions/PermissionsView.tsx
+++ b/src/components/Permissions/PermissionsView.tsx
@@ -9,8 +9,12 @@ import {
 import useReactTablePaginationState from "@flanksource-ui/ui/DataTable/Hooks/useReactTablePaginationState";
 import useReactTableSortState from "@flanksource-ui/ui/DataTable/Hooks/useReactTableSortState";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "..";
+import { toastSuccess } from "../Toast/toast";
+import useMrtBulkSelection, {
+  BulkSelectionPayload
+} from "@flanksource-ui/ui/MRTDataTable/Hooks/useMrtBulkSelection";
 import { FormikSelectDropdownOption } from "../Forms/Formik/FormikSelectDropdown";
 import PermissionForm from "./ManagePermissions/Forms/PermissionForm";
 import PermissionsTable from "./PermissionsTable";
@@ -72,13 +76,31 @@ export function getActionsForResourceType(
   return commonActions;
 }
 
+type SelectionScope = {
+  permissionRequest: FetchPermissionsInput;
+  sortBy?: string;
+  sortOrder: "asc" | "desc";
+};
+
+export type PermissionsBulkActionControls = {
+  hasSelectedRows: boolean;
+  selectionSummary: string;
+  onAllowSelected: () => void;
+  onDenySelected: () => void;
+  onClearSelection: () => void;
+};
+
 type PermissionsViewProps = {
   permissionRequest: FetchPermissionsInput;
   setIsLoading?: (isLoading: boolean) => void;
   hideResourceColumn?: boolean;
   newPermissionData?: Partial<PermissionTable>;
   showAddPermission?: boolean;
+  showInlineBulkActionControls?: boolean;
   onRefetch?: (refetch: () => void) => void;
+  onBulkActionControlsChange?: (
+    controls: PermissionsBulkActionControls
+  ) => void;
 };
 
 export default function PermissionsView({
@@ -87,7 +109,9 @@ export default function PermissionsView({
   hideResourceColumn = false,
   newPermissionData,
   showAddPermission = false,
-  onRefetch
+  showInlineBulkActionControls = true,
+  onRefetch,
+  onBulkActionControlsChange
 }: PermissionsViewProps) {
   const [selectedPermission, setSelectedPermission] =
     useState<PermissionsSummary>();
@@ -137,29 +161,151 @@ export default function PermissionsView({
 
   const totalEntries = data?.totalEntries || 0;
   const pageCount = totalEntries ? Math.ceil(totalEntries / pageSize) : 1;
-  const permissions = data?.data || [];
+  const permissions = useMemo(() => data?.data ?? [], [data?.data]);
+
+  const selectionScope = useMemo<SelectionScope>(
+    () => ({
+      permissionRequest,
+      sortBy: mappedSortBy,
+      sortOrder: sortState[0]?.desc ? "desc" : "asc"
+    }),
+    [mappedSortBy, permissionRequest, sortState]
+  );
+
+  const selectionResetKey = useMemo(
+    () => JSON.stringify(permissionRequest),
+    [permissionRequest]
+  );
+
+  const {
+    rowSelection,
+    selectedCount,
+    hasSelectedRows,
+    selectionSummary,
+    onRowSelectionChange: handleRowSelectionChange,
+    onSelectAllChange: handleSelectAllChange,
+    clearSelection: handleClearSelection,
+    buildPayload
+  } = useMrtBulkSelection<PermissionsSummary, SelectionScope>({
+    rows: permissions,
+    totalRowCount: totalEntries,
+    getRowId: (row) => row.id,
+    selectionScope,
+    resetKey: selectionResetKey
+  });
+
+  const handleBulkAction = useCallback(
+    (action: "allow" | "deny") => {
+      const payload: BulkSelectionPayload<SelectionScope> = buildPayload();
+
+      toastSuccess(
+        `${action === "allow" ? "Allow Selected" : "Deny Selected"} prepared for ${selectedCount} permission${selectedCount === 1 ? "" : "s"}`
+      );
+
+      // Frontend-only wiring for now. API call will use this payload in follow-up work.
+      void payload;
+    },
+    [buildPayload, selectedCount]
+  );
+
+  const handleAllowSelected = useCallback(() => {
+    handleBulkAction("allow");
+  }, [handleBulkAction]);
+
+  const handleDenySelected = useCallback(() => {
+    handleBulkAction("deny");
+  }, [handleBulkAction]);
+
+  useEffect(() => {
+    if (!onBulkActionControlsChange) {
+      return;
+    }
+
+    onBulkActionControlsChange({
+      hasSelectedRows,
+      selectionSummary,
+      onAllowSelected: handleAllowSelected,
+      onDenySelected: handleDenySelected,
+      onClearSelection: handleClearSelection
+    });
+  }, [
+    hasSelectedRows,
+    handleAllowSelected,
+    handleClearSelection,
+    handleDenySelected,
+    onBulkActionControlsChange,
+    selectionSummary
+  ]);
 
   return (
     <>
-      {showAddPermission && (
-        <div className="flex flex-row items-center justify-between p-2">
-          <Button
-            onClick={() => {
-              setIsPermissionModalOpen(true);
-            }}
-          >
-            Add Permission
-          </Button>
+      <div className="flex h-full min-h-0 flex-col">
+        {showAddPermission && (
+          <div className="mb-2 flex flex-row flex-wrap items-center gap-2">
+            <Button
+              onClick={() => {
+                setIsPermissionModalOpen(true);
+              }}
+            >
+              Add Permission
+            </Button>
+          </div>
+        )}
+
+        <div className="relative flex min-h-0 flex-1 flex-col">
+          {showInlineBulkActionControls && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-3 z-50 flex justify-center px-4">
+              <div
+                className={`pointer-events-auto flex flex-row flex-wrap items-center gap-1.5 rounded-xl border border-gray-300 bg-gray-100 px-2.5 py-1.5 shadow-lg transition-all duration-500 ease-out ${
+                  hasSelectedRows
+                    ? "translate-y-0 opacity-100"
+                    : "translate-y-2 opacity-0"
+                }`}
+              >
+                <span className="pr-1 text-xs font-medium text-gray-700">
+                  {selectionSummary}
+                </span>
+                <Button
+                  size="none"
+                  disabled={!hasSelectedRows}
+                  className="rounded border border-gray-400 bg-white px-2 py-1 text-xs leading-none text-gray-800 hover:bg-gray-50"
+                  onClick={handleAllowSelected}
+                >
+                  Allow Selected
+                </Button>
+                <Button
+                  size="none"
+                  disabled={!hasSelectedRows}
+                  className="rounded border border-gray-400 bg-gray-200 px-2 py-1 text-xs leading-none text-gray-800 hover:bg-gray-300"
+                  onClick={handleDenySelected}
+                >
+                  Deny Selected
+                </Button>
+                <Button
+                  size="none"
+                  className="rounded border border-gray-400 bg-white px-2 py-1 text-xs leading-none text-gray-800 hover:bg-gray-50"
+                  onClick={handleClearSelection}
+                >
+                  Clear
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <PermissionsTable
+            permissions={permissions}
+            isLoading={isLoading}
+            pageCount={pageCount}
+            totalEntries={totalEntries}
+            enableRowSelection
+            rowSelection={rowSelection}
+            onRowSelectionChange={handleRowSelectionChange}
+            onSelectAllChange={handleSelectAllChange}
+            handleRowClick={(row) => setSelectedPermission(row)}
+            hideResourceColumn={hideResourceColumn}
+          />
         </div>
-      )}
-      <PermissionsTable
-        permissions={permissions}
-        isLoading={isLoading}
-        pageCount={pageCount}
-        totalEntries={totalEntries}
-        handleRowClick={(row) => setSelectedPermission(row)}
-        hideResourceColumn={hideResourceColumn}
-      />
+      </div>
       {selectedPermission && (
         <PermissionForm
           isOpen={!!selectedPermission}

--- a/src/pages/Settings/PermissionsPage.tsx
+++ b/src/pages/Settings/PermissionsPage.tsx
@@ -90,7 +90,7 @@ export function PermissionsPage() {
         loading={isLoading}
       >
         <div className="flex h-full flex-col overflow-y-auto px-6 pb-0">
-          <div className="flex flex-row items-center py-4">
+          <div className="flex flex-row flex-wrap items-center justify-between gap-2 py-4">
             <ReactSelectDropdown
               name="permissions-action-filter"
               items={actionOptions}
@@ -110,7 +110,7 @@ export function PermissionsPage() {
               prefix={<span className="text-xs text-gray-500">Action:</span>}
             />
           </div>
-          <div className="flex h-full flex-col overflow-y-auto pb-6">
+          <div className="flex h-full flex-col overflow-y-auto p-2">
             <PermissionsView
               permissionRequest={{
                 ...(rawActionFilter !== "all"

--- a/src/ui/MRTDataTable/Hooks/useMrtBulkSelection.ts
+++ b/src/ui/MRTDataTable/Hooks/useMrtBulkSelection.ts
@@ -1,0 +1,256 @@
+import { OnChangeFn, RowSelectionState, Updater } from "@tanstack/react-table";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export type BulkSelectionState<S> =
+  | {
+      mode: "selective";
+      includedIds: Set<string>;
+    }
+  | {
+      mode: "all";
+      selectionScope: S;
+    }
+  | {
+      mode: "allExcept";
+      selectionScope: S;
+      excludedIds: Set<string>;
+    };
+
+export type BulkSelectionPayload<S> =
+  | { mode: "selective"; ids: string[] }
+  | { mode: "all"; ids: string[]; selectionScope: S }
+  | { mode: "allExcept"; ids: string[]; selectionScope: S };
+
+type UseMrtBulkSelectionOptions<T, S> = {
+  rows: T[];
+  totalRowCount: number;
+  getRowId: (row: T) => string;
+  selectionScope: S;
+  resetKey?: string;
+};
+
+const emptyBulkSelection = <S>(): BulkSelectionState<S> => ({
+  mode: "selective",
+  includedIds: new Set<string>()
+});
+
+function isIdSelected<S>(state: BulkSelectionState<S>, id: string) {
+  if (state.mode === "selective") {
+    return state.includedIds.has(id);
+  }
+
+  if (state.mode === "all") {
+    return true;
+  }
+
+  return !state.excludedIds.has(id);
+}
+
+function selectId<S>(
+  state: BulkSelectionState<S>,
+  id: string
+): BulkSelectionState<S> {
+  if (state.mode === "selective") {
+    const next = new Set(state.includedIds);
+    next.add(id);
+    return {
+      mode: "selective",
+      includedIds: next
+    };
+  }
+
+  if (state.mode === "all") {
+    return state;
+  }
+
+  const next = new Set(state.excludedIds);
+  next.delete(id);
+
+  if (next.size === 0) {
+    return {
+      mode: "all",
+      selectionScope: state.selectionScope
+    };
+  }
+
+  return {
+    mode: "allExcept",
+    selectionScope: state.selectionScope,
+    excludedIds: next
+  };
+}
+
+function deselectId<S>(
+  state: BulkSelectionState<S>,
+  id: string
+): BulkSelectionState<S> {
+  if (state.mode === "selective") {
+    const next = new Set(state.includedIds);
+    next.delete(id);
+    return {
+      mode: "selective",
+      includedIds: next
+    };
+  }
+
+  if (state.mode === "all") {
+    return {
+      mode: "allExcept",
+      selectionScope: state.selectionScope,
+      excludedIds: new Set([id])
+    };
+  }
+
+  const next = new Set(state.excludedIds);
+  next.add(id);
+  return {
+    mode: "allExcept",
+    selectionScope: state.selectionScope,
+    excludedIds: next
+  };
+}
+
+function countSelectedRows<S>(
+  state: BulkSelectionState<S>,
+  totalEntries: number
+) {
+  if (state.mode === "selective") {
+    return state.includedIds.size;
+  }
+
+  if (state.mode === "all") {
+    return totalEntries;
+  }
+
+  return Math.max(totalEntries - state.excludedIds.size, 0);
+}
+
+export default function useMrtBulkSelection<T, S>({
+  rows,
+  totalRowCount,
+  getRowId,
+  selectionScope,
+  resetKey
+}: UseMrtBulkSelectionOptions<T, S>) {
+  const [bulkSelection, setBulkSelection] = useState<BulkSelectionState<S>>(
+    emptyBulkSelection<S>
+  );
+
+  useEffect(() => {
+    if (resetKey === undefined) {
+      return;
+    }
+
+    setBulkSelection(emptyBulkSelection<S>());
+  }, [resetKey]);
+
+  const rowSelection = useMemo<RowSelectionState>(() => {
+    return rows.reduce<RowSelectionState>((acc, row) => {
+      const id = getRowId(row);
+      if (id && isIdSelected(bulkSelection, id)) {
+        acc[id] = true;
+      }
+      return acc;
+    }, {});
+  }, [bulkSelection, getRowId, rows]);
+
+  const selectedCount = useMemo(
+    () => countSelectedRows(bulkSelection, totalRowCount),
+    [bulkSelection, totalRowCount]
+  );
+
+  const hasSelectedRows = selectedCount > 0;
+
+  const selectionSummary =
+    bulkSelection.mode === "all"
+      ? `All ${selectedCount} selected`
+      : bulkSelection.mode === "allExcept"
+        ? `All selected except ${bulkSelection.excludedIds.size}`
+        : `${selectedCount} selected`;
+
+  const onRowSelectionChange = useCallback<OnChangeFn<RowSelectionState>>(
+    (updater: Updater<RowSelectionState>) => {
+      const nextRowSelection =
+        typeof updater === "function" ? updater(rowSelection) : updater;
+
+      setBulkSelection((previous) => {
+        let nextState = previous;
+
+        rows.forEach((row) => {
+          const id = getRowId(row);
+          if (!id) {
+            return;
+          }
+
+          const wasSelected = isIdSelected(nextState, id);
+          const isSelectedNow = !!nextRowSelection[id];
+
+          if (wasSelected === isSelectedNow) {
+            return;
+          }
+
+          nextState = isSelectedNow
+            ? selectId(nextState, id)
+            : deselectId(nextState, id);
+        });
+
+        return nextState;
+      });
+    },
+    [getRowId, rowSelection, rows]
+  );
+
+  const onSelectAllChange = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        setBulkSelection({
+          mode: "all",
+          selectionScope
+        });
+        return;
+      }
+
+      setBulkSelection(emptyBulkSelection<S>());
+    },
+    [selectionScope]
+  );
+
+  const clearSelection = useCallback(() => {
+    setBulkSelection(emptyBulkSelection<S>());
+  }, []);
+
+  const buildPayload = useCallback((): BulkSelectionPayload<S> => {
+    if (bulkSelection.mode === "selective") {
+      return {
+        mode: "selective",
+        ids: Array.from(bulkSelection.includedIds)
+      };
+    }
+
+    if (bulkSelection.mode === "all") {
+      return {
+        mode: "all",
+        ids: [],
+        selectionScope: bulkSelection.selectionScope
+      };
+    }
+
+    return {
+      mode: "allExcept",
+      ids: Array.from(bulkSelection.excludedIds),
+      selectionScope: bulkSelection.selectionScope
+    };
+  }, [bulkSelection]);
+
+  return {
+    bulkSelection,
+    rowSelection,
+    selectedCount,
+    hasSelectedRows,
+    selectionSummary,
+    onRowSelectionChange,
+    onSelectAllChange,
+    clearSelection,
+    buildPayload
+  };
+}

--- a/src/ui/MRTDataTable/MRTDataTable.tsx
+++ b/src/ui/MRTDataTable/MRTDataTable.tsx
@@ -1,7 +1,9 @@
 import { memo, useCallback, useMemo } from "react";
+import type { MouseEvent } from "react";
 import {
   GroupingState,
   OnChangeFn,
+  RowSelectionState,
   SortingState,
   VisibilityState
 } from "@tanstack/react-table";
@@ -16,6 +18,14 @@ import {
 } from "mantine-react-table";
 import useReactTablePaginationState from "../DataTable/Hooks/useReactTablePaginationState";
 import useReactTableSortState from "../DataTable/Hooks/useReactTableSortState";
+
+const defaultMantineSelectCheckboxProps = {
+  styles: {
+    icon: {
+      display: "none"
+    }
+  }
+};
 
 type MRTDataTableProps<T extends Record<string, any> = {}> = {
   data: T[];
@@ -44,11 +54,26 @@ type MRTDataTableProps<T extends Record<string, any> = {}> = {
   enableGrouping?: boolean;
   onGroupingChange?: OnChangeFn<GroupingState>;
   disableHiding?: boolean;
+
+  // //////////////////
+  // Row Selection stuff (https://www.mantine-react-table.com/docs/guides/row-selection#enable-row-selection)
+  // //////////////////
+  enableRowSelection?: boolean;
+  enableSelectAll?: boolean;
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  /** to derive a unique ID for any given row */
+  getRowId?: MRT_TableOptions<T>["getRowId"];
+  mantineSelectCheckboxProps?: MRT_TableOptions<T>["mantineSelectCheckboxProps"];
+  mantineSelectAllCheckboxProps?: MRT_TableOptions<T>["mantineSelectAllCheckboxProps"];
+  // --- End Row Selection ---
+
   mantineTableBodyRowProps?: {
     style?: Record<string, any>;
   };
   displayColumnDefOptions?: {
     "mrt-row-expand"?: Partial<MRT_ColumnDef<T>>;
+    "mrt-row-select"?: Partial<MRT_ColumnDef<T>>;
   };
   /** Prefix to namespace URL search params for sorting/pagination */
   urlParamPrefix?: string;
@@ -78,6 +103,13 @@ function MRTDataTableInner<T extends Record<string, any> = {}>({
   enableExpanding = false,
   onGroupingChange = () => {},
   disableHiding = false,
+  enableRowSelection = false,
+  enableSelectAll = false,
+  rowSelection,
+  onRowSelectionChange,
+  getRowId,
+  mantineSelectCheckboxProps,
+  mantineSelectAllCheckboxProps,
   mantineTableBodyRowProps,
   displayColumnDefOptions,
   urlParamPrefix,
@@ -128,6 +160,11 @@ function MRTDataTableInner<T extends Record<string, any> = {}>({
       "mrt-row-expand": {
         size: 100,
         ...displayColumnDefOptions?.["mrt-row-expand"]
+      },
+      "mrt-row-select": {
+        size: 40,
+        maxSize: 40,
+        ...displayColumnDefOptions?.["mrt-row-select"]
       }
     }),
     [displayColumnDefOptions]
@@ -135,7 +172,13 @@ function MRTDataTableInner<T extends Record<string, any> = {}>({
 
   const tableBodyRowProps = useCallback(
     ({ row }: { row: MRT_Row<T> }) => ({
-      onClick: () => onRowClick(row.original),
+      onClick: (event: MouseEvent<HTMLElement>) => {
+        const target = event.target as HTMLElement;
+        if (target.closest("a,button,input,[role='checkbox']")) {
+          return;
+        }
+        onRowClick(row.original);
+      },
       sx: { cursor: "pointer", maxHeight: "100%", overflowY: "auto" },
       ...mantineTableBodyRowProps
     }),
@@ -151,7 +194,6 @@ function MRTDataTableInner<T extends Record<string, any> = {}>({
         enableFilters: false,
         enableHiding: !disableHiding,
         enableExpanding,
-        enableSelectAll: false,
         enableFullScreenToggle: false,
         layoutMode: "grid",
         enableTopToolbar: false,
@@ -210,7 +252,8 @@ function MRTDataTableInner<T extends Record<string, any> = {}>({
             pageSize
           },
           sorting: sortState,
-          grouping: groupBy
+          grouping: groupBy,
+          rowSelection: rowSelection ?? {}
         },
         initialState: {
           ...initialState,
@@ -221,13 +264,31 @@ function MRTDataTableInner<T extends Record<string, any> = {}>({
         },
         mantineExpandButtonProps: { size: "xs" as const },
         mantineExpandAllButtonProps: { size: "xs" as const },
-        renderDetailPanel
+        renderDetailPanel,
+
+        //////////////////////////////
+        // Row Selection stuff
+        //////////////////////////////
+        selectDisplayMode: "checkbox",
+        getRowId,
+        enableSelectAll,
+        enableRowSelection,
+        enableMultiRowSelection: enableRowSelection,
+        mantineSelectCheckboxProps:
+          mantineSelectCheckboxProps ?? defaultMantineSelectCheckboxProps,
+        mantineSelectAllCheckboxProps:
+          mantineSelectAllCheckboxProps ?? defaultMantineSelectCheckboxProps,
+        onRowSelectionChange: enableRowSelection
+          ? onRowSelectionChange
+          : undefined
       }) as MRT_TableOptions<T>,
     [
       data,
       columns,
       disableHiding,
       enableExpanding,
+      enableRowSelection,
+      enableSelectAll,
       enableColumnActions,
       enableServerSideSorting,
       enableServerSidePagination,
@@ -236,6 +297,7 @@ function MRTDataTableInner<T extends Record<string, any> = {}>({
       setPageIndex,
       setSortState,
       onGroupingChange,
+      onRowSelectionChange,
       enableGrouping,
       mergedDisplayColumnDefOptions,
       tableBodyRowProps,
@@ -244,10 +306,14 @@ function MRTDataTableInner<T extends Record<string, any> = {}>({
       pageSize,
       sortState,
       groupBy,
+      rowSelection,
       isRefetching,
       columnVisibility,
       initialState,
       rowsPerPageOptions,
+      getRowId,
+      mantineSelectCheckboxProps,
+      mantineSelectAllCheckboxProps,
       renderDetailPanel
     ]
   );


### PR DESCRIPTION
Multiselect on MRT Table with bulk actions was added for the MCP settings permissions page.
But we decided we'll not use MRT table and bulk action for permissions.

Separated out the row selection and bulk action in this PR just in case we need it in future.