### PR TITLE
chore: reduce notification summary latency from repeated refetches

### DIFF
--- a/src/pages/Settings/notifications/NotificationsPage.tsx
+++ b/src/pages/Settings/notifications/NotificationsPage.tsx
@@ -18,7 +18,7 @@ export default function NotificationsPage() {
 
   const includeDeletedResources = useShowDeletedConfigs();
 
-  const { data, isLoading, refetch, isRefetching } = useQuery({
+  const { data, isLoading, isFetching, refetch } = useQuery({
     queryKey: [
       "notifications_send_history_summary",
       pageIndex,
@@ -42,9 +42,11 @@ export default function NotificationsPage() {
       return res;
     },
     keepPreviousData: true,
-    staleTime: 1000 * 60,
-    cacheTime: 1000 * 60 * 5
+    staleTime: 1000 * 60
   });
+
+  const isInitialLoading = isLoading;
+  const isRefetching = !isLoading && isFetching;
 
   const totalEntries = data?.total;
   const pageCount = totalEntries ? Math.ceil(totalEntries / pageSize) : -1;
@@ -53,13 +55,13 @@ export default function NotificationsPage() {
     <NotificationTabsLinks
       activeTab={"Notifications"}
       refresh={refetch}
-      isLoading={isLoading || isRefetching}
+      isLoading={isInitialLoading}
     >
       <div className="flex h-full w-full flex-1 flex-col p-3">
         <NotificationFilterBar />
         <NotificationSendHistorySummaryList
           data={data?.results ?? []}
-          isLoading={isLoading}
+          isLoading={isInitialLoading}
           isRefetching={isRefetching}
           pageCount={pageCount}
           sendHistoryRowCount={totalEntries ?? 0}

--- a/src/pages/Settings/notifications/NotificationsPage.tsx
+++ b/src/pages/Settings/notifications/NotificationsPage.tsx
@@ -42,8 +42,8 @@ export default function NotificationsPage() {
       return res;
     },
     keepPreviousData: true,
-    staleTime: 0,
-    cacheTime: 0
+    staleTime: 1000 * 60,
+    cacheTime: 1000 * 60 * 5
   });
 
   const totalEntries = data?.total;


### PR DESCRIPTION
/notification/summary is relatively slow, and immediate staleness was triggering unnecessary refetches. This change keeps results fresh for a short window so users see faster loads and fewer redundant backend calls.