### PR TITLE
feat: add logs tab to job history settings

### DIFF
--- a/src/components/JobsHistory/JobsHistoryLogsTab.tsx
+++ b/src/components/JobsHistory/JobsHistoryLogsTab.tsx
@@ -1,0 +1,38 @@
+import { useSearchParams } from "react-router-dom";
+import { useJobsHistoryForSettingQuery } from "../../api/query-hooks/useJobsHistoryQuery";
+import JobHistoryFilters from "./Filters/JobsHistoryFilters";
+import JobsHistoryTable from "./JobsHistoryTable";
+
+type JobsHistoryLogsTabProps = {
+  active: boolean;
+};
+
+export default function JobsHistoryLogsTab({
+  active
+}: JobsHistoryLogsTabProps) {
+  const [searchParams] = useSearchParams();
+  const pageSize = parseInt(searchParams.get("pageSize") ?? "150");
+
+  const { data, isLoading, isRefetching } = useJobsHistoryForSettingQuery({
+    keepPreviousData: true,
+    enabled: active
+  });
+
+  const jobs = data?.data;
+  const totalEntries = data?.totalEntries;
+  const pageCount = totalEntries ? Math.ceil(totalEntries / pageSize) : -1;
+
+  return (
+    <>
+      <JobHistoryFilters defaultStatusFilter={null} />
+
+      <JobsHistoryTable
+        jobs={jobs ?? []}
+        isLoading={isLoading}
+        isRefetching={isRefetching}
+        pageCount={pageCount}
+        totalJobHistoryItems={totalEntries}
+      />
+    </>
+  );
+}

--- a/src/components/JobsHistory/JobsHistorySettingsPage.tsx
+++ b/src/components/JobsHistory/JobsHistorySettingsPage.tsx
@@ -1,23 +1,71 @@
 import { useSearchParams } from "react-router-dom";
-import { useJobsHistorySummaryForSettingQuery } from "../../api/query-hooks/useJobsHistoryQuery";
+import {
+  useJobsHistoryForSettingQuery,
+  useJobsHistorySummaryForSettingQuery
+} from "../../api/query-hooks/useJobsHistoryQuery";
 import { BreadcrumbNav, BreadcrumbRoot } from "../../ui/BreadcrumbNav";
 import { Head } from "../../ui/Head";
 import { SearchLayout } from "../../ui/Layout/SearchLayout";
+import { Tab, Tabs } from "../../ui/Tabs/Tabs";
+import JobHistoryFilters from "./Filters/JobsHistoryFilters";
 import JobHistorySummary from "./JobHistorySummary";
