### PR TITLE
feat: add jobs summary page with drilldown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -286,6 +286,10 @@ const JobsHistorySettingsPage = dynamic(
   () => import("./components/JobsHistory/JobsHistorySettingsPage")
 );
 
+const JobsHistoryDrilldownSettingsPage = dynamic(
+  () => import("./components/JobsHistory/JobsHistoryDrilldownSettingsPage")
+);
+
 const AgentsPage = dynamic(
   () => import("@flanksource-ui/components/Agents/AgentPage")
 );
@@ -778,6 +782,15 @@ export function IncidentManagerRoutes({ sidebar }: { sidebar: ReactNode }) {
           path="jobs"
           element={withAuthorizationAccessCheck(
             <JobsHistorySettingsPage />,
+            tables.database,
+            "read",
+            true
+          )}
+        />
+        <Route
+          path="jobs/:jobName"
+          element={withAuthorizationAccessCheck(
+            <JobsHistoryDrilldownSettingsPage />,
             tables.database,
             "read",
             true

--- a/src/api/query-hooks/useJobsHistoryQuery.ts
+++ b/src/api/query-hooks/useJobsHistoryQuery.ts
@@ -1,8 +1,14 @@
+import dayjs from "dayjs";
 import { durationOptions } from "@flanksource-ui/components/JobsHistory/Filters/JobHistoryDurationDropdown";
 import { jobHistoryDefaultDateFilter } from "@flanksource-ui/components/JobsHistory/Filters/JobsHistoryFilters";
 import { JobHistory } from "@flanksource-ui/components/JobsHistory/JobsHistoryTable";
 import { resourceTypeMap } from "@flanksource-ui/components/SchemaResourcePage/SchemaResourceEditJobsTab";
+import { parseDateMath } from "@flanksource-ui/ui/Dates/TimeRangePicker/parseDateMath";
 import useTimeRangeParams from "@flanksource-ui/ui/Dates/TimeRangePicker/useTimeRangeParams";
+import {
+  mappedOptionsTimeRanges,
+  MappedOptionsDisplay
+} from "@flanksource-ui/ui/Dates/TimeRangePicker/rangeOptions";
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -49,9 +55,7 @@ export function useJobsHistoryForSettingQuery(
   tableName?: keyof typeof resourceTypeMap,
   nameOverride?: string
 ) {
-  const { timeRangeAbsoluteValue } = useTimeRangeParams(
-    jobHistoryDefaultDateFilter
-  );
+  useTimeRangeParams(jobHistoryDefaultDateFilter);
 
   const [searchParams] = useSearchParams();
   const pageIndex = parseInt(searchParams.get("pageIndex") ?? "0");
@@ -68,8 +72,12 @@ export function useJobsHistoryForSettingQuery(
   const durationMillis = duration
     ? durationOptions[duration].valueInMillis
     : undefined;
-  const startsAt = timeRangeAbsoluteValue?.from ?? undefined;
-  const endsAt = timeRangeAbsoluteValue?.to ?? undefined;
+  const rangeType = searchParams.get("rangeType");
+  const range = searchParams.get("range");
+  const from = searchParams.get("from");
+  const to = searchParams.get("to");
+  const timeRange = searchParams.get("timeRange");
+
   const resourceType = useMemo(() => {
     if (!tableName) {
       return undefined;
@@ -85,15 +93,36 @@ export function useJobsHistoryForSettingQuery(
     status,
     sortBy,
     sortOrder,
-    startsAt,
-    endsAt,
     duration: durationMillis,
     resourceId
-  } satisfies GetJobsHistoryParams;
+  } satisfies Omit<GetJobsHistoryParams, "startsAt" | "endsAt">;
 
   return useQuery<Response, Error>(
-    ["jobs_history", params],
-    () => getJobsHistory(params),
+    ["jobs_history", params, rangeType, range, from, to, timeRange],
+    () => {
+      let startsAt: string | undefined;
+      let endsAt: string | undefined;
+
+      if (rangeType === "absolute") {
+        startsAt = from ? dayjs(from).toISOString() : undefined;
+        endsAt = to ? dayjs(to).toISOString() : undefined;
+      } else if (rangeType === "relative") {
+        startsAt = range ? parseDateMath(range, false) : undefined;
+        endsAt = undefined;
+      } else if (rangeType === "mapped") {
+        const mapped = mappedOptionsTimeRanges.get(
+          (timeRange ?? "") as MappedOptionsDisplay
+        )?.();
+        startsAt = mapped?.from ? parseDateMath(mapped.from, false) : undefined;
+        endsAt = mapped?.to ? parseDateMath(mapped.to, false) : undefined;
+      }
+
+      return getJobsHistory({
+        ...params,
+        startsAt,
+        endsAt
+      });
+    },
     options
   );
 }

--- a/src/api/query-hooks/useJobsHistoryQuery.ts
+++ b/src/api/query-hooks/useJobsHistoryQuery.ts
@@ -8,14 +8,25 @@ import { useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   getJobsHistory,
+  getJobsHistorySummary,
   getJobsHistoryWithArtifacts,
-  GetJobsHistoryParams
+  GetJobsHistoryParams,
+  GetJobsHistorySummaryParams,
+  JobHistorySummary
 } from "../services/jobsHistory";
 
 type Response =
   | { error: Error; data: null; totalEntries: undefined }
   | {
       data: JobHistory[] | null;
+      totalEntries?: number | undefined;
+      error: null;
+    };
+
+type SummaryResponse =
+  | { error: Error; data: null; totalEntries: undefined }
+  | {
+      data: JobHistorySummary[] | null;
       totalEntries?: number | undefined;
       error: null;
     };
@@ -35,7 +46,8 @@ export function useJobsHistoryQuery(
 export function useJobsHistoryForSettingQuery(
   options?: UseQueryOptions<Response, Error>,
   resourceId?: string,
-  tableName?: keyof typeof resourceTypeMap
+  tableName?: keyof typeof resourceTypeMap,
+  nameOverride?: string
 ) {
   const { timeRangeAbsoluteValue } = useTimeRangeParams(
     jobHistoryDefaultDateFilter
@@ -44,7 +56,11 @@ export function useJobsHistoryForSettingQuery(
   const [searchParams] = useSearchParams();
   const pageIndex = parseInt(searchParams.get("pageIndex") ?? "0");
   const pageSize = parseInt(searchParams.get("pageSize") ?? "150");
-  const name = searchParams.get("name") ?? "";
+  const name = nameOverride
+    ? nameOverride.includes(":")
+      ? nameOverride
+      : `${nameOverride}:1`
+    : (searchParams.get("name") ?? "");
   const sortBy = searchParams.get("sortBy") ?? "";
   const sortOrder = searchParams.get("sortOrder") ?? "desc";
   const status = searchParams.get("status") ?? "";
@@ -121,6 +137,32 @@ export function useScraperJobsHistoryForSettingQuery(
   return useQuery<Response, Error>(
     ["jobs_history", "scraper", params],
     () => getJobsHistoryWithArtifacts(params),
+    options
+  );
+}
+
+export function useJobsHistorySummaryForSettingQuery(
+  options?: UseQueryOptions<SummaryResponse, Error>
+) {
+  const [searchParams] = useSearchParams();
+
+  const pageIndex = parseInt(searchParams.get("pageIndex") ?? "0");
+  const pageSize = parseInt(searchParams.get("pageSize") ?? "50");
+  const name = searchParams.get("name") ?? "";
+  const sortBy = searchParams.get("sortBy") ?? "";
+  const sortOrder = searchParams.get("sortOrder") ?? "desc";
+
+  const params = {
+    pageIndex,
+    pageSize,
+    name,
+    sortBy,
+    sortOrder
+  } satisfies GetJobsHistorySummaryParams;
+
+  return useQuery<SummaryResponse, Error>(
+    ["job_history_summary", params],
+    () => getJobsHistorySummary(params),
     options
   );
 }

--- a/src/api/services/jobsHistory.ts
+++ b/src/api/services/jobsHistory.ts
@@ -67,6 +67,54 @@ export const getJobsHistory = async ({
   );
 };
 
+export type JobHistorySummary = {
+  name: string;
+  total: number;
+  running: number;
+  success: number;
+  warning: number;
+  failed: number;
+  stale: number;
+  skipped: number;
+  last_run_at: string;
+  average_duration: number | string | null;
+};
+
+export type GetJobsHistorySummaryParams = {
+  pageIndex: number;
+  pageSize: number;
+  name?: string;
+  sortBy?: string;
+  sortOrder?: string;
+};
+
+export const getJobsHistorySummary = async ({
+  pageIndex,
+  pageSize,
+  name,
+  sortBy,
+  sortOrder
+}: GetJobsHistorySummaryParams) => {
+  const pagingParams = `&limit=${pageSize}&offset=${pageIndex * pageSize}`;
+
+  const nameParam = name ? tristateOutputToQueryFilterParam(name, "name") : "";
+
+  const sortByParam = sortBy ? `&order=${sortBy}` : "&order=last_run_at";
+
+  const sortOrderParam = sortOrder ? `.${sortOrder}` : ".desc";
+
+  return resolvePostGrestRequestWithPagination(
+    IncidentCommander.get<JobHistorySummary[] | null>(
+      `/job_history_summary?select=*${pagingParams}${nameParam}${sortByParam}${sortOrderParam}`,
+      {
+        headers: {
+          Prefer: "count=exact"
+        }
+      }
+    )
+  );
+};
+
 export type JobHistoryNames = {
   name: string;
 };

--- a/src/api/services/jobsHistory.ts
+++ b/src/api/services/jobsHistory.ts
@@ -50,11 +50,18 @@ export const getJobsHistory = async ({
 
   const durationParam = duration ? `&duration_millis=gte.${duration}` : "";
 
-  const rangeParam = startsAt
-    ? endsAt
-      ? `&and=(created_at.gt.${startsAt},created_at.lt.${endsAt})`
-      : `&created_at=gt.${startsAt}`
-    : "";
+  const rangeParam = (() => {
+    if (startsAt && endsAt) {
+      return `&and=(created_at.gt.${startsAt},created_at.lt.${endsAt})`;
+    }
+    if (startsAt) {
+      return `&created_at=gt.${startsAt}`;
+    }
+    if (endsAt) {
+      return `&created_at=lt.${endsAt}`;
+    }
+    return "";
+  })();
 
   return resolvePostGrestRequestWithPagination(
     IncidentCommander.get<JobHistory[] | null>(

--- a/src/api/services/jobsHistory.ts
+++ b/src/api/services/jobsHistory.ts
@@ -50,10 +50,11 @@ export const getJobsHistory = async ({
 
   const durationParam = duration ? `&duration_millis=gte.${duration}` : "";
 
-  const rangeParam =
-    startsAt && endsAt
+  const rangeParam = startsAt
+    ? endsAt
       ? `&and=(created_at.gt.${startsAt},created_at.lt.${endsAt})`
-      : "";
+      : `&created_at=gt.${startsAt}`
+    : "";
 
   return resolvePostGrestRequestWithPagination(
     IncidentCommander.get<JobHistory[] | null>(

--- a/src/components/JobsHistory/Filters/JobsHistoryFilters.tsx
+++ b/src/components/JobsHistory/Filters/JobsHistoryFilters.tsx
@@ -15,27 +15,37 @@ export const jobHistoryDefaultDateFilter: URLSearchParamsInit = {
 
 type JobHistoryFiltersProps = {
   paramsToReset?: string[];
+  showJobNameDropdown?: boolean;
+  defaultStatusFilter?: string | null;
 };
 
 export default function JobHistoryFilters({
-  paramsToReset = ["pageIndex", "pageSize"]
+  paramsToReset = ["pageIndex", "pageSize"],
+  showJobNameDropdown = true,
+  defaultStatusFilter = ""
 }: JobHistoryFiltersProps) {
   const { setTimeRangeParams, getTimeRangeFromUrl } = useTimeRangeParams(
     jobHistoryDefaultDateFilter
   );
 
   const timeRangeValue = getTimeRangeFromUrl();
+  const defaultFieldValues = defaultStatusFilter
+    ? { status: defaultStatusFilter }
+    : undefined;
 
   return (
     <FormikFilterForm
       paramsToReset={paramsToReset}
-      filterFields={["name", "resource_type", "status", "duration"]}
-      defaultFieldValues={{
-        status: "SUCCESS:-1"
-      }}
+      filterFields={[
+        ...(showJobNameDropdown ? ["name"] : []),
+        "resource_type",
+        "status",
+        "duration"
+      ]}
+      defaultFieldValues={defaultFieldValues}
     >
       <div className="flex flex-wrap gap-2 py-4">
-        <JobHistoryNamesDropdown />
+        {showJobNameDropdown && <JobHistoryNamesDropdown />}
 
         <JobHistoryResourceTypeDropdown />
 

--- a/src/components/JobsHistory/JobHistoryOverridesDialog.tsx
+++ b/src/components/JobsHistory/JobHistoryOverridesDialog.tsx
@@ -30,7 +30,7 @@ import {
 import { formatJobName } from "@flanksource-ui/utils/common";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type DisableProperty = {
   name: string;
@@ -116,6 +116,13 @@ const upsertProperty = async (
   }
 };
 
+const ignoreNotFound = (error: unknown) => {
+  if (isAxiosError(error) && error.response?.status === 404) {
+    return;
+  }
+  throw error;
+};
+
 export default function JobHistoryOverridesDialog({
   open,
   jobName,
@@ -162,12 +169,13 @@ export default function JobHistoryOverridesDialog({
   }, [jobName, safeProperties]);
 
   const [values, setValues] = useState<Record<string, string>>(initialValues);
+  const wasOpenRef = useRef(open);
 
   useEffect(() => {
-    if (!open) {
-      return;
+    if (open && !wasOpenRef.current) {
+      setValues(initialValues);
     }
-    setValues(initialValues);
+    wasOpenRef.current = open;
   }, [initialValues, open]);
 
   const saveMutation = useMutation({
@@ -188,13 +196,13 @@ export default function JobHistoryOverridesDialog({
 
           if (value === "") {
             operations.push(
-              deleteProperty({ name: disabledName }).catch(() => {}),
-              deleteProperty({ name: legacyDisabledName }).catch(() => {})
+              deleteProperty({ name: disabledName }).catch(ignoreNotFound),
+              deleteProperty({ name: legacyDisabledName }).catch(ignoreNotFound)
             );
           } else {
             operations.push(upsertProperty(disabledName, value, user.user?.id));
             operations.push(
-              deleteProperty({ name: legacyDisabledName }).catch(() => {})
+              deleteProperty({ name: legacyDisabledName }).catch(ignoreNotFound)
             );
           }
 
@@ -204,7 +212,7 @@ export default function JobHistoryOverridesDialog({
         const propertyName = `${prefix}${field.key}`;
         if (value === "") {
           operations.push(
-            deleteProperty({ name: propertyName }).catch(() => {})
+            deleteProperty({ name: propertyName }).catch(ignoreNotFound)
           );
         } else {
           operations.push(upsertProperty(propertyName, value, user.user?.id));

--- a/src/components/JobsHistory/JobHistoryOverridesDialog.tsx
+++ b/src/components/JobsHistory/JobHistoryOverridesDialog.tsx
@@ -1,0 +1,313 @@
+import {
+  toastError,
+  toastSuccess
+} from "@flanksource-ui/components/Toast/toast";
+import { Button } from "@flanksource-ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@flanksource-ui/components/ui/dialog";
+import { Input } from "@flanksource-ui/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@flanksource-ui/components/ui/select";
+import { Switch } from "@flanksource-ui/components/ui/switch";
+import { useUser } from "@flanksource-ui/context";
+import {
+  deleteProperty,
+  fetchProperties,
+  saveProperty,
+  updateProperty
+} from "@flanksource-ui/api/services/properties";
+import { formatJobName } from "@flanksource-ui/utils/common";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+
+type DisableProperty = {
+  name: string;
+  value: string;
+};
+
+type JobHistoryOverridesDialogProps = {
+  open: boolean;
+  jobName?: string;
+  onOpenChange: (open: boolean) => void;
+};
+
+type OverrideField = {
+  key: string;
+  label: string;
+  description: string;
+  type: "string" | "number" | "switch" | "select";
+};
+
+const overrideFields: OverrideField[] = [
+  {
+    key: "schedule",
+    label: "Schedule",
+    description: "Cron expression that overrides the job's run schedule.",
+    type: "string"
+  },
+  {
+    key: "retention.success",
+    label: "Retention Success",
+    description: "Number of successful runs to retain in history.",
+    type: "number"
+  },
+  {
+    key: "retention.failed",
+    label: "Retention Failed",
+    description: "Number of failed runs to retain in history.",
+    type: "number"
+  },
+  {
+    key: "db-log-level",
+    label: "Log Level",
+    description: "Override SQL logging verbosity for this job.",
+    type: "select"
+  },
+  {
+    key: "disabled",
+    label: "Disable",
+    description:
+      "Disable job execution before it starts and before history is recorded.",
+    type: "switch"
+  }
+];
+
+const supportedLogLevels = ["info", "debug", "trace", "warn", "error"] as const;
+
+const upsertProperty = async (
+  name: string,
+  value: string,
+  userID?: string
+): Promise<void> => {
+  const payload = {
+    name,
+    value,
+    created_by: userID
+  };
+
+  const createResponse = await saveProperty(payload);
+  if (!createResponse.data) {
+    const updateResponse = await updateProperty(payload);
+    if (!updateResponse.data) {
+      throw new Error(
+        createResponse.error?.message ??
+          updateResponse.error?.message ??
+          `Failed to update ${name}`
+      );
+    }
+  }
+};
+
+export default function JobHistoryOverridesDialog({
+  open,
+  jobName,
+  onOpenChange
+}: JobHistoryOverridesDialogProps) {
+  const user = useUser();
+
+  const { data: properties = [] } = useQuery({
+    queryKey: ["job_history_overrides", "properties", jobName],
+    queryFn: async () => {
+      const response = await fetchProperties();
+      return (response.data ?? []) as DisableProperty[];
+    },
+    enabled: open && !!jobName,
+    staleTime: 0
+  });
+
+  const initialValues = useMemo(() => {
+    const values: Record<string, string> = {};
+    if (!jobName) {
+      return values;
+    }
+
+    const prefix = `jobs.${jobName}.`;
+    const byName = new Map(
+      properties.map((property) => [property.name, property.value])
+    );
+
+    for (const field of overrideFields) {
+      if (field.key === "disabled") {
+        values[field.key] =
+          byName.get(`${prefix}disabled`) ??
+          byName.get(`${prefix}disable`) ??
+          "";
+        continue;
+      }
+
+      values[field.key] = byName.get(`${prefix}${field.key}`) ?? "";
+    }
+
+    return values;
+  }, [jobName, properties]);
+
+  const [values, setValues] = useState<Record<string, string>>(initialValues);
+
+  useEffect(() => {
+    setValues(initialValues);
+  }, [initialValues, open]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      if (!jobName) {
+        return;
+      }
+
+      const prefix = `jobs.${jobName}.`;
+      const operations: Promise<any>[] = [];
+
+      for (const field of overrideFields) {
+        const value = values[field.key] ?? "";
+
+        if (field.key === "disabled") {
+          const disabledName = `${prefix}disabled`;
+          const legacyDisabledName = `${prefix}disable`;
+
+          if (value === "") {
+            operations.push(
+              deleteProperty({ name: disabledName }).catch(() => {}),
+              deleteProperty({ name: legacyDisabledName }).catch(() => {})
+            );
+          } else {
+            operations.push(upsertProperty(disabledName, value, user.user?.id));
+            operations.push(
+              deleteProperty({ name: legacyDisabledName }).catch(() => {})
+            );
+          }
+
+          continue;
+        }
+
+        const propertyName = `${prefix}${field.key}`;
+        if (value === "") {
+          operations.push(
+            deleteProperty({ name: propertyName }).catch(() => {})
+          );
+        } else {
+          operations.push(upsertProperty(propertyName, value, user.user?.id));
+        }
+      }
+
+      const results = await Promise.allSettled(operations);
+      const failures = results.filter((result) => result.status === "rejected");
+      if (failures.length > 0) {
+        throw new Error("Failed to save one or more overrides");
+      }
+    },
+    onSuccess: () => {
+      toastSuccess("Job overrides updated");
+      onOpenChange(false);
+    },
+    onError: (error) => {
+      toastError((error as Error).message);
+    }
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>
+            Edit Job Overrides {jobName ? `- ${formatJobName(jobName)}` : ""}
+          </DialogTitle>
+          <DialogDescription>
+            Configure property overrides for this job. Leave a field empty to
+            use the default behavior.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4">
+          {overrideFields.map((field) => (
+            <div className="grid grid-cols-3 items-start gap-4" key={field.key}>
+              <div>
+                <label className="text-sm font-medium text-gray-700">
+                  {field.label}
+                </label>
+                <p className="mt-1 text-xs text-gray-500">
+                  {field.description}
+                </p>
+              </div>
+
+              <div className="col-span-2">
+                {field.type === "switch" ? (
+                  <Switch
+                    className="data-[state=checked]:bg-red-600"
+                    checked={values[field.key] === "true"}
+                    onCheckedChange={(checked) => {
+                      setValues((current) => ({
+                        ...current,
+                        [field.key]: checked ? "true" : ""
+                      }));
+                    }}
+                  />
+                ) : field.type === "select" ? (
+                  <Select
+                    value={values[field.key] || "__default__"}
+                    onValueChange={(value) => {
+                      setValues((current) => ({
+                        ...current,
+                        [field.key]: value === "__default__" ? "" : value
+                      }));
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Default" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__default__">Default</SelectItem>
+                      {supportedLogLevels.map((level) => (
+                        <SelectItem key={level} value={level}>
+                          {level}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <Input
+                    type={field.type === "number" ? "number" : "text"}
+                    value={values[field.key] ?? ""}
+                    onChange={(event) => {
+                      const nextValue = event.target.value;
+                      setValues((current) => ({
+                        ...current,
+                        [field.key]: nextValue
+                      }));
+                    }}
+                    placeholder="Default"
+                  />
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={saveMutation.isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => saveMutation.mutate()}
+            disabled={saveMutation.isLoading}
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/JobsHistory/JobHistoryOverridesDialog.tsx
+++ b/src/components/JobsHistory/JobHistoryOverridesDialog.tsx
@@ -29,6 +29,7 @@ import {
 } from "@flanksource-ui/api/services/properties";
 import { formatJobName } from "@flanksource-ui/utils/common";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 import { useEffect, useMemo, useState } from "react";
 
 type DisableProperty = {
@@ -96,16 +97,21 @@ const upsertProperty = async (
     created_by: userID
   };
 
-  const createResponse = await saveProperty(payload);
-  if (!createResponse.data) {
-    const updateResponse = await updateProperty(payload);
-    if (!updateResponse.data) {
-      throw new Error(
-        createResponse.error?.message ??
-          updateResponse.error?.message ??
-          `Failed to update ${name}`
-      );
+  try {
+    await saveProperty(payload);
+    return;
+  } catch (error) {
+    const code = isAxiosError(error)
+      ? (error.response?.data as { code?: string } | undefined)?.code
+      : undefined;
+
+    // If the property already exists, update it instead.
+    if (code === "23505") {
+      await updateProperty(payload);
+      return;
     }
+
+    throw error;
   }
 };
 

--- a/src/components/JobsHistory/JobHistoryOverridesDialog.tsx
+++ b/src/components/JobsHistory/JobHistoryOverridesDialog.tsx
@@ -85,6 +85,7 @@ const overrideFields: OverrideField[] = [
 ];
 
 const supportedLogLevels = ["info", "debug", "trace", "warn", "error"] as const;
+const EMPTY_PROPERTIES: DisableProperty[] = [];
 
 const upsertProperty = async (
   name: string,
@@ -122,7 +123,7 @@ export default function JobHistoryOverridesDialog({
 }: JobHistoryOverridesDialogProps) {
   const user = useUser();
 
-  const { data: properties = [] } = useQuery({
+  const { data: properties } = useQuery({
     queryKey: ["job_history_overrides", "properties", jobName],
     queryFn: async () => {
       const response = await fetchProperties();
@@ -132,6 +133,8 @@ export default function JobHistoryOverridesDialog({
     staleTime: 0
   });
 
+  const safeProperties = properties ?? EMPTY_PROPERTIES;
+
   const initialValues = useMemo(() => {
     const values: Record<string, string> = {};
     if (!jobName) {
@@ -140,7 +143,7 @@ export default function JobHistoryOverridesDialog({
 
     const prefix = `jobs.${jobName}.`;
     const byName = new Map(
-      properties.map((property) => [property.name, property.value])
+      safeProperties.map((property) => [property.name, property.value])
     );
 
     for (const field of overrideFields) {
@@ -156,11 +159,14 @@ export default function JobHistoryOverridesDialog({
     }
 
     return values;
-  }, [jobName, properties]);
+  }, [jobName, safeProperties]);
 
   const [values, setValues] = useState<Record<string, string>>(initialValues);
 
   useEffect(() => {
+    if (!open) {
+      return;
+    }
     setValues(initialValues);
   }, [initialValues, open]);
 

--- a/src/components/JobsHistory/JobHistorySummary.tsx
+++ b/src/components/JobsHistory/JobHistorySummary.tsx
@@ -1,9 +1,20 @@
+import { toastError } from "@flanksource-ui/components/Toast/toast";
+import { Switch } from "@flanksource-ui/components/ui/switch";
+import { useUser } from "@flanksource-ui/context";
+import {
+  deleteProperty,
+  fetchProperties,
+  saveProperty,
+  updateProperty
+} from "@flanksource-ui/api/services/properties";
 import { JobHistorySummary as JobHistorySummaryType } from "@flanksource-ui/api/services/jobsHistory";
 import { MRTDateCell } from "@flanksource-ui/ui/MRTDataTable/Cells/MRTDateCells";
 import MRTDataTable from "@flanksource-ui/ui/MRTDataTable/MRTDataTable";
 import { formatJobName } from "@flanksource-ui/utils/common";
 import { formatDuration } from "@flanksource-ui/utils/date";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { MRT_ColumnDef } from "mantine-react-table";
+import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 type JobHistorySummaryProps = {
@@ -14,85 +25,11 @@ type JobHistorySummaryProps = {
   totalEntries?: number;
 };
 
-const columns: MRT_ColumnDef<JobHistorySummaryType>[] = [
-  {
-    header: "Job Name",
-    id: "name",
-    accessorKey: "name",
-    minSize: 220,
-    Cell: ({ row }) => <span>{formatJobName(row.original.name)}</span>
-  },
-  {
-    header: "Total",
-    id: "total",
-    accessorKey: "total",
-    size: 70
-  },
-  {
-    header: "Success",
-    id: "success",
-    accessorKey: "success",
-    size: 70
-  },
-  {
-    header: "Failed",
-    id: "failed",
-    accessorKey: "failed",
-    size: 70,
-    Cell: ({ row }) => (
-      <span className={row.original.failed > 0 ? "text-red-500" : ""}>
-        {row.original.failed}
-      </span>
-    )
-  },
-  {
-    header: "Warning",
-    id: "warning",
-    accessorKey: "warning",
-    size: 70
-  },
-  {
-    header: "Running",
-    id: "running",
-    accessorKey: "running",
-    size: 70
-  },
-  {
-    header: "Stale",
-    id: "stale",
-    accessorKey: "stale",
-    size: 70
-  },
-  {
-    header: "Skipped",
-    id: "skipped",
-    accessorKey: "skipped",
-    size: 70
-  },
-  {
-    header: "Last Run",
-    id: "last_run_at",
-    accessorKey: "last_run_at",
-    size: 90,
-    Cell: MRTDateCell
-  },
-  {
-    header: "Average Duration",
-    id: "average_duration",
-    accessorKey: "average_duration",
-    size: 100,
-    Cell: ({ row }) => {
-      const rawValue = row.original.average_duration;
-      const duration = Number(rawValue ?? 0);
+const getJobDisabledPropertyName = (jobName: string) =>
+  `jobs.${jobName}.disabled`;
 
-      if (!Number.isFinite(duration) || duration <= 0) {
-        return <span>-</span>;
-      }
-
-      return <span>{formatDuration(duration)}</span>;
-    }
-  }
-];
+const getLegacyJobDisabledPropertyName = (jobName: string) =>
+  `jobs.${jobName}.disable`;
 
 export default function JobHistorySummary({
   data,
@@ -102,6 +39,175 @@ export default function JobHistorySummary({
   totalEntries
 }: JobHistorySummaryProps) {
   const navigate = useNavigate();
+  const user = useUser();
+  const queryClient = useQueryClient();
+
+  const { data: properties = [] } = useQuery({
+    queryKey: ["job_history_summary", "disabled_properties"],
+    queryFn: async () => {
+      const response = await fetchProperties();
+      return response.data ?? [];
+    },
+    staleTime: 5000
+  });
+
+  const disabledJobs = useMemo(() => {
+    return new Set(
+      properties
+        .filter((property) => {
+          if (property.value !== "true") {
+            return false;
+          }
+
+          const isDisabled = property.name.endsWith(".disabled");
+          const isLegacyDisabled = property.name.endsWith(".disable");
+          return isDisabled || isLegacyDisabled;
+        })
+        .map((property) => {
+          if (property.name.endsWith(".disabled")) {
+            return property.name.slice(5, -9);
+          }
+          return property.name.slice(5, -8);
+        })
+    );
+  }, [properties]);
+
+  const toggleJobMutation = useMutation({
+    mutationFn: async ({
+      jobName,
+      disabled
+    }: {
+      jobName: string;
+      disabled: boolean;
+    }) => {
+      const propertyName = getJobDisabledPropertyName(jobName);
+      const legacyPropertyName = getLegacyJobDisabledPropertyName(jobName);
+
+      if (disabled) {
+        const payload = {
+          name: propertyName,
+          value: "true",
+          created_by: user.user?.id
+        };
+
+        const createResponse = await saveProperty(payload);
+        if (!createResponse.data) {
+          const updateResponse = await updateProperty(payload);
+          if (!updateResponse.data) {
+            throw new Error(
+              createResponse.error?.message ??
+                updateResponse.error?.message ??
+                "Failed to disable job"
+            );
+          }
+        }
+
+        await deleteProperty({ name: legacyPropertyName });
+        return;
+      }
+
+      await Promise.all([
+        deleteProperty({ name: propertyName }),
+        deleteProperty({ name: legacyPropertyName })
+      ]);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["job_history_summary", "disabled_properties"]
+      });
+    },
+    onError: (error) => {
+      toastError((error as Error).message);
+    }
+  });
+
+  const columns: MRT_ColumnDef<JobHistorySummaryType>[] = [
+    {
+      header: "Job Name",
+      id: "name",
+      accessorKey: "name",
+      minSize: 220,
+      Cell: ({ row }) => <span>{formatJobName(row.original.name)}</span>
+    },
+    {
+      header: "Average Duration",
+      id: "average_duration",
+      accessorKey: "average_duration",
+      size: 100,
+      Cell: ({ row }) => {
+        const rawValue = row.original.average_duration;
+        const duration = Number(rawValue ?? 0);
+
+        if (!Number.isFinite(duration) || duration <= 0) {
+          return <span>-</span>;
+        }
+
+        return <span>{formatDuration(duration)}</span>;
+      }
+    },
+    {
+      header: "Total",
+      id: "total",
+      accessorKey: "total",
+      size: 70
+    },
+    {
+      header: "Success",
+      id: "success",
+      accessorKey: "success",
+      size: 70
+    },
+    {
+      header: "Failed",
+      id: "failed",
+      accessorKey: "failed",
+      size: 70,
+      Cell: ({ row }) => (
+        <span className={row.original.failed > 0 ? "text-red-500" : ""}>
+          {row.original.failed}
+        </span>
+      )
+    },
+    {
+      header: "Skipped",
+      id: "skipped",
+      accessorKey: "skipped",
+      size: 70
+    },
+    {
+      header: "Last Run",
+      id: "last_run_at",
+      accessorKey: "last_run_at",
+      size: 90,
+      Cell: MRTDateCell
+    },
+    {
+      header: "Disable",
+      id: "action",
+      enableSorting: false,
+      size: 80,
+      Cell: ({ row }) => (
+        <div
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          <Switch
+            className="data-[state=checked]:bg-red-600"
+            checked={disabledJobs.has(row.original.name)}
+            disabled={toggleJobMutation.isLoading}
+            onCheckedChange={(checked) => {
+              toggleJobMutation.mutate({
+                jobName: row.original.name,
+                disabled: checked
+              });
+            }}
+          />
+        </div>
+      )
+    }
+  ];
 
   return (
     <MRTDataTable

--- a/src/components/JobsHistory/JobHistorySummary.tsx
+++ b/src/components/JobsHistory/JobHistorySummary.tsx
@@ -105,6 +105,7 @@ export default function JobHistorySummary({
             <Button
               variant="outline"
               size="sm"
+              className="h-6 px-2"
               onClick={() => {
                 setSelectedJobName(row.original.name);
                 setIsOverridesDialogOpen(true);

--- a/src/components/JobsHistory/JobHistorySummary.tsx
+++ b/src/components/JobsHistory/JobHistorySummary.tsx
@@ -1,21 +1,13 @@
-import { toastError } from "@flanksource-ui/components/Toast/toast";
-import { Switch } from "@flanksource-ui/components/ui/switch";
-import { useUser } from "@flanksource-ui/context";
-import {
-  deleteProperty,
-  fetchProperties,
-  saveProperty,
-  updateProperty
-} from "@flanksource-ui/api/services/properties";
+import { Button } from "@flanksource-ui/components/ui/button";
 import { JobHistorySummary as JobHistorySummaryType } from "@flanksource-ui/api/services/jobsHistory";
 import { MRTDateCell } from "@flanksource-ui/ui/MRTDataTable/Cells/MRTDateCells";
 import MRTDataTable from "@flanksource-ui/ui/MRTDataTable/MRTDataTable";
 import { formatJobName } from "@flanksource-ui/utils/common";
 import { formatDuration } from "@flanksource-ui/utils/date";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { MRT_ColumnDef } from "mantine-react-table";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import JobHistoryOverridesDialog from "./JobHistoryOverridesDialog";
 
 type JobHistorySummaryProps = {
   data: JobHistorySummaryType[];
@@ -25,12 +17,6 @@ type JobHistorySummaryProps = {
   totalEntries?: number;
 };
 
-const getJobDisabledPropertyName = (jobName: string) =>
-  `jobs.${jobName}.disabled`;
-
-const getLegacyJobDisabledPropertyName = (jobName: string) =>
-  `jobs.${jobName}.disable`;
-
 export default function JobHistorySummary({
   data,
   isLoading,
@@ -39,199 +25,127 @@ export default function JobHistorySummary({
   totalEntries
 }: JobHistorySummaryProps) {
   const navigate = useNavigate();
-  const user = useUser();
-  const queryClient = useQueryClient();
 
-  const { data: properties = [] } = useQuery({
-    queryKey: ["job_history_summary", "disabled_properties"],
-    queryFn: async () => {
-      const response = await fetchProperties();
-      return response.data ?? [];
-    },
-    staleTime: 5000
-  });
+  const [isOverridesDialogOpen, setIsOverridesDialogOpen] = useState(false);
+  const [selectedJobName, setSelectedJobName] = useState<string>();
 
-  const disabledJobs = useMemo(() => {
-    return new Set(
-      properties
-        .filter((property) => {
-          if (property.value !== "true") {
-            return false;
+  const columns: MRT_ColumnDef<JobHistorySummaryType>[] = useMemo(
+    () => [
+      {
+        header: "Job Name",
+        id: "name",
+        accessorKey: "name",
+        minSize: 220,
+        Cell: ({ row }) => <span>{formatJobName(row.original.name)}</span>
+      },
+      {
+        header: "Average Duration",
+        id: "average_duration",
+        accessorKey: "average_duration",
+        size: 100,
+        Cell: ({ row }) => {
+          const rawValue = row.original.average_duration;
+          const duration = Number(rawValue ?? 0);
+
+          if (!Number.isFinite(duration) || duration <= 0) {
+            return <span>-</span>;
           }
 
-          const isDisabled = property.name.endsWith(".disabled");
-          const isLegacyDisabled = property.name.endsWith(".disable");
-          return isDisabled || isLegacyDisabled;
-        })
-        .map((property) => {
-          if (property.name.endsWith(".disabled")) {
-            return property.name.slice(5, -9);
-          }
-          return property.name.slice(5, -8);
-        })
-    );
-  }, [properties]);
-
-  const toggleJobMutation = useMutation({
-    mutationFn: async ({
-      jobName,
-      disabled
-    }: {
-      jobName: string;
-      disabled: boolean;
-    }) => {
-      const propertyName = getJobDisabledPropertyName(jobName);
-      const legacyPropertyName = getLegacyJobDisabledPropertyName(jobName);
-
-      if (disabled) {
-        const payload = {
-          name: propertyName,
-          value: "true",
-          created_by: user.user?.id
-        };
-
-        const createResponse = await saveProperty(payload);
-        if (!createResponse.data) {
-          const updateResponse = await updateProperty(payload);
-          if (!updateResponse.data) {
-            throw new Error(
-              createResponse.error?.message ??
-                updateResponse.error?.message ??
-                "Failed to disable job"
-            );
-          }
+          return <span>{formatDuration(duration)}</span>;
         }
-
-        await deleteProperty({ name: legacyPropertyName }).catch(() => {
-          // legacy property may not exist; ignore cleanup failure
-        });
-        return;
-      }
-
-      const results = await Promise.allSettled([
-        deleteProperty({ name: propertyName }),
-        deleteProperty({ name: legacyPropertyName })
-      ]);
-
-      const hasDeleteSuccess = results.some(
-        (result) => result.status === "fulfilled"
-      );
-      if (!hasDeleteSuccess) {
-        throw new Error("Failed to enable job");
-      }
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["job_history_summary", "disabled_properties"]
-      });
-    },
-    onError: (error) => {
-      toastError((error as Error).message);
-    }
-  });
-
-  const columns: MRT_ColumnDef<JobHistorySummaryType>[] = [
-    {
-      header: "Job Name",
-      id: "name",
-      accessorKey: "name",
-      minSize: 220,
-      Cell: ({ row }) => <span>{formatJobName(row.original.name)}</span>
-    },
-    {
-      header: "Average Duration",
-      id: "average_duration",
-      accessorKey: "average_duration",
-      size: 100,
-      Cell: ({ row }) => {
-        const rawValue = row.original.average_duration;
-        const duration = Number(rawValue ?? 0);
-
-        if (!Number.isFinite(duration) || duration <= 0) {
-          return <span>-</span>;
-        }
-
-        return <span>{formatDuration(duration)}</span>;
-      }
-    },
-    {
-      header: "Total",
-      id: "total",
-      accessorKey: "total",
-      size: 70
-    },
-    {
-      header: "Success",
-      id: "success",
-      accessorKey: "success",
-      size: 70
-    },
-    {
-      header: "Failed",
-      id: "failed",
-      accessorKey: "failed",
-      size: 70,
-      Cell: ({ row }) => (
-        <span className={row.original.failed > 0 ? "text-red-500" : ""}>
-          {row.original.failed}
-        </span>
-      )
-    },
-    {
-      header: "Skipped",
-      id: "skipped",
-      accessorKey: "skipped",
-      size: 70
-    },
-    {
-      header: "Last Run",
-      id: "last_run_at",
-      accessorKey: "last_run_at",
-      size: 90,
-      Cell: MRTDateCell
-    },
-    {
-      header: "Disable",
-      id: "action",
-      enableSorting: false,
-      size: 80,
-      Cell: ({ row }) => (
-        <div
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-        >
-          <Switch
-            className="data-[state=checked]:bg-red-600"
-            checked={disabledJobs.has(row.original.name)}
-            disabled={toggleJobMutation.isLoading}
-            onCheckedChange={(checked) => {
-              toggleJobMutation.mutate({
-                jobName: row.original.name,
-                disabled: checked
-              });
+      },
+      {
+        header: "Total",
+        id: "total",
+        accessorKey: "total",
+        size: 70
+      },
+      {
+        header: "Success",
+        id: "success",
+        accessorKey: "success",
+        size: 70
+      },
+      {
+        header: "Failed",
+        id: "failed",
+        accessorKey: "failed",
+        size: 70,
+        Cell: ({ row }) => (
+          <span className={row.original.failed > 0 ? "text-red-500" : ""}>
+            {row.original.failed}
+          </span>
+        )
+      },
+      {
+        header: "Skipped",
+        id: "skipped",
+        accessorKey: "skipped",
+        size: 70
+      },
+      {
+        header: "Last Run",
+        id: "last_run_at",
+        accessorKey: "last_run_at",
+        size: 90,
+        Cell: MRTDateCell
+      },
+      {
+        header: "Action",
+        id: "edit",
+        enableSorting: false,
+        size: 80,
+        Cell: ({ row }) => (
+          <div
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
             }}
-          />
-        </div>
-      )
-    }
-  ];
+          >
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setSelectedJobName(row.original.name);
+                setIsOverridesDialogOpen(true);
+              }}
+            >
+              Manage
+            </Button>
+          </div>
+        )
+      }
+    ],
+    []
+  );
 
   return (
-    <MRTDataTable
-      data={data}
-      columns={columns}
-      isLoading={isLoading}
-      isRefetching={isRefetching}
-      enableServerSideSorting
-      enableServerSidePagination
-      manualPageCount={pageCount}
-      totalRowCount={totalEntries}
-      defaultSorting={[{ id: "last_run_at", desc: true }]}
-      onRowClick={(row) => {
-        navigate(`/settings/jobs/${encodeURIComponent(row.name)}`);
-      }}
-    />
+    <>
+      <MRTDataTable
+        data={data}
+        columns={columns}
+        isLoading={isLoading}
+        isRefetching={isRefetching}
+        enableServerSideSorting
+        enableServerSidePagination
+        manualPageCount={pageCount}
+        totalRowCount={totalEntries}
+        defaultSorting={[{ id: "last_run_at", desc: true }]}
+        onRowClick={(row) => {
+          navigate(`/settings/jobs/${encodeURIComponent(row.name)}`);
+        }}
+      />
+
+      <JobHistoryOverridesDialog
+        open={isOverridesDialogOpen}
+        jobName={selectedJobName}
+        onOpenChange={(isOpen) => {
+          setIsOverridesDialogOpen(isOpen);
+          if (!isOpen) {
+            setSelectedJobName(undefined);
+          }
+        }}
+      />
+    </>
   );
 }

--- a/src/components/JobsHistory/JobHistorySummary.tsx
+++ b/src/components/JobsHistory/JobHistorySummary.tsx
@@ -1,0 +1,122 @@
+import { JobHistorySummary as JobHistorySummaryType } from "@flanksource-ui/api/services/jobsHistory";
+import { MRTDateCell } from "@flanksource-ui/ui/MRTDataTable/Cells/MRTDateCells";
+import MRTDataTable from "@flanksource-ui/ui/MRTDataTable/MRTDataTable";
+import { formatJobName } from "@flanksource-ui/utils/common";
+import { formatDuration } from "@flanksource-ui/utils/date";
+import { MRT_ColumnDef } from "mantine-react-table";
+import { useNavigate } from "react-router-dom";
+
+type JobHistorySummaryProps = {
+  data: JobHistorySummaryType[];
+  isLoading?: boolean;
+  isRefetching?: boolean;
+  pageCount: number;
+  totalEntries?: number;
+};
+
+const columns: MRT_ColumnDef<JobHistorySummaryType>[] = [
+  {
+    header: "Job Name",
+    id: "name",
+    accessorKey: "name",
+    minSize: 220,
+    Cell: ({ row }) => <span>{formatJobName(row.original.name)}</span>
+  },
+  {
+    header: "Total",
+    id: "total",
+    accessorKey: "total",
+    size: 70
+  },
+  {
+    header: "Success",
+    id: "success",
+    accessorKey: "success",
+    size: 70
+  },
+  {
+    header: "Failed",
+    id: "failed",
+    accessorKey: "failed",
+    size: 70,
+    Cell: ({ row }) => (
+      <span className={row.original.failed > 0 ? "text-red-500" : ""}>
+        {row.original.failed}
+      </span>
+    )
+  },
+  {
+    header: "Warning",
+    id: "warning",
+    accessorKey: "warning",
+    size: 70
+  },
+  {
+    header: "Running",
+    id: "running",
+    accessorKey: "running",
+    size: 70
+  },
+  {
+    header: "Stale",
+    id: "stale",
+    accessorKey: "stale",
+    size: 70
+  },
+  {
+    header: "Skipped",
+    id: "skipped",
+    accessorKey: "skipped",
+    size: 70
+  },
+  {
+    header: "Last Run",
+    id: "last_run_at",
+    accessorKey: "last_run_at",
+    size: 90,
+    Cell: MRTDateCell
+  },
+  {
+    header: "Average Duration",
+    id: "average_duration",
+    accessorKey: "average_duration",
+    size: 100,
+    Cell: ({ row }) => {
+      const rawValue = row.original.average_duration;
+      const duration = Number(rawValue ?? 0);
+
+      if (!Number.isFinite(duration) || duration <= 0) {
+        return <span>-</span>;
+      }
+
+      return <span>{formatDuration(duration)}</span>;
+    }
+  }
+];
+
+export default function JobHistorySummary({
+  data,
+  isLoading,
+  isRefetching,
+  pageCount,
+  totalEntries
+}: JobHistorySummaryProps) {
+  const navigate = useNavigate();
+
+  return (
+    <MRTDataTable
+      data={data}
+      columns={columns}
+      isLoading={isLoading}
+      isRefetching={isRefetching}
+      enableServerSideSorting
+      enableServerSidePagination
+      manualPageCount={pageCount}
+      totalRowCount={totalEntries}
+      defaultSorting={[{ id: "last_run_at", desc: true }]}
+      onRowClick={(row) => {
+        navigate(`/settings/jobs/${encodeURIComponent(row.name)}`);
+      }}
+    />
+  );
+}

--- a/src/components/JobsHistory/JobHistorySummary.tsx
+++ b/src/components/JobsHistory/JobHistorySummary.tsx
@@ -102,14 +102,23 @@ export default function JobHistorySummary({
           }
         }
 
-        await deleteProperty({ name: legacyPropertyName });
+        await deleteProperty({ name: legacyPropertyName }).catch(() => {
+          // legacy property may not exist; ignore cleanup failure
+        });
         return;
       }
 
-      await Promise.all([
+      const results = await Promise.allSettled([
         deleteProperty({ name: propertyName }),
         deleteProperty({ name: legacyPropertyName })
       ]);
+
+      const hasDeleteSuccess = results.some(
+        (result) => result.status === "fulfilled"
+      );
+      if (!hasDeleteSuccess) {
+        throw new Error("Failed to enable job");
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/src/components/JobsHistory/JobsHistoryDrilldownSettingsPage.tsx
+++ b/src/components/JobsHistory/JobsHistoryDrilldownSettingsPage.tsx
@@ -1,0 +1,75 @@
+import { formatJobName } from "@flanksource-ui/utils/common";
+import { useParams, useSearchParams } from "react-router-dom";
+import { useJobsHistoryForSettingQuery } from "../../api/query-hooks/useJobsHistoryQuery";
+import { BreadcrumbNav, BreadcrumbRoot } from "../../ui/BreadcrumbNav";
+import { Head } from "../../ui/Head";
+import { SearchLayout } from "../../ui/Layout/SearchLayout";
+import JobHistoryFilters from "./Filters/JobsHistoryFilters";
+import JobsHistoryTable from "./JobsHistoryTable";
+
+export default function JobsHistoryDrilldownSettingsPage() {
+  const { jobName } = useParams<{ jobName: string }>();
+  const [searchParams] = useSearchParams();
+
+  const decodedJobName = jobName ? decodeURIComponent(jobName) : "";
+
+  const pageSize = parseInt(searchParams.get("pageSize") ?? "50");
+
+  const { data, isLoading, refetch, isRefetching } =
+    useJobsHistoryForSettingQuery(
+      {
+        keepPreviousData: true
+      },
+      undefined,
+      undefined,
+      decodedJobName
+    );
+
+  const jobs = data?.data;
+  const totalEntries = data?.totalEntries;
+  const pageCount = totalEntries ? Math.ceil(totalEntries / pageSize) : -1;
+
+  return (
+    <>
+      <Head
+        prefix={`Job History - ${formatJobName(decodedJobName) || decodedJobName}`}
+      />
+      <SearchLayout
+        title={
+          <BreadcrumbNav
+            list={[
+              <BreadcrumbRoot key={"history"} link="/settings/jobs">
+                Job History
+              </BreadcrumbRoot>,
+              <BreadcrumbRoot
+                key={decodedJobName}
+                link={`/settings/jobs/${encodeURIComponent(decodedJobName)}`}
+              >
+                {formatJobName(decodedJobName)}
+              </BreadcrumbRoot>
+            ]}
+          />
+        }
+        onRefresh={refetch}
+        contentClass="p-0 h-full"
+        loading={isLoading || isRefetching}
+      >
+        <div className="flex h-full w-full flex-1 flex-col p-6 pb-0">
+          <JobHistoryFilters
+            showJobNameDropdown={false}
+            defaultStatusFilter={null}
+          />
+
+          <JobsHistoryTable
+            jobs={jobs ?? []}
+            isLoading={isLoading}
+            isRefetching={isRefetching}
+            pageCount={pageCount}
+            totalJobHistoryItems={totalEntries}
+            hiddenColumns={["name"]}
+          />
+        </div>
+      </SearchLayout>
+    </>
+  );
+}

--- a/src/components/JobsHistory/JobsHistoryDrilldownSettingsPage.tsx
+++ b/src/components/JobsHistory/JobsHistoryDrilldownSettingsPage.tsx
@@ -11,7 +11,7 @@ export default function JobsHistoryDrilldownSettingsPage() {
   const { jobName } = useParams<{ jobName: string }>();
   const [searchParams] = useSearchParams();
 
-  const decodedJobName = jobName ? decodeURIComponent(jobName) : "";
+  const decodedJobName = jobName ?? "";
 
   const pageSize = parseInt(searchParams.get("pageSize") ?? "50");
 

--- a/src/components/JobsHistory/JobsHistorySettingsPage.tsx
+++ b/src/components/JobsHistory/JobsHistorySettingsPage.tsx
@@ -1,10 +1,9 @@
 import { useSearchParams } from "react-router-dom";
-import { useJobsHistoryForSettingQuery } from "../../api/query-hooks/useJobsHistoryQuery";
+import { useJobsHistorySummaryForSettingQuery } from "../../api/query-hooks/useJobsHistoryQuery";
 import { BreadcrumbNav, BreadcrumbRoot } from "../../ui/BreadcrumbNav";
 import { Head } from "../../ui/Head";
 import { SearchLayout } from "../../ui/Layout/SearchLayout";
-import JobHistoryFilters from "./Filters/JobsHistoryFilters";
-import JobsHistoryTable from "./JobsHistoryTable";
+import JobHistorySummary from "./JobHistorySummary";
 
 export default function JobsHistorySettingsPage() {
   const [searchParams] = useSearchParams();
@@ -12,11 +11,11 @@ export default function JobsHistorySettingsPage() {
   const pageSize = parseInt(searchParams.get("pageSize") ?? "50");
 
   const { data, isLoading, refetch, isRefetching } =
-    useJobsHistoryForSettingQuery({
+    useJobsHistorySummaryForSettingQuery({
       keepPreviousData: true
     });
 
-  const jobs = data?.data;
+  const summary = data?.data;
   const totalEntries = data?.totalEntries;
   const pageCount = totalEntries ? Math.ceil(totalEntries / pageSize) : -1;
 
@@ -38,14 +37,12 @@ export default function JobsHistorySettingsPage() {
         loading={isLoading || isRefetching}
       >
         <div className="flex h-full w-full flex-1 flex-col p-6 pb-0">
-          <JobHistoryFilters />
-
-          <JobsHistoryTable
-            jobs={jobs ?? []}
+          <JobHistorySummary
+            data={summary ?? []}
             isLoading={isLoading}
             isRefetching={isRefetching}
             pageCount={pageCount}
-            totalJobHistoryItems={totalEntries}
+            totalEntries={totalEntries}
           />
         </div>
       </SearchLayout>

--- a/src/pages/Settings/FeatureFlagsPage.tsx
+++ b/src/pages/Settings/FeatureFlagsPage.tsx
@@ -100,7 +100,7 @@ export function FeatureFlagsPage() {
         contentClass="p-0 h-full"
         loading={isLoading}
       >
-        <div className="mx-auto flex h-full max-w-screen-xl flex-1 flex-col px-6 pb-0">
+        <div className="flex h-full w-full flex-1 flex-col px-6 pb-0">
           <FeatureFlagsList
             className="mt-6 overflow-y-hidden"
             data={featureFlags ?? []}


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/2963


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs history summary page with aggregated metrics (avg duration, counts), server-side sorting and pagination.
  * Per-job overrides dialog to view/edit job settings, including enable/disable toggle.
  * Drill-down settings page and navigation to view detailed job history with pagination and refresh.
  * Filters updated to optionally hide job-name selector and accept a default status filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->