### PR TITLE
feat(config): manage manual properties

### DIFF
--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -14,6 +14,7 @@ import {
   ConfigSummary,
   ConfigTypeRelationships
 } from "../types/configs";
+import { Property } from "../types/topology";
 
 export * from "./configAccess";
 
@@ -163,6 +164,47 @@ export const getConfig = (id: string) =>
   resolvePostGrestRequestWithPagination<ConfigDetail[]>(
     ConfigDB.get(`/config_detail?id=eq.${id}&select=*`)
   );
+
+export type UpdateConfigItemPropertiesResponse = {
+  changed: boolean;
+  properties: Property[];
+};
+
+export const updateConfigItemProperties = async (
+  configId: string,
+  creatorType: "person" | "scraper",
+  createdBy: string,
+  properties: Property[]
+) => {
+  const res = await ConfigDB.post<UpdateConfigItemPropertiesResponse[]>(
+    "/rpc/update_config_item_properties",
+    {
+      p_config_id: configId,
+      p_creator_type: creatorType,
+      p_created_by: createdBy,
+      p_properties: properties
+    }
+  );
+  return res.data?.[0];
+};
+
+export const deleteConfigItemProperty = async (
+  configId: string,
+  creatorType: "person" | "scraper",
+  createdBy: string,
+  propertyName: string
+) => {
+  const res = await ConfigDB.post<UpdateConfigItemPropertiesResponse[]>(
+    "/rpc/delete_config_item_property",
+    {
+      p_config_id: configId,
+      p_creator_type: creatorType,
+      p_created_by: createdBy,
+      p_property_name: propertyName
+    }
+  );
+  return res.data?.[0];
+};
 
 export type ConfigsTagList = {
   key: string;

--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -170,17 +170,18 @@ export type ConfigItemPropertiesResponse = {
   properties: Property[];
 };
 
-type ConfigPropertyRow = {
+export type ConfigPropertyRow = {
+  id?: string;
   config_id: string;
-  creator_type: "person" | "scraper";
-  created_by: string;
+  scraper_id?: string | null;
+  created_by?: string | null;
   name: string;
   label?: string;
   tooltip?: string;
   icon?: string;
-  type?: string;
+  property_type?: string;
   color?: string;
-  order?: number;
+  display_order?: number;
   headline?: boolean;
   hidden?: boolean;
   text?: string;
@@ -189,9 +190,9 @@ type ConfigPropertyRow = {
   max?: number;
   min?: number;
   status?: string;
-  last_transition?: string;
-  link?: string;
+  link_url?: string;
   link_label?: string;
+  link_icon?: string;
 };
 
 const getConfigProperties = async (configId: string) => {
@@ -201,7 +202,6 @@ const getConfigProperties = async (configId: string) => {
 
 const toConfigPropertyRow = (
   configId: string,
-  creatorType: "person" | "scraper",
   createdBy: string,
   property: Property
 ): ConfigPropertyRow => {
@@ -209,15 +209,14 @@ const toConfigPropertyRow = (
 
   return {
     config_id: configId,
-    creator_type: creatorType,
     created_by: createdBy,
     name: property.name,
     label: property.label,
     tooltip: property.tooltip,
     icon: property.icon,
-    type: property.type,
+    property_type: property.type,
     color: property.color,
-    order: property.order,
+    display_order: property.order,
     headline: property.headline,
     hidden: property.hidden,
     text: property.text,
@@ -229,40 +228,99 @@ const toConfigPropertyRow = (
     max: property.max,
     min: property.min,
     status: property.status,
-    link: property.link ?? property.url ?? firstLink?.url,
+    link_url: property.link ?? property.url ?? firstLink?.url,
     link_label: property.link_label ?? firstLink?.label
   };
 };
 
+const toProperty = (row: ConfigPropertyRow): Property => ({
+  name: row.name,
+  label: row.label,
+  tooltip: row.tooltip,
+  icon: row.icon,
+  type: row.property_type as Property["type"],
+  color: row.color,
+  order: row.display_order,
+  headline: row.headline,
+  hidden: row.hidden,
+  text: row.text,
+  value: row.value,
+  unit: row.unit,
+  max: row.max,
+  min: row.min,
+  status: row.status,
+  link: row.link_url,
+  link_label: row.link_label,
+  links: row.link_url
+    ? [
+        {
+          label: row.link_label ?? row.link_url,
+          url: row.link_url
+        }
+      ]
+    : undefined
+});
+
+export const getManualConfigItemProperties = async (
+  configId: string,
+  createdBy: string
+) => {
+  const result = await resolvePostGrestRequestWithPagination<
+    ConfigPropertyRow[]
+  >(
+    ConfigDB.get(
+      `/config_properties?config_id=eq.${configId}&created_by=eq.${createdBy}&order=display_order.asc,name.asc`
+    )
+  );
+
+  return result.data ?? [];
+};
+
 export const createConfigItemProperty = async (
   configId: string,
-  creatorType: "person" | "scraper",
   createdBy: string,
   property: Property
 ): Promise<ConfigItemPropertiesResponse> => {
   await ConfigDB.post(
-    "config_properties",
-    toConfigPropertyRow(configId, creatorType, createdBy, property),
+    "/config_properties",
+    toConfigPropertyRow(configId, createdBy, property),
     { headers: { Prefer: "return=minimal" } }
   );
+
+  return { changed: true, properties: await getConfigProperties(configId) };
+};
+
+export const updateConfigItemProperty = async (
+  propertyId: string,
+  configId: string,
+  createdBy: string,
+  property: Property
+): Promise<ConfigItemPropertiesResponse> => {
+  const row: Partial<ConfigPropertyRow> = toConfigPropertyRow(
+    configId,
+    createdBy,
+    property
+  );
+  delete row.config_id;
+  delete row.created_by;
+
+  await ConfigDB.patch(`/config_properties?id=eq.${propertyId}`, row, {
+    headers: { Prefer: "return=minimal" }
+  });
 
   return { changed: true, properties: await getConfigProperties(configId) };
 };
 
 export const deleteConfigItemProperty = async (
   configId: string,
-  creatorType: "person" | "scraper",
-  createdBy: string,
-  propertyName: string
+  propertyId: string
 ) => {
-  await ConfigDB.patch(
-    `config_properties?config_id=eq.${configId}&creator_type=eq.${creatorType}&created_by=eq.${createdBy}&name=eq.${encodeURIComponent(propertyName)}&deleted_at=is.null`,
-    { deleted_at: new Date().toISOString() },
-    { headers: { Prefer: "return=minimal" } }
-  );
+  await ConfigDB.delete(`/config_properties?id=eq.${propertyId}`);
 
   return { changed: true, properties: await getConfigProperties(configId) };
 };
+
+export const configPropertyRowToProperty = toProperty;
 
 export type ConfigsTagList = {
   key: string;

--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -165,27 +165,88 @@ export const getConfig = (id: string) =>
     ConfigDB.get(`/config_detail?id=eq.${id}&select=*`)
   );
 
-export type UpdateConfigItemPropertiesResponse = {
+export type ConfigItemPropertiesResponse = {
   changed: boolean;
   properties: Property[];
 };
 
-export const updateConfigItemProperties = async (
+type ConfigPropertyRow = {
+  config_id: string;
+  creator_type: "person" | "scraper";
+  created_by: string;
+  name: string;
+  label?: string;
+  tooltip?: string;
+  icon?: string;
+  type?: string;
+  color?: string;
+  order?: number;
+  headline?: boolean;
+  hidden?: boolean;
+  text?: string;
+  value?: number | string;
+  unit?: string;
+  max?: number;
+  min?: number;
+  status?: string;
+  last_transition?: string;
+  link?: string;
+  link_label?: string;
+};
+
+const getConfigProperties = async (configId: string) => {
+  const result = await getConfig(configId);
+  return result.data?.[0]?.properties ?? [];
+};
+
+const toConfigPropertyRow = (
   configId: string,
   creatorType: "person" | "scraper",
   createdBy: string,
-  properties: Property[]
-) => {
-  const res = await ConfigDB.post<UpdateConfigItemPropertiesResponse[]>(
-    "/rpc/update_config_item_properties",
-    {
-      p_config_id: configId,
-      p_creator_type: creatorType,
-      p_created_by: createdBy,
-      p_properties: properties
-    }
+  property: Property
+): ConfigPropertyRow => {
+  const firstLink = property.links?.[0];
+
+  return {
+    config_id: configId,
+    creator_type: creatorType,
+    created_by: createdBy,
+    name: property.name,
+    label: property.label,
+    tooltip: property.tooltip,
+    icon: property.icon,
+    type: property.type,
+    color: property.color,
+    order: property.order,
+    headline: property.headline,
+    hidden: property.hidden,
+    text: property.text,
+    value:
+      property.value instanceof Date
+        ? property.value.getTime()
+        : property.value,
+    unit: property.unit,
+    max: property.max,
+    min: property.min,
+    status: property.status,
+    link: property.link ?? property.url ?? firstLink?.url,
+    link_label: property.link_label ?? firstLink?.label
+  };
+};
+
+export const createConfigItemProperty = async (
+  configId: string,
+  creatorType: "person" | "scraper",
+  createdBy: string,
+  property: Property
+): Promise<ConfigItemPropertiesResponse> => {
+  await ConfigDB.post(
+    "config_properties",
+    toConfigPropertyRow(configId, creatorType, createdBy, property),
+    { headers: { Prefer: "return=minimal" } }
   );
-  return res.data?.[0];
+
+  return { changed: true, properties: await getConfigProperties(configId) };
 };
 
 export const deleteConfigItemProperty = async (
@@ -194,16 +255,13 @@ export const deleteConfigItemProperty = async (
   createdBy: string,
   propertyName: string
 ) => {
-  const res = await ConfigDB.post<UpdateConfigItemPropertiesResponse[]>(
-    "/rpc/delete_config_item_property",
-    {
-      p_config_id: configId,
-      p_creator_type: creatorType,
-      p_created_by: createdBy,
-      p_property_name: propertyName
-    }
+  await ConfigDB.patch(
+    `config_properties?config_id=eq.${configId}&creator_type=eq.${creatorType}&created_by=eq.${createdBy}&name=eq.${encodeURIComponent(propertyName)}&deleted_at=is.null`,
+    { deleted_at: new Date().toISOString() },
+    { headers: { Prefer: "return=minimal" } }
   );
-  return res.data?.[0];
+
+  return { changed: true, properties: await getConfigProperties(configId) };
 };
 
 export type ConfigsTagList = {

--- a/src/api/types/configs.ts
+++ b/src/api/types/configs.ts
@@ -83,14 +83,7 @@ export interface ConfigItem extends Timestamped, Avatar, Agent, Costs {
     playbook_runs?: number;
     checks?: number;
   };
-  properties?: {
-    icon: string;
-    name: string;
-    links: {
-      label: string;
-      url: string;
-    }[];
-  }[];
+  properties?: Property[] | null;
   last_scraped_time?: string;
 }
 

--- a/src/api/types/topology.ts
+++ b/src/api/types/topology.ts
@@ -22,6 +22,8 @@ export type Property = {
     label: string;
     url: string;
   }[];
+  created_by?: string;
+  creator_type?: "scraper" | "person" | string;
 };
 
 export interface Component extends Timestamped, Namespaced {

--- a/src/api/types/topology.ts
+++ b/src/api/types/topology.ts
@@ -8,6 +8,7 @@ export type Property = {
   name: string;
   icon?: string;
   label?: string;
+  tooltip?: string;
   type?: "url" | "badge" | "currency" | "text" | "age" | "hidden";
   text?: string;
   max?: number;
@@ -16,8 +17,13 @@ export type Property = {
   value?: ValueType;
   unit?: string;
   color?: string;
+  order?: number;
+  hidden?: boolean;
+  status?: string;
   namespace?: string;
   url?: string;
+  link?: string;
+  link_label?: string;
   links?: {
     label: string;
     url: string;

--- a/src/api/types/topology.ts
+++ b/src/api/types/topology.ts
@@ -28,8 +28,6 @@ export type Property = {
     label: string;
     url: string;
   }[];
-  created_by?: string;
-  creator_type?: "scraper" | "person" | string;
 };
 
 export interface Component extends Timestamped, Namespaced {

--- a/src/components/Configs/Sidebar/AddConfigPropertyModal.tsx
+++ b/src/components/Configs/Sidebar/AddConfigPropertyModal.tsx
@@ -87,7 +87,6 @@ export default function AddConfigPropertyModal({
 
             const result = await createConfigItemProperty(
               configId,
-              "person",
               user.id,
               newProperty
             );

--- a/src/components/Configs/Sidebar/AddConfigPropertyModal.tsx
+++ b/src/components/Configs/Sidebar/AddConfigPropertyModal.tsx
@@ -1,0 +1,151 @@
+import { updateConfigItemProperties } from "@flanksource-ui/api/services/configs";
+import { Property } from "@flanksource-ui/api/types/topology";
+import FormikTextInput from "@flanksource-ui/components/Forms/Formik/FormikTextInput";
+import {
+  toastError,
+  toastSuccess
+} from "@flanksource-ui/components/Toast/toast";
+import { useUser } from "@flanksource-ui/context";
+import { Button } from "@flanksource-ui/ui/Buttons/Button";
+import { Modal } from "@flanksource-ui/ui/Modal";
+import { Field, Form, Formik } from "formik";
+
+type Props = {
+  configId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onAdded?: (properties?: Property[]) => void;
+  existingProperties?: Property[] | null;
+};
+
+type AddPropertyForm = {
+  name: string;
+  valueType: "text" | "value";
+  text: string;
+  value: string;
+};
+
+export default function AddConfigPropertyModal({
+  configId,
+  isOpen,
+  onClose,
+  onAdded,
+  existingProperties
+}: Props) {
+  const { user } = useUser();
+
+  const userProperties =
+    existingProperties?.filter(
+      (property) =>
+        property.creator_type === "person" && property.created_by === user?.id
+    ) ?? [];
+
+  return (
+    <Modal
+      title="Add Property"
+      size="very-small"
+      open={isOpen}
+      onClose={onClose}
+    >
+      <Formik<AddPropertyForm>
+        initialValues={{ name: "", valueType: "text", text: "", value: "" }}
+        onSubmit={async (values, formik) => {
+          if (!user?.id) {
+            toastError("Could not determine current user");
+            return;
+          }
+
+          if (!values.name) {
+            toastError("Please provide property name");
+            formik.setSubmitting(false);
+            return;
+          }
+
+          if (values.valueType === "text" && !values.text) {
+            toastError("Please provide property text");
+            formik.setSubmitting(false);
+            return;
+          }
+
+          if (values.valueType === "value" && values.value === "") {
+            toastError("Please provide property value");
+            formik.setSubmitting(false);
+            return;
+          }
+
+          try {
+            const newProperty: Property =
+              values.valueType === "value"
+                ? { name: values.name, value: Number(values.value) }
+                : { name: values.name, text: values.text };
+
+            const incoming = [
+              ...userProperties.filter(
+                (property) => property.name !== values.name
+              ),
+              newProperty
+            ];
+
+            const result = await updateConfigItemProperties(
+              configId,
+              "person",
+              user.id,
+              incoming
+            );
+            toastSuccess("Property added");
+            onAdded?.(result?.properties);
+            onClose();
+          } catch (e) {
+            toastError((e as Error).message);
+          } finally {
+            formik.setSubmitting(false);
+          }
+        }}
+      >
+        {({ isSubmitting, values }) => (
+          <Form>
+            <div className="flex flex-col gap-4 p-2">
+              <FormikTextInput name="name" label="Name" required />
+              <label className="flex flex-col text-sm font-medium text-gray-700">
+                Value type
+                <Field
+                  as="select"
+                  name="valueType"
+                  className="form-select mt-1 rounded border-gray-300 text-sm"
+                >
+                  <option value="text">Text</option>
+                  <option value="value">Number</option>
+                </Field>
+              </label>
+              {values.valueType === "value" ? (
+                <FormikTextInput
+                  name="value"
+                  label="Value"
+                  type="number"
+                  required
+                />
+              ) : (
+                <FormikTextInput name="text" label="Text" required />
+              )}
+            </div>
+            <div className="flex items-center justify-end rounded-lg bg-gray-100 px-5 py-4">
+              <button
+                className="btn-secondary-base btn-secondary mr-4"
+                type="button"
+                onClick={onClose}
+              >
+                Cancel
+              </button>
+              <Button
+                type="submit"
+                text="Save"
+                className="btn-primary"
+                disabled={isSubmitting}
+              />
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </Modal>
+  );
+}

--- a/src/components/Configs/Sidebar/AddConfigPropertyModal.tsx
+++ b/src/components/Configs/Sidebar/AddConfigPropertyModal.tsx
@@ -1,4 +1,4 @@
-import { updateConfigItemProperties } from "@flanksource-ui/api/services/configs";
+import { createConfigItemProperty } from "@flanksource-ui/api/services/configs";
 import { Property } from "@flanksource-ui/api/types/topology";
 import FormikTextInput from "@flanksource-ui/components/Forms/Formik/FormikTextInput";
 import {
@@ -15,7 +15,6 @@ type Props = {
   isOpen: boolean;
   onClose: () => void;
   onAdded?: (properties?: Property[]) => void;
-  existingProperties?: Property[] | null;
 };
 
 type AddPropertyForm = {
@@ -23,22 +22,17 @@ type AddPropertyForm = {
   valueType: "text" | "value";
   text: string;
   value: string;
+  link: string;
+  link_label: string;
 };
 
 export default function AddConfigPropertyModal({
   configId,
   isOpen,
   onClose,
-  onAdded,
-  existingProperties
+  onAdded
 }: Props) {
   const { user } = useUser();
-
-  const userProperties =
-    existingProperties?.filter(
-      (property) =>
-        property.creator_type === "person" && property.created_by === user?.id
-    ) ?? [];
 
   return (
     <Modal
@@ -48,7 +42,14 @@ export default function AddConfigPropertyModal({
       onClose={onClose}
     >
       <Formik<AddPropertyForm>
-        initialValues={{ name: "", valueType: "text", text: "", value: "" }}
+        initialValues={{
+          name: "",
+          valueType: "text",
+          text: "",
+          value: "",
+          link: "",
+          link_label: ""
+        }}
         onSubmit={async (values, formik) => {
           if (!user?.id) {
             toastError("Could not determine current user");
@@ -74,23 +75,21 @@ export default function AddConfigPropertyModal({
           }
 
           try {
-            const newProperty: Property =
-              values.valueType === "value"
-                ? { name: values.name, value: Number(values.value) }
-                : { name: values.name, text: values.text };
+            const newProperty: Property = {
+              name: values.name,
+              ...(values.valueType === "value"
+                ? { value: Number(values.value) }
+                : { text: values.text }),
+              ...(values.link
+                ? { link: values.link, link_label: values.link_label }
+                : {})
+            };
 
-            const incoming = [
-              ...userProperties.filter(
-                (property) => property.name !== values.name
-              ),
-              newProperty
-            ];
-
-            const result = await updateConfigItemProperties(
+            const result = await createConfigItemProperty(
               configId,
               "person",
               user.id,
-              incoming
+              newProperty
             );
             toastSuccess("Property added");
             onAdded?.(result?.properties);
@@ -127,6 +126,8 @@ export default function AddConfigPropertyModal({
               ) : (
                 <FormikTextInput name="text" label="Text" required />
               )}
+              <FormikTextInput name="link" label="Link" />
+              <FormikTextInput name="link_label" label="Link label" />
             </div>
             <div className="flex items-center justify-end rounded-lg bg-gray-100 px-5 py-4">
               <button

--- a/src/components/Configs/Sidebar/ConfigDetails.tsx
+++ b/src/components/Configs/Sidebar/ConfigDetails.tsx
@@ -9,15 +9,19 @@ import TextSkeletonLoader from "@flanksource-ui/ui/SkeletonLoader/TextSkeletonLo
 import { refreshButtonClickedTrigger } from "@flanksource-ui/ui/SlidingSideBar/SlidingSideBar";
 import dayjs from "dayjs";
 import { useAtom } from "jotai";
-import { useMemo, useEffect } from "react";
-import { FaExclamationTriangle, FaTrash } from "react-icons/fa";
+import { useEffect, useMemo, useState } from "react";
+import { FaEdit, FaExclamationTriangle, FaPlus, FaTrash } from "react-icons/fa";
 import { Link } from "react-router-dom";
+import { Tooltip } from "react-tooltip";
 import { InfoMessage } from "../../InfoMessage";
 import { Status } from "../../Status";
 import DisplayDetailsRow from "../../Utils/DisplayDetailsRow";
 import { DisplayGroupedProperties } from "../../Utils/DisplayGroupedProperties";
 import ConfigCostValue from "../ConfigCosts/ConfigCostValue";
 import ConfigsTypeIcon from "../ConfigsTypeIcon";
+import { IconButton } from "../../../ui/Buttons/IconButton";
+import AddConfigPropertyModal from "./AddConfigPropertyModal";
+import ManageConfigPropertiesModal from "./ManageConfigPropertiesModal";
 import { formatConfigLabels } from "./Utils/formatConfigLabels";
 import { MdOutlineSupportAgent } from "react-icons/md";
 
@@ -26,6 +30,9 @@ type Props = {
 };
 
 export function ConfigDetails({ configId }: Props) {
+  const [isAddPropertyOpen, setIsAddPropertyOpen] = useState(false);
+  const [isManagePropertiesOpen, setIsManagePropertiesOpen] = useState(false);
+
   const {
     data: configDetails,
     isLoading,
@@ -252,7 +259,44 @@ export function ConfigDetails({ configId }: Props) {
 
           <DisplayDetailsRow items={types} />
 
+          <div className="flex items-center justify-between py-1 text-sm text-gray-700">
+            <span className="border-b border-dashed border-gray-500">
+              Properties
+            </span>
+            <div className="flex items-center gap-2">
+              <IconButton
+                data-tooltip-id="edit-properties-tooltip"
+                data-tooltip-content="Edit properties"
+                icon={<FaEdit className="text-gray-600" size={14} />}
+                onClick={() => setIsManagePropertiesOpen(true)}
+              />
+              <IconButton
+                data-tooltip-id="add-property-tooltip"
+                data-tooltip-content="Add property"
+                icon={<FaPlus className="text-gray-600" size={14} />}
+                onClick={() => setIsAddPropertyOpen(true)}
+              />
+            </div>
+            <Tooltip id="edit-properties-tooltip" />
+            <Tooltip id="add-property-tooltip" />
+          </div>
           <DisplayGroupedProperties items={properties} />
+
+          <AddConfigPropertyModal
+            configId={configId}
+            isOpen={isAddPropertyOpen}
+            onClose={() => setIsAddPropertyOpen(false)}
+            existingProperties={configDetails.properties}
+            onAdded={() => refetchConfig()}
+          />
+
+          <ManageConfigPropertiesModal
+            configId={configId}
+            isOpen={isManagePropertiesOpen}
+            onClose={() => setIsManagePropertiesOpen(false)}
+            existingProperties={configDetails.properties}
+            onChanged={() => refetchConfig()}
+          />
 
           {!isCostsEmpty(configDetails) && (
             <DisplayDetailsRow

--- a/src/components/Configs/Sidebar/ConfigDetails.tsx
+++ b/src/components/Configs/Sidebar/ConfigDetails.tsx
@@ -293,7 +293,6 @@ export function ConfigDetails({ configId }: Props) {
             configId={configId}
             isOpen={isManagePropertiesOpen}
             onClose={() => setIsManagePropertiesOpen(false)}
-            existingProperties={configDetails.properties}
             onChanged={() => refetchConfig()}
           />
 

--- a/src/components/Configs/Sidebar/ConfigDetails.tsx
+++ b/src/components/Configs/Sidebar/ConfigDetails.tsx
@@ -286,7 +286,6 @@ export function ConfigDetails({ configId }: Props) {
             configId={configId}
             isOpen={isAddPropertyOpen}
             onClose={() => setIsAddPropertyOpen(false)}
-            existingProperties={configDetails.properties}
             onAdded={() => refetchConfig()}
           />
 

--- a/src/components/Configs/Sidebar/ManageConfigPropertiesModal.tsx
+++ b/src/components/Configs/Sidebar/ManageConfigPropertiesModal.tsx
@@ -1,0 +1,103 @@
+import { deleteConfigItemProperty } from "@flanksource-ui/api/services/configs";
+import { Property } from "@flanksource-ui/api/types/topology";
+import {
+  toastError,
+  toastSuccess
+} from "@flanksource-ui/components/Toast/toast";
+import { useUser } from "@flanksource-ui/context";
+import { IconButton } from "@flanksource-ui/ui/Buttons/IconButton";
+import { Modal } from "@flanksource-ui/ui/Modal";
+import { FaTrash } from "react-icons/fa";
+
+type Props = {
+  configId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onChanged?: (properties?: Property[]) => void;
+  existingProperties?: Property[] | null;
+};
+
+export default function ManageConfigPropertiesModal({
+  configId,
+  isOpen,
+  onClose,
+  onChanged,
+  existingProperties
+}: Props) {
+  const { user } = useUser();
+
+  const userProperties =
+    existingProperties?.filter(
+      (property) =>
+        property.creator_type === "person" && property.created_by === user?.id
+    ) ?? [];
+
+  const deleteProperty = async (property: Property) => {
+    if (!user?.id) {
+      toastError("Could not determine current user");
+      return;
+    }
+
+    try {
+      const result = await deleteConfigItemProperty(
+        configId,
+        "person",
+        user.id,
+        property.name
+      );
+      toastSuccess("Property deleted");
+      onChanged?.(result?.properties);
+    } catch (e) {
+      toastError((e as Error).message);
+    }
+  };
+
+  return (
+    <Modal
+      title="Delete Properties"
+      size="very-small"
+      open={isOpen}
+      onClose={onClose}
+    >
+      <div className="flex flex-col gap-2 p-2">
+        {userProperties.length === 0 ? (
+          <div className="text-sm text-gray-500">
+            You have not added any manual properties.
+          </div>
+        ) : (
+          userProperties.map((property) => (
+            <div
+              key={property.name}
+              className="flex items-center justify-between rounded border border-gray-200 px-3 py-2 text-sm"
+            >
+              <div className="min-w-0">
+                <div className="truncate font-medium text-gray-700">
+                  {property.name}
+                </div>
+                <div className="truncate text-gray-500">
+                  {String(property.text ?? property.value ?? "")}
+                </div>
+              </div>
+              <IconButton
+                aria-label={`Delete ${property.name}`}
+                title="Delete property"
+                className="text-gray-500 hover:text-red-600"
+                icon={<FaTrash />}
+                onClick={() => deleteProperty(property)}
+              />
+            </div>
+          ))
+        )}
+      </div>
+      <div className="flex items-center justify-end rounded-lg bg-gray-100 px-5 py-4">
+        <button
+          className="btn-secondary-base btn-secondary"
+          type="button"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/Configs/Sidebar/ManageConfigPropertiesModal.tsx
+++ b/src/components/Configs/Sidebar/ManageConfigPropertiesModal.tsx
@@ -1,4 +1,10 @@
-import { deleteConfigItemProperty } from "@flanksource-ui/api/services/configs";
+import {
+  ConfigPropertyRow,
+  configPropertyRowToProperty,
+  deleteConfigItemProperty,
+  getManualConfigItemProperties,
+  updateConfigItemProperty
+} from "@flanksource-ui/api/services/configs";
 import { Property } from "@flanksource-ui/api/types/topology";
 import {
   toastError,
@@ -7,43 +13,111 @@ import {
 import { useUser } from "@flanksource-ui/context";
 import { IconButton } from "@flanksource-ui/ui/Buttons/IconButton";
 import { Modal } from "@flanksource-ui/ui/Modal";
-import { FaTrash } from "react-icons/fa";
+import { useEffect, useState } from "react";
+import { FaEdit, FaSave, FaTimes, FaTrash } from "react-icons/fa";
 
 type Props = {
   configId: string;
   isOpen: boolean;
   onClose: () => void;
   onChanged?: (properties?: Property[]) => void;
-  existingProperties?: Property[] | null;
 };
 
 export default function ManageConfigPropertiesModal({
   configId,
   isOpen,
   onClose,
-  onChanged,
-  existingProperties
+  onChanged
 }: Props) {
   const { user } = useUser();
+  const [userProperties, setUserProperties] = useState<ConfigPropertyRow[]>([]);
+  const [editingPropertyId, setEditingPropertyId] = useState<string>();
+  const [draftProperty, setDraftProperty] = useState({
+    name: "",
+    text: "",
+    value: "",
+    link_url: "",
+    link_label: ""
+  });
 
-  const userProperties =
-    existingProperties?.filter(
-      (property) =>
-        property.creator_type === "person" && property.created_by === user?.id
-    ) ?? [];
+  useEffect(() => {
+    if (!isOpen || !user?.id) {
+      setUserProperties([]);
+      return;
+    }
 
-  const deleteProperty = async (property: Property) => {
-    if (!user?.id) {
-      toastError("Could not determine current user");
+    getManualConfigItemProperties(configId, user.id)
+      .then(setUserProperties)
+      .catch((e) => toastError((e as Error).message));
+  }, [configId, isOpen, user?.id]);
+
+  const startEditing = (property: ConfigPropertyRow) => {
+    setEditingPropertyId(property.id);
+    setDraftProperty({
+      name: property.name,
+      text: property.text ?? "",
+      value: property.value?.toString() ?? "",
+      link_url: property.link_url ?? "",
+      link_label: property.link_label ?? ""
+    });
+  };
+
+  const updateProperty = async (property: ConfigPropertyRow) => {
+    if (!property.id || !user?.id) {
+      toastError("Could not determine property id or current user");
+      return;
+    }
+
+    if (!draftProperty.name) {
+      toastError("Please provide property name");
+      return;
+    }
+
+    if (!draftProperty.text && draftProperty.value === "") {
+      toastError("Please provide property text or value");
+      return;
+    }
+
+    const nextProperty: ConfigPropertyRow = {
+      ...property,
+      name: draftProperty.name,
+      text: draftProperty.value === "" ? draftProperty.text : undefined,
+      value:
+        draftProperty.value === "" ? undefined : Number(draftProperty.value),
+      link_url: draftProperty.link_url || undefined,
+      link_label: draftProperty.link_label || undefined
+    };
+
+    try {
+      const result = await updateConfigItemProperty(
+        property.id,
+        configId,
+        user.id,
+        configPropertyRowToProperty(nextProperty)
+      );
+      setUserProperties((properties) =>
+        properties.map((item) =>
+          item.id === property.id ? nextProperty : item
+        )
+      );
+      setEditingPropertyId(undefined);
+      toastSuccess("Property updated");
+      onChanged?.(result?.properties);
+    } catch (e) {
+      toastError((e as Error).message);
+    }
+  };
+
+  const deleteProperty = async (property: ConfigPropertyRow) => {
+    if (!property.id) {
+      toastError("Could not determine property id");
       return;
     }
 
     try {
-      const result = await deleteConfigItemProperty(
-        configId,
-        "person",
-        user.id,
-        property.name
+      const result = await deleteConfigItemProperty(configId, property.id);
+      setUserProperties((properties) =>
+        properties.filter((item) => item.id !== property.id)
       );
       toastSuccess("Property deleted");
       onChanged?.(result?.properties);
@@ -54,7 +128,7 @@ export default function ManageConfigPropertiesModal({
 
   return (
     <Modal
-      title="Delete Properties"
+      title="Manage Properties"
       size="very-small"
       open={isOpen}
       onClose={onClose}
@@ -65,28 +139,125 @@ export default function ManageConfigPropertiesModal({
             You have not added any manual properties.
           </div>
         ) : (
-          userProperties.map((property) => (
-            <div
-              key={property.name}
-              className="flex items-center justify-between rounded border border-gray-200 px-3 py-2 text-sm"
-            >
-              <div className="min-w-0">
-                <div className="truncate font-medium text-gray-700">
-                  {property.name}
+          userProperties.map((property) => {
+            const isEditing = editingPropertyId === property.id;
+
+            return (
+              <div
+                key={property.id ?? property.name}
+                className="flex items-center justify-between gap-2 rounded border border-gray-200 px-3 py-2 text-sm"
+              >
+                <div className="min-w-0 flex-1">
+                  {isEditing ? (
+                    <div className="flex flex-col gap-2">
+                      <input
+                        className="form-input rounded border-gray-300 text-sm"
+                        value={draftProperty.name}
+                        onChange={(e) =>
+                          setDraftProperty((draft) => ({
+                            ...draft,
+                            name: e.target.value
+                          }))
+                        }
+                        placeholder="Name"
+                      />
+                      <input
+                        className="form-input rounded border-gray-300 text-sm"
+                        value={draftProperty.text}
+                        onChange={(e) =>
+                          setDraftProperty((draft) => ({
+                            ...draft,
+                            text: e.target.value,
+                            value: ""
+                          }))
+                        }
+                        placeholder="Text"
+                      />
+                      <input
+                        className="form-input rounded border-gray-300 text-sm"
+                        type="number"
+                        value={draftProperty.value}
+                        onChange={(e) =>
+                          setDraftProperty((draft) => ({
+                            ...draft,
+                            value: e.target.value,
+                            text: ""
+                          }))
+                        }
+                        placeholder="Value"
+                      />
+                      <input
+                        className="form-input rounded border-gray-300 text-sm"
+                        value={draftProperty.link_url}
+                        onChange={(e) =>
+                          setDraftProperty((draft) => ({
+                            ...draft,
+                            link_url: e.target.value
+                          }))
+                        }
+                        placeholder="Link URL"
+                      />
+                      <input
+                        className="form-input rounded border-gray-300 text-sm"
+                        value={draftProperty.link_label}
+                        onChange={(e) =>
+                          setDraftProperty((draft) => ({
+                            ...draft,
+                            link_label: e.target.value
+                          }))
+                        }
+                        placeholder="Link label"
+                      />
+                    </div>
+                  ) : (
+                    <>
+                      <div className="truncate font-medium text-gray-700">
+                        {property.name}
+                      </div>
+                      <div className="truncate text-gray-500">
+                        {String(property.text ?? property.value ?? "")}
+                      </div>
+                    </>
+                  )}
                 </div>
-                <div className="truncate text-gray-500">
-                  {String(property.text ?? property.value ?? "")}
+                <div className="flex items-center gap-1">
+                  {isEditing ? (
+                    <>
+                      <IconButton
+                        aria-label={`Save ${property.name}`}
+                        title="Save property"
+                        className="text-gray-500 hover:text-green-600"
+                        icon={<FaSave />}
+                        onClick={() => updateProperty(property)}
+                      />
+                      <IconButton
+                        aria-label="Cancel edit"
+                        title="Cancel edit"
+                        className="text-gray-500"
+                        icon={<FaTimes />}
+                        onClick={() => setEditingPropertyId(undefined)}
+                      />
+                    </>
+                  ) : (
+                    <IconButton
+                      aria-label={`Edit ${property.name}`}
+                      title="Edit property"
+                      className="text-gray-500"
+                      icon={<FaEdit />}
+                      onClick={() => startEditing(property)}
+                    />
+                  )}
+                  <IconButton
+                    aria-label={`Delete ${property.name}`}
+                    title="Delete property"
+                    className="text-gray-500 hover:text-red-600"
+                    icon={<FaTrash />}
+                    onClick={() => deleteProperty(property)}
+                  />
                 </div>
               </div>
-              <IconButton
-                aria-label={`Delete ${property.name}`}
-                title="Delete property"
-                className="text-gray-500 hover:text-red-600"
-                icon={<FaTrash />}
-                onClick={() => deleteProperty(property)}
-              />
-            </div>
-          ))
+            );
+          })
         )}
       </div>
       <div className="flex items-center justify-end rounded-lg bg-gray-100 px-5 py-4">

--- a/src/components/Topology/Sidebar/Utils/formatProperties.tsx
+++ b/src/components/Topology/Sidebar/Utils/formatProperties.tsx
@@ -28,7 +28,11 @@ type SingleProperty = {
 
 export type PropertyItem = GroupedProperties | SingleProperty;
 
-export function formatProperties(topology?: Pick<Topology, "properties">) {
+export function formatProperties(
+  topology?:
+    | Pick<Topology, "properties">
+    | { properties?: Topology["properties"] | null }
+) {
   if (topology == null) {
     return [];
   }


### PR DESCRIPTION
Add config sidebar actions for users to add and delete manually-owned config properties.

Manual add supports both text and numeric property values. Delete is exposed through a separate properties manage modal and calls the single-property delete RPC so users do not replace their whole owned property list.

Property ownership fields are carried through config property types so the UI only shows the current user's manual properties for deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to add custom properties to configuration items with a dedicated modal interface.
  * Added ability to manage and delete user-created properties.
  * Property management now tracks creator information for better organization and ownership clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->