+import JobsHistoryTable from "./JobsHistoryTable";
+
+type JobsHistoryTab = "summary" | "logs";
 
 export default function JobsHistorySettingsPage() {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const pageSize = parseInt(searchParams.get("pageSize") ?? "50");
+  const activeTab: JobsHistoryTab =
+    searchParams.get("tab") === "logs" ? "logs" : "summary";
+  const pageSize = parseInt(
+    searchParams.get("pageSize") ?? (activeTab === "logs" ? "150" : "50")
+  );
 
-  const { data, isLoading, refetch, isRefetching } =
-    useJobsHistorySummaryForSettingQuery({
-      keepPreviousData: true
+  const {
+    data: summaryData,
+    isLoading: isSummaryLoading,
+    refetch: refetchSummary,
+    isRefetching: isSummaryRefetching
+  } = useJobsHistorySummaryForSettingQuery({
+    keepPreviousData: true,
+    enabled: activeTab === "summary"
+  });
+
+  const {
+    data: logsData,
+    isLoading: isLogsLoading,
+    refetch: refetchLogs,
+    isRefetching: isLogsRefetching
+  } = useJobsHistoryForSettingQuery({
+    keepPreviousData: true,
+    enabled: activeTab === "logs"
+  });
+
+  const summary = summaryData?.data;
+  const summaryTotalEntries = summaryData?.totalEntries;
+  const summaryPageCount = summaryTotalEntries
+    ? Math.ceil(summaryTotalEntries / pageSize)
+    : -1;
+
+  const jobs = logsData?.data;
+  const logsTotalEntries = logsData?.totalEntries;
+  const logsPageCount = logsTotalEntries
+    ? Math.ceil(logsTotalEntries / pageSize)
+    : -1;
+
+  const isLoading = activeTab === "summary" ? isSummaryLoading : isLogsLoading;
+  const isRefetching =
+    activeTab === "summary" ? isSummaryRefetching : isLogsRefetching;
+  const refetch = activeTab === "summary" ? refetchSummary : refetchLogs;
+
+  const setActiveTab = (tab: JobsHistoryTab) => {
+    setSearchParams((params) => {
+      params.set("tab", tab);
+      params.delete("pageIndex");
+      return params;
     });
-
-  const summary = data?.data;
-  const totalEntries = data?.totalEntries;
-  const pageCount = totalEntries ? Math.ceil(totalEntries / pageSize) : -1;
+  };
 
   return (
     <>
@@ -37,13 +85,40 @@ export default function JobsHistorySettingsPage() {
         loading={isLoading || isRefetching}
       >
         <div className="flex h-full w-full flex-1 flex-col p-6 pb-0">
-          <JobHistorySummary
-            data={summary ?? []}
-            isLoading={isLoading}
-            isRefetching={isRefetching}
-            pageCount={pageCount}
-            totalEntries={totalEntries}
-          />
+          <Tabs
+            activeTab={activeTab}
+            onSelectTab={setActiveTab}
+            contentClassName="flex min-h-0 flex-1 flex-col bg-white"
+          >
+            <Tab
+              label="Summary"
+              value="summary"
+              className="mt-4 flex min-h-0 flex-1 flex-col"
+            >
+              <JobHistorySummary
+                data={summary ?? []}
+                isLoading={isSummaryLoading}
+                isRefetching={isSummaryRefetching}
+                pageCount={summaryPageCount}
+                totalEntries={summaryTotalEntries}
+              />
+            </Tab>
+            <Tab
+              label="Logs"
+              value="logs"
+              className="flex min-h-0 flex-1 flex-col"
+            >
+              <JobHistoryFilters defaultStatusFilter={null} />
+
+              <JobsHistoryTable
+                jobs={jobs ?? []}
+                isLoading={isLogsLoading}
+                isRefetching={isLogsRefetching}
+                pageCount={logsPageCount}
+                totalJobHistoryItems={logsTotalEntries}
+              />
+            </Tab>
+          </Tabs>
         </div>
       </SearchLayout>
     </>

--- a/src/components/JobsHistory/JobsHistorySettingsPage.tsx
+++ b/src/components/JobsHistory/JobsHistorySettingsPage.tsx
@@ -1,15 +1,10 @@
 import { useSearchParams } from "react-router-dom";
-import {
-  useJobsHistoryForSettingQuery,
-  useJobsHistorySummaryForSettingQuery
-} from "../../api/query-hooks/useJobsHistoryQuery";
 import { BreadcrumbNav, BreadcrumbRoot } from "../../ui/BreadcrumbNav";
 import { Head } from "../../ui/Head";
 import { SearchLayout } from "../../ui/Layout/SearchLayout";
 import { Tab, Tabs } from "../../ui/Tabs/Tabs";
-import JobHistoryFilters from "./Filters/JobsHistoryFilters";
-import JobHistorySummary from "./JobHistorySummary";
-import JobsHistoryTable from "./JobsHistoryTable";
+import JobsHistoryLogsTab from "./JobsHistoryLogsTab";
+import JobsHistorySummaryTab from "./JobsHistorySummaryTab";
 
 type JobsHistoryTab = "summary" | "logs";
 
@@ -18,46 +13,6 @@ export default function JobsHistorySettingsPage() {
 
   const activeTab: JobsHistoryTab =
     searchParams.get("tab") === "logs" ? "logs" : "summary";
-  const pageSize = parseInt(
-    searchParams.get("pageSize") ?? (activeTab === "logs" ? "150" : "50")
-  );
-
-  const {
-    data: summaryData,
-    isLoading: isSummaryLoading,
-    refetch: refetchSummary,
-    isRefetching: isSummaryRefetching
-  } = useJobsHistorySummaryForSettingQuery({
-    keepPreviousData: true,
-    enabled: activeTab === "summary"
-  });
-
-  const {
-    data: logsData,
-    isLoading: isLogsLoading,
-    refetch: refetchLogs,
-    isRefetching: isLogsRefetching
-  } = useJobsHistoryForSettingQuery({
-    keepPreviousData: true,
-    enabled: activeTab === "logs"
-  });
-
-  const summary = summaryData?.data;
-  const summaryTotalEntries = summaryData?.totalEntries;
-  const summaryPageCount = summaryTotalEntries
-    ? Math.ceil(summaryTotalEntries / pageSize)
-    : -1;
-
-  const jobs = logsData?.data;
-  const logsTotalEntries = logsData?.totalEntries;
-  const logsPageCount = logsTotalEntries
-    ? Math.ceil(logsTotalEntries / pageSize)
-    : -1;
-
-  const isLoading = activeTab === "summary" ? isSummaryLoading : isLogsLoading;
-  const isRefetching =
-    activeTab === "summary" ? isSummaryRefetching : isLogsRefetching;
-  const refetch = activeTab === "summary" ? refetchSummary : refetchLogs;
 
   const setActiveTab = (tab: JobsHistoryTab) => {
     setSearchParams((params) => {
@@ -80,11 +35,9 @@ export default function JobsHistorySettingsPage() {
             ]}
           />
         }
-        onRefresh={refetch}
         contentClass="p-0 h-full"
-        loading={isLoading || isRefetching}
       >
-        <div className="flex h-full w-full flex-1 flex-col p-6 pb-0">
+        <div className="flex h-full w-full flex-1 flex-col p-4 pb-0">
           <Tabs
             activeTab={activeTab}
             onSelectTab={setActiveTab}
@@ -95,28 +48,14 @@ export default function JobsHistorySettingsPage() {
               value="summary"
               className="mt-4 flex min-h-0 flex-1 flex-col"
             >
-              <JobHistorySummary
-                data={summary ?? []}
-                isLoading={isSummaryLoading}
-                isRefetching={isSummaryRefetching}
-                pageCount={summaryPageCount}
-                totalEntries={summaryTotalEntries}
-              />
+              <JobsHistorySummaryTab active={activeTab === "summary"} />
             </Tab>
             <Tab
               label="Logs"
               value="logs"
               className="flex min-h-0 flex-1 flex-col"
             >
-              <JobHistoryFilters defaultStatusFilter={null} />
-
-              <JobsHistoryTable
-                jobs={jobs ?? []}
-                isLoading={isLogsLoading}
-                isRefetching={isLogsRefetching}
-                pageCount={logsPageCount}
-                totalJobHistoryItems={logsTotalEntries}
-              />
+              <JobsHistoryLogsTab active={activeTab === "logs"} />
             </Tab>
           </Tabs>
         </div>

--- a/src/components/JobsHistory/JobsHistorySummaryTab.tsx
+++ b/src/components/JobsHistory/JobsHistorySummaryTab.tsx
@@ -1,0 +1,34 @@
+import { useSearchParams } from "react-router-dom";
+import { useJobsHistorySummaryForSettingQuery } from "../../api/query-hooks/useJobsHistoryQuery";
+import JobHistorySummary from "./JobHistorySummary";
+
+type JobsHistorySummaryTabProps = {
+  active: boolean;
+};
+
+export default function JobsHistorySummaryTab({
+  active
+}: JobsHistorySummaryTabProps) {
+  const [searchParams] = useSearchParams();
+  const pageSize = parseInt(searchParams.get("pageSize") ?? "50");
+
+  const { data, isLoading, isRefetching } =
+    useJobsHistorySummaryForSettingQuery({
+      keepPreviousData: true,
+      enabled: active
+    });
+
+  const summary = data?.data;
+  const totalEntries = data?.totalEntries;
+  const pageCount = totalEntries ? Math.ceil(totalEntries / pageSize) : -1;
+
+  return (
+    <JobHistorySummary
+      data={summary ?? []}
+      isLoading={isLoading}
+      isRefetching={isRefetching}
+      pageCount={pageCount}
+      totalEntries={totalEntries}
+    />
+  );
+}


### PR DESCRIPTION
Add tabbed navigation to the job history settings page.

The Summary tab remains the default view, while the new Logs tab shows the full job history table with job name filtering and the Job column visible.

Extract summary and logs tab logic into dedicated components so the settings page stays focused on layout and tab selection.