### PR TITLE
fix: show in-progress notification counts in send history summary

### DIFF
--- a/src/api/types/notifications.ts
+++ b/src/api/types/notifications.ts
@@ -161,6 +161,7 @@ export type NotificationSendHistorySummary = {
   sent: number;
   error: number;
   suppressed: number;
+  in_progress?: number;
 };
 
 export type NotificationSendHistoryApiResponse = NotificationSendHistory & {

--- a/src/components/Notifications/NotificationSendHistorySummary.tsx
+++ b/src/components/Notifications/NotificationSendHistorySummary.tsx
@@ -123,6 +123,12 @@ const notificationSendHistoryColumns: MRT_ColumnDef<NotificationSendHistorySumma
                 statusText={`${row.original.suppressed} suppressed`}
               />
             )}
+            {(row.original.in_progress ?? 0) > 0 && (
+              <Status
+                status="unknown"
+                statusText={`${row.original.in_progress} in progress`}
+              />
+            )}
           </div>
         );
       }


### PR DESCRIPTION
The notifications send history summary table could render an empty Status cell when all events were still in progress.

Root cause was that UI only displayed `sent`, `error`, and `suppressed` counts, while API also returns `in_progress`.

This change adds `in_progress` to `NotificationSendHistorySummary` and renders an `N in progress` status badge in the summary table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added "in progress" status indicator to notification history summary, displaying the count of notifications currently being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->