### PR TITLE
feat: improve notification rules table event badges and tooltip behavior

### DIFF
--- a/src/components/Notifications/Rules/notificationsRulesTableColumns.tsx
+++ b/src/components/Notifications/Rules/notificationsRulesTableColumns.tsx
@@ -1,15 +1,20 @@
 import { NotificationRules } from "@flanksource-ui/api/types/notifications";
-import { Badge } from "@flanksource-ui/ui/Badge/Badge";
+import { Badge } from "@flanksource-ui/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from "@flanksource-ui/components/ui/tooltip";
 import MRTAvatarCell from "@flanksource-ui/ui/MRTDataTable/Cells/MRTAvataCell";
 import { MRTDateCell } from "@flanksource-ui/ui/MRTDataTable/Cells/MRTDateCells";
 import { MRTCellProps } from "@flanksource-ui/ui/MRTDataTable/MRTCellProps";
 import { formatDuration, age } from "@flanksource-ui/utils/date";
 import dayjs from "dayjs";
 import { MRT_ColumnDef } from "mantine-react-table";
-import { useState, useId } from "react";
+import { useState } from "react";
 import JobHistoryStatusColumn from "../../JobsHistory/JobHistoryStatusColumn";
 import { JobsHistoryDetails } from "../../JobsHistory/JobsHistoryDetails";
-import { Tooltip } from "react-tooltip";
 import { Status } from "../../Status";
 
 export const notificationEvents = [
@@ -76,6 +81,42 @@ export const notificationEvents = [
   }
 ].sort((a, b) => a.label.localeCompare(b.label));
 
+function WrappedHeader({ title }: { title: string }) {
+  return <span className="whitespace-normal leading-tight">{title}</span>;
+}
+
+function getEventBadgeClasses(event: string) {
+  if (
+    event.endsWith(".failed") ||
+    event.endsWith(".unhealthy") ||
+    event.endsWith(".deleted")
+  ) {
+    return "border-red-200 bg-red-50 text-red-700";
+  }
+
+  if (event.endsWith(".warning")) {
+    return "border-amber-200 bg-amber-50 text-amber-700";
+  }
+
+  if (event.endsWith(".unknown")) {
+    return "border-slate-200 bg-slate-100 text-slate-700";
+  }
+
+  if (event.endsWith(".passed") || event.endsWith(".healthy")) {
+    return "border-emerald-200 bg-emerald-50 text-emerald-700";
+  }
+
+  if (event.endsWith(".created") || event.endsWith(".updated")) {
+    return "border-blue-200 bg-blue-50 text-blue-700";
+  }
+
+  if (event.startsWith("playbook.")) {
+    return "border-violet-200 bg-violet-50 text-violet-700";
+  }
+
+  return "border-muted-foreground/20 bg-muted text-foreground";
+}
+
 export function StatusColumn({ cell }: MRTCellProps<NotificationRules>) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const value = cell.row.original.job_status;
