### PR TITLE
fix: default job history logs to actionable statuses

### DIFF
--- a/src/components/JobsHistory/Filters/JobHistoryStatusDropdown.tsx
+++ b/src/components/JobsHistory/Filters/JobHistoryStatusDropdown.tsx
@@ -23,6 +23,16 @@ const statusOptions: Record<string, TriStateOptions> = {
     id: "4",
     label: "Failed",
     value: "FAILED"
+  },
+  stale: {
+    id: "5",
+    label: "Stale",
+    value: "STALE"
+  },
+  skipped: {
+    id: "6",
+    label: "Skipped",
+    value: "SKIPPED"
   }
 };
 

--- a/src/components/JobsHistory/JobsHistoryLogsTab.tsx
+++ b/src/components/JobsHistory/JobsHistoryLogsTab.tsx
@@ -24,7 +24,7 @@ export default function JobsHistoryLogsTab({
 
   return (
     <>
-      <JobHistoryFilters defaultStatusFilter={null} />
+      <JobHistoryFilters defaultStatusFilter="SUCCESS:-1,STALE:-1,SKIPPED:-1" />
 
       <JobsHistoryTable
         jobs={jobs ?? []}


### PR DESCRIPTION
Job history Logs currently include successful, stale, and skipped runs by default, which makes it harder to focus on actionable job runs.

Add missing `STALE` and `SKIPPED` status options to the status dropdown, and default the Logs tab to exclude `SUCCESS`, `STALE`, and `SKIPPED`.