### PR TITLE
fix: MCP installation guide on Windows

### DIFF
--- a/src/components/Tokens/Add/TokenDisplayModal.tsx
+++ b/src/components/Tokens/Add/TokenDisplayModal.tsx
@@ -163,11 +163,37 @@ function McpSetupTabs({ token, onTabChange }: McpSetupTabsProps) {
 
   const bearerAuth = `Bearer ${token}`;
   const baseUrl = useAgentsBaseURL() + "/mcp";
+  const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
+  const isWindows = /Windows/i.test(userAgent);
+  const isMac = /Macintosh|Mac OS X/i.test(userAgent);
+  const isLinux = /Linux/i.test(userAgent) && !/Android/i.test(userAgent);
+  const claudeDesktopConfigPath = isWindows
+    ? "%LOCALAPPDATA%\\Packages\\Claude_pzs8sxrjxfjjc\\LocalCache\\Roaming\\Claude\\claude_desktop_config.json"
+    : isMac
+      ? "~/Library/Application Support/Claude/claude_desktop_config.json"
+      : isLinux
+        ? "~/.config/Claude/claude_desktop_config.json"
+        : null;
 
-  const mcpConfigs = {
-    "claude-desktop": {
-      label: "Claude Desktop",
-      config: `{
+  const claudeDesktopConfig = isWindows
+    ? `{
+  "mcpServers": {
+    "mission-control": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx.cmd",
+        "-y",
+        "mcp-remote",
+        "${baseUrl}",
+        "--header",
+        "Authorization:${bearerAuth}"
+      ],
+      "env": {}
+    }
+  }
+}`
+    : `{
   "mcpServers": {
     "mission-control": {
       "command": "npx",
@@ -181,7 +207,12 @@ function McpSetupTabs({ token, onTabChange }: McpSetupTabsProps) {
       "env": {}
     }
   }
-}`
+}`;
+
+  const mcpConfigs = {
+    "claude-desktop": {
+      label: "Claude Desktop",
+      config: claudeDesktopConfig
     },
     "claude-code": {
       label: "Claude Code",
@@ -299,43 +330,29 @@ MCP_BEARER_TOKEN=${token}`
     switch (key) {
       case "claude-desktop":
         return (
-          <>
-            <li>
-              Add this configuration to{" "}
+          <span>
+            Add this configuration to{" "}
+            <code className="rounded bg-blue-100 px-1">
+              claude_desktop_config.json
+            </code>{" "}
+            located at{" "}
+            {claudeDesktopConfigPath ? (
               <code className="rounded bg-blue-100 px-1">
-                claude_desktop_config.json
-              </code>{" "}
-              located at:
-            </li>
-            <ul className="list-inside list-disc space-y-1 pl-6">
-              <li>
-                macOS:{" "}
-                <code className="rounded bg-blue-100 px-1">
-                  ~/Library/Application Support/Claude/
-                </code>
-              </li>
-              <li>
-                Windows:{" "}
-                <code className="rounded bg-blue-100 px-1">
-                  %APPDATA%\Claude\
-                </code>
-              </li>
-              <li>
-                Linux:{" "}
-                <code className="rounded bg-blue-100 px-1">
-                  ~/.config/Claude/
-                </code>
-              </li>
-            </ul>
-          </>
+                {claudeDesktopConfigPath}
+              </code>
+            ) : (
+              "the Claude configuration directory for your OS"
+            )}
+            .
+          </span>
         );
       case "claude-code":
         return (
-          <li>
+          <span>
             Add this configuration to{" "}
             <code className="rounded bg-blue-100 px-1">.mcp.json</code> file in
             your project root.
-          </li>
+          </span>
         );
       default:
         return null;
@@ -374,10 +391,10 @@ MCP_BEARER_TOKEN=${token}`
           <h4 className="mb-2 font-medium text-blue-800">
             Usage Instructions:
           </h4>
-          <ul className="space-y-1 text-sm text-blue-700">
+          <span className="space-y-1 text-sm text-blue-700">
             {usageInstructions}
-            <li>• Store it securely and never share it publicly</li>
-          </ul>
+            <span> Store it securely and never share it publicly</span>
+          </span>
         </div>
       )}
     </>

--- a/src/components/Tokens/Add/TokenDisplayModal.tsx
+++ b/src/components/Tokens/Add/TokenDisplayModal.tsx
@@ -165,15 +165,6 @@ function McpSetupTabs({ token, onTabChange }: McpSetupTabsProps) {
   const baseUrl = useAgentsBaseURL() + "/mcp";
   const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
   const isWindows = /Windows/i.test(userAgent);
-  const isMac = /Macintosh|Mac OS X/i.test(userAgent);
-  const isLinux = /Linux/i.test(userAgent) && !/Android/i.test(userAgent);
-  const claudeDesktopConfigPath = isWindows
-    ? "%LOCALAPPDATA%\\Packages\\Claude_pzs8sxrjxfjjc\\LocalCache\\Roaming\\Claude\\claude_desktop_config.json"
-    : isMac
-      ? "~/Library/Application Support/Claude/claude_desktop_config.json"
-      : isLinux
-        ? "~/.config/Claude/claude_desktop_config.json"
-        : null;
 
   const claudeDesktopConfig = isWindows
     ? `{
@@ -330,29 +321,32 @@ MCP_BEARER_TOKEN=${token}`
     switch (key) {
       case "claude-desktop":
         return (
-          <span>
-            Add this configuration to{" "}
-            <code className="rounded bg-blue-100 px-1">
-              claude_desktop_config.json
-            </code>{" "}
-            located at{" "}
-            {claudeDesktopConfigPath ? (
+          <>
+            <div>
+              Open Claude Desktop, go to <strong>Settings → Developer</strong>,
+              click the <strong>Edit Config</strong> button, and add this
+              configuration to{" "}
               <code className="rounded bg-blue-100 px-1">
-                {claudeDesktopConfigPath}
+                claude_desktop_config.json
               </code>
-            ) : (
-              "the Claude configuration directory for your OS"
-            )}
-            .
-          </span>
+              .
+            </div>
+            <div>
+              If Claude opens a folder instead of the file, create or edit{" "}
+              <code className="rounded bg-blue-100 px-1">
+                claude_desktop_config.json
+              </code>{" "}
+              in that folder.
+            </div>
+          </>
         );
       case "claude-code":
         return (
-          <span>
+          <div>
             Add this configuration to{" "}
             <code className="rounded bg-blue-100 px-1">.mcp.json</code> file in
             your project root.
-          </span>
+          </div>
         );
       default:
         return null;
@@ -377,7 +371,7 @@ MCP_BEARER_TOKEN=${token}`
                   <JSONViewer
                     code={config}
                     format="json"
-                    showLineNo
+                    showLineNo={false}
                     hideCopyButton={false}
                   />
                 )}
@@ -388,8 +382,12 @@ MCP_BEARER_TOKEN=${token}`
       </div>
       {usageInstructions && (
         <div className="mt-2 space-y-1 text-sm text-blue-700">
-          <div>{usageInstructions}</div>
-          <div>Please ensure that you have node and npx installed.</div>
+          {usageInstructions}
+          <div>
+            Please ensure that you have{" "}
+            <code className="rounded bg-blue-100 px-1">node</code> and{" "}
+            <code className="rounded bg-blue-100 px-1">npx</code> installed.
+          </div>
         </div>
       )}
     </>

--- a/src/components/Tokens/Add/TokenDisplayModal.tsx
+++ b/src/components/Tokens/Add/TokenDisplayModal.tsx
@@ -36,12 +36,12 @@ export function TokenDisplayContent({
   const maskedToken = tokenResponse.payload.token.replace(/./g, "•");
 
   return (
-    <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
-      <div className="rounded-md border border-yellow-200 bg-yellow-50 p-4">
-        <h3 className="mb-2 text-lg font-bold text-yellow-800">
+    <div className="flex flex-1 flex-col gap-4 overflow-y-auto">
+      <div className="rounded-md border border-yellow-200 bg-yellow-50 p-2">
+        <h3 className="mb-2 font-bold text-yellow-800">
           ⚠️ Important Security Notice
         </h3>
-        <p className="text-yellow-700">
+        <p className="text-sm text-yellow-700">
           This token will only be displayed once. Please copy and store it
           securely. You won't be able to see it again after closing this dialog.
         </p>
@@ -76,7 +76,7 @@ export function TokenDisplayContent({
       </div>
 
       {isMcp ? (
-        <div className="rounded-md border border-green-200 bg-green-50 p-4">
+        <div className="rounded-md border border-green-200 bg-green-50 p-4 text-sm">
           <h4 className="mb-2 font-medium text-green-800">MCP Client Setup:</h4>
           <McpSetupTabs
             token={tokenResponse.payload.token}
@@ -86,7 +86,7 @@ export function TokenDisplayContent({
           />
         </div>
       ) : (
-        <div className="rounded-md border border-blue-200 bg-blue-50 p-4">
+        <div className="">
           <h4 className="mb-2 font-medium text-blue-800">
             Usage Instructions:
           </h4>
@@ -366,8 +366,8 @@ MCP_BEARER_TOKEN=${token}`
       <div className="mt-4">
         <Tabs activeTab={activeTab} onSelectTab={handleTabChange}>
           {Object.entries(mcpConfigs).map(([key, { label, config }]) => (
-            <Tab key={key} label={label} value={key} className="p-4">
-              <div className="max-h-64 overflow-y-auto">
+            <Tab key={key} label={label} value={key} className="p-2">
+              <div className="overflow-y-auto">
                 {key === "direct" || key === "slack-bot" ? (
                   <CodeBlock
                     code={config}
@@ -387,14 +387,9 @@ MCP_BEARER_TOKEN=${token}`
         </Tabs>
       </div>
       {usageInstructions && (
-        <div className="mt-4 rounded-md border border-blue-200 bg-blue-50 p-4">
-          <h4 className="mb-2 font-medium text-blue-800">
-            Usage Instructions:
-          </h4>
-          <span className="space-y-1 text-sm text-blue-700">
-            {usageInstructions}
-            <span> Store it securely and never share it publicly</span>
-          </span>
+        <div className="mt-2 space-y-1 text-sm text-blue-700">
+          <div>{usageInstructions}</div>
+          <div>Please ensure that you have node and npx installed.</div>
         </div>
       )}
     </>

--- a/src/components/Users/SetupMcpModal.tsx
+++ b/src/components/Users/SetupMcpModal.tsx
@@ -81,8 +81,8 @@ export default function SetupMcpModal({ isOpen, onClose }: Props) {
       bodyClass="flex w-full flex-col"
     >
       <div className="flex w-full flex-col gap-4 p-4">
-        <div className="rounded-md border border-gray-200 bg-gray-50 p-4">
-          <h3 className="text-base font-semibold text-gray-900">
+        <div className="">
+          <h3 className="text-md text-base font-semibold text-gray-900">
             Choose how MCP should authenticate
           </h3>
           <p className="mt-1 text-sm text-gray-700">


### PR DESCRIPTION
Fixes the MCP installation guide for Windows users.

Updates the MCP setup instructions and formatting so the Windows guide is clearer and includes the required node/npx guidance. Also tidies the related modal spacing to keep the setup instructions easier to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined spacing and typography in token and MCP setup modals for clearer readability.
  * Simplified setup instructions layout and removed bordered/padded panels for a cleaner presentation.
  * Claude Desktop MCP setup now auto-detects the user platform and shows appropriate commands.
  * Compacted tab layout, reduced visual clutter (JSON view hides line numbers), and streamlined final usage note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->