@@ -111,41 +152,88 @@ export type UpdateNotificationRule = Omit<
 export const notificationsRulesTableColumns: MRT_ColumnDef<NotificationRules>[] =
   [
     {
-      header: "Events",
-      id: "events",
-      accessorKey: "events",
-      size: 150,
-      Cell: ({ row, column }) => {
-        const value = row.getValue<NotificationRules["events"]>(column.id);
-
-        return (
-          <div className="flex w-full flex-col">
-            {value.map((event) => (
-              <div className="block p-1" key={event}>
-                <Badge text={event} className="w-auto text-sm" />
-              </div>
-            ))}
-          </div>
-        );
-      }
-    },
-    {
       header: "Name",
       id: "name",
       size: 150,
       accessorKey: "name"
     },
     {
+      header: "Events",
+      id: "events",
+      accessorKey: "events",
+      size: 150,
+      Cell: ({ row, column }) => {
+        const value =
+          row.getValue<NotificationRules["events"]>(column.id) ?? [];
+        const visibleEvents = value.slice(0, 2);
+        const hiddenCount = value.length - visibleEvents.length;
+
+        return (
+          <div className="flex w-full flex-wrap items-center gap-1 py-1">
+            {visibleEvents.map((event) => (
+              <Badge
+                key={event}
+                variant="outline"
+                className={`truncate text-xs ${getEventBadgeClasses(event)}`}
+                title={event}
+              >
+                {event}
+              </Badge>
+            ))}
+            {hiddenCount > 0 && (
+              <TooltipProvider delayDuration={0}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex">
+                      <Badge variant="outline" className="px-2 text-xs">
+                        +{hiddenCount}
+                      </Badge>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    side="top"
+                    className="max-w-[500px] break-all"
+                  >
+                    {value.slice(2).join(", ")}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
+        );
+      }
+    },
+    {
       header: "Filter",
       id: "filter",
       size: 100,
-      accessorKey: "filter"
+      accessorKey: "filter",
+      Cell: ({ row, column }) => {
+        const value = row.getValue<string>(column.id) ?? "";
+
+        if (!value) {
+          return null;
+        }
+
+        return (
+          <TooltipProvider delayDuration={0}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="block max-w-[220px] truncate">{value}</span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-[500px] break-all">
+                {value}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        );
+      }
     },
     {
       header: "Status",
       id: "status",
       accessorKey: "error",
-      size: 100,
+      size: 80,
       Cell: ({ row }) => {
         const error = row.original.error;
         return (
@@ -160,6 +248,7 @@ export const notificationsRulesTableColumns: MRT_ColumnDef<NotificationRules>[] 
     },
     {
       header: "Sent / Failed / Pending",
+      Header: () => <WrappedHeader title="Sent / Failed / Pending" />,
       id: "sent_failed_pending",
       size: 200,
       Cell: ({ row }) => {
@@ -168,7 +257,6 @@ export const notificationsRulesTableColumns: MRT_ColumnDef<NotificationRules>[] 
         const pending = row.original.pending ?? 0;
         const mostCommonError = row.original.most_common_error ?? "";
         const errorAt = row.original.error_at;
-        const tooltipId = useId();
 
         const tooltipContent = errorAt
           ? `${age(errorAt)} ago: ${mostCommonError}`
@@ -179,18 +267,26 @@ export const notificationsRulesTableColumns: MRT_ColumnDef<NotificationRules>[] 
             {sent > 0 && (
               <Status status="healthy" statusText={`Sent: ${sent}`} />
             )}
-            {failed > 0 && (
-              <div
-                className="inline-flex"
-                data-tooltip-id={tooltipId}
-                data-tooltip-content={tooltipContent}
-              >
+            {failed > 0 &&
+              (tooltipContent ? (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="inline-flex">
+                        <Status
+                          status="unhealthy"
+                          statusText={`Failed: ${failed}`}
+                        />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="max-w-[500px]">
+                      {tooltipContent}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : (
                 <Status status="unhealthy" statusText={`Failed: ${failed}`} />
-                {tooltipContent && (
-                  <Tooltip id={tooltipId} className="z-[999999]" />
-                )}
-              </div>
-            )}
+              ))}
             {pending > 0 && (
               <Status status="warning" statusText={`Pending: ${pending}`} />
             )}
@@ -200,6 +296,7 @@ export const notificationsRulesTableColumns: MRT_ColumnDef<NotificationRules>[] 
     },
     {
       header: "Avg Duration",
+      Header: () => <WrappedHeader title="Avg Duration" />,
       id: "avg_duration_ms",
       accessorKey: "avg_duration_ms",
       size: 80,
@@ -214,6 +311,7 @@ export const notificationsRulesTableColumns: MRT_ColumnDef<NotificationRules>[] 
     },
     {
       header: "Repeat Interval",
+      Header: () => <WrappedHeader title="Repeat Interval" />,
       id: "repeat_interval",
       accessorKey: "repeat_interval",
       size: 80,
@@ -238,6 +336,7 @@ export const notificationsRulesTableColumns: MRT_ColumnDef<NotificationRules>[] 
     },
     {
       header: "Created At",
+      Header: () => <WrappedHeader title="Created At" />,
       id: "created_at",
       accessorKey: "created_at",
       size: 100,
@@ -245,6 +344,7 @@ export const notificationsRulesTableColumns: MRT_ColumnDef<NotificationRules>[] 
     },
     {
       header: "Updated At",
+      Header: () => <WrappedHeader title="Updated At" />,
       id: "updated_at",
       accessorKey: "updated_at",
       size: 100,
@@ -252,6 +352,7 @@ export const notificationsRulesTableColumns: MRT_ColumnDef<NotificationRules>[] 
     },
     {
       header: "Created By",
+      Header: () => <WrappedHeader title="Created By" />,
       id: "created_by",
       accessorKey: "created_by",
       size: 100,

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -18,7 +18,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 origin-[--radix-tooltip-content-transform-origin] overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 origin-[--radix-tooltip-content-transform-origin] overflow-hidden rounded-md bg-[#222] px-3 py-1.5 text-xs text-primary-foreground text-white animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}


### PR DESCRIPTION
- Migrates notification rules table badges to ShadCN `Badge` in the Events column.
- Adds event-specific badge coloring and collapses long event lists to first two entries with a `+N` indicator.
- Replaces `react-tooltip` usage in this table with ShadCN tooltips (for filter text, `+N`, and failed count details).
- Updates shared tooltip styling to a dark neutral background (`#222`) so hover content is readable and consistent.
- Adds wrapped headers for longer column labels to avoid cramped/truncated header text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Name" column to notification rules table for better organization.
  * Event display now shows up to two badges with a "+N" indicator for additional events.
  * Filter values now truncate with full text visible in a tooltip on hover.

* **Style**
  * Updated tooltip styling for improved visibility and contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->