### PR TITLE
fix(feature-flags): refetch settings flags on page mount

### DIFF
--- a/src/api/query-hooks/useFeatureFlags.tsx
+++ b/src/api/query-hooks/useFeatureFlags.tsx
@@ -43,14 +43,17 @@ export function useGetPropertyFromDB(featureFlag?: FeatureFlag) {
   });
 }
 
-export function useGetFeatureFlagsFromAPI() {
+export function useGetFeatureFlagsFromAPI(options?: {
+  refetchOnMount?: boolean | "always";
+}) {
   return useQuery({
     queryKey: ["feature-flags", "all", "api"],
     queryFn: async () => {
       const res = await fetchFeatureFlagsAPI();
       return res.data ?? [];
     },
-    staleTime: 30 * 1000
+    staleTime: 30 * 1000,
+    ...options
   });
 }
 

--- a/src/components/FeatureFlags/FeatureFlagList.tsx
+++ b/src/components/FeatureFlags/FeatureFlagList.tsx
@@ -22,11 +22,8 @@ const AvatarCell = ({ getValue }: CellContext<FeatureFlag, any>) => {
 const columns: ColumnDef<FeatureFlag>[] = [
   {
     header: "Name",
-    accessorKey: "name"
-  },
-  {
-    header: "Description",
-    accessorKey: "description"
+    accessorKey: "name",
+    minSize: 300
   },
   {
     header: "Value",
@@ -34,23 +31,27 @@ const columns: ColumnDef<FeatureFlag>[] = [
   },
   {
     header: "Source",
-    accessorKey: "source"
+    accessorKey: "source",
+    maxSize: 80
   },
   {
     header: "Created By",
     accessorKey: "created_by",
-    cell: AvatarCell
+    cell: AvatarCell,
+    maxSize: 80
   },
   {
     header: "Created At",
     accessorKey: "created_at",
     cell: DateCell,
-    sortingFn: "datetime"
+    sortingFn: "datetime",
+    maxSize: 120
   },
   {
     header: "Updated At",
     accessorKey: "updated_at",
     cell: DateCell,
+    maxSize: 120,
     sortingFn: "datetime"
   }
 ];

--- a/src/pages/Settings/FeatureFlagsPage.tsx
+++ b/src/pages/Settings/FeatureFlagsPage.tsx
@@ -33,7 +33,7 @@ export function FeatureFlagsPage() {
     data: featureFlags,
     isLoading,
     refetch
-  } = useGetFeatureFlagsFromAPI();
+  } = useGetFeatureFlagsFromAPI({ refetchOnMount: "always" });
 
   const { mutate: saveFeatureFlag } = useAddFeatureFlag(() => {
     refetch();


### PR DESCRIPTION
Feature Flags settings page reused cached query data on navigation, which could show stale values until manual refresh.

This change keeps the shared feature-flag query behavior intact while allowing per-consumer overrides, then enables refetchOnMount='always' for FeatureFlagsPage so each page visit revalidates data immediately.

Also includes the staged FeatureFlagList table updates (column sizing and description column removal).