### PR TITLE
fix: sync job overrides modal with persisted properties

### DIFF
--- a/src/components/JobsHistory/JobHistoryOverridesDialog.tsx
+++ b/src/components/JobsHistory/JobHistoryOverridesDialog.tsx
@@ -30,7 +30,7 @@ import {
 import { formatJobName } from "@flanksource-ui/utils/common";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type DisableProperty = {
   name: string;
@@ -169,13 +169,11 @@ export default function JobHistoryOverridesDialog({
   }, [jobName, safeProperties]);
 
   const [values, setValues] = useState<Record<string, string>>(initialValues);
-  const wasOpenRef = useRef(open);
 
   useEffect(() => {
-    if (open && !wasOpenRef.current) {
+    if (open) {
       setValues(initialValues);
     }
-    wasOpenRef.current = open;
   }, [initialValues, open]);
 
   const saveMutation = useMutation({


### PR DESCRIPTION
The Manage Job Overrides modal could show default values even when overrides already existed in properties.

Root cause: form state was initialized before properties finished loading, and it only reset on dialog open transitions, so it did not re-sync when query data arrived.

This updates JobHistoryOverridesDialog to rehydrate form values from fetched initial values whenever the dialog is open and property data changes.

Persisted overrides like jobs.<JobName>.disabled=true now show correctly in the modal.