### PR TITLE
fix(ui): improve toast and plugin error handling

### DIFF
--- a/src/api/query-hooks/useFeatureFlags.tsx
+++ b/src/api/query-hooks/useFeatureFlags.tsx
@@ -75,7 +75,7 @@ export function useAddFeatureFlag(onSuccess: () => void) {
       onSuccess();
     },
     onError: (error) => {
-      toastError((error as Error).message);
+      toastError(error);
     }
   });
 }
@@ -98,7 +98,7 @@ export function useUpdateFeatureFlag(onSuccess: () => void) {
       onSuccess();
     },
     onError: (error) => {
-      toastError((error as Error).message);
+      toastError(error);
     }
   });
 }
@@ -116,7 +116,7 @@ export function useDeleteFeatureFlag(onSuccess: () => void) {
       onSuccess();
     },
     onError: (error) => {
-      toastError((error as Error).message);
+      toastError(error);
     }
   });
 }

--- a/src/api/services/scrapePlugins.ts
+++ b/src/api/services/scrapePlugins.ts
@@ -45,7 +45,9 @@ export const getAllScrapePlugins = (
   );
 };
 
-export const createScrapePlugin = async (plugin: Partial<ScrapePlugin>) => {
+export const createScrapePlugin = async (
+  plugin: Omit<Partial<ScrapePlugin>, "created_by"> & { created_by?: string }
+) => {
   return ConfigDB.post("/scrape_plugins", plugin);
 };
 

--- a/src/components/Configs/Sidebar/ConfigsPanel.tsx
+++ b/src/components/Configs/Sidebar/ConfigsPanel.tsx
@@ -62,7 +62,7 @@ export function ConfigsPanelList({
       }
       toastError(response.error?.message);
     } catch (ex) {
-      toastError((ex as Error).message);
+      toastError(ex);
     }
   };
 

--- a/src/components/Forms/Formik/FormikConnectionField.tsx
+++ b/src/components/Forms/Formik/FormikConnectionField.tsx
@@ -38,7 +38,7 @@ export default function FormikConnectionField({
       });
     },
     onError: (err: Error) => {
-      toastError((err as Error).message);
+      toastError(err);
     }
   });
 

--- a/src/components/Plugins/PluginsForm.tsx
+++ b/src/components/Plugins/PluginsForm.tsx
@@ -16,6 +16,7 @@ type PluginsFormProps = {
   handleBack?: () => void;
   isSubmitting?: boolean;
   isDeleting?: boolean;
+  errorMessage?: string;
   className?: string;
 };
 
@@ -26,9 +27,11 @@ export default function PluginsForm({
   handleBack = () => {},
   isSubmitting = false,
   isDeleting = false,
+  errorMessage,
   className
 }: PluginsFormProps) {
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+  const [isErrorExpanded, setIsErrorExpanded] = useState(false);
   const isReadOnly = formValue?.source === "KubernetesCRD";
 
   return (
@@ -77,6 +80,22 @@ export default function PluginsForm({
               />
             </div>
           </div>
+          {errorMessage && (
+            <div className="mx-4 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+              <div className={isErrorExpanded ? "" : "line-clamp-2"}>
+                {errorMessage}
+              </div>
+              {errorMessage.length > 120 && (
+                <button
+                  type="button"
+                  className="mt-1 text-xs font-medium text-red-600 hover:text-red-800"
+                  onClick={() => setIsErrorExpanded(!isErrorExpanded)}
+                >
+                  {isErrorExpanded ? "Show less" : "Show more"}
+                </button>
+              )}
+            </div>
+          )}
           <div className="flex items-center gap-2 rounded-lg bg-gray-100 px-5 py-4">
             {!formValue?.id && (
               <Button

--- a/src/components/Plugins/PluginsFormModal.tsx
+++ b/src/components/Plugins/PluginsFormModal.tsx
@@ -15,6 +15,7 @@ type PluginsFormModalProps = Omit<
   formValue?: ScrapePlugin;
   isSubmitting?: boolean;
   isDeleting?: boolean;
+  errorMessage?: string;
 };
 
 export default function PluginsFormModal({
@@ -25,7 +26,8 @@ export default function PluginsFormModal({
   onDelete,
   formValue,
   isSubmitting = false,
-  isDeleting = false
+  isDeleting = false,
+  errorMessage
 }: PluginsFormModalProps) {
   const [, setHelpModal] = useAtom(modalHelpLinkAtom);
   useEffect(() => {
@@ -56,6 +58,7 @@ export default function PluginsFormModal({
         className={className}
         isSubmitting={isSubmitting}
         isDeleting={isDeleting}
+        errorMessage={errorMessage}
         handleBack={() => setIsOpen(false)}
       />
     </Modal>

--- a/src/components/Toast/toast.ts
+++ b/src/components/Toast/toast.ts
@@ -1,26 +1,11 @@
+import { getErrorMessage } from "@flanksource-ui/api/types/error";
 import toast, { ToastOptions } from "react-hot-toast";
 
-type ErrorMessage =
-  | {
-      response?: {
-        data?: {
-          error: string;
-          message: string;
-        };
-      };
-    }
-  | string
-  | undefined;
-
-export function toastError(message: ErrorMessage) {
-  if (typeof message === "string" || !message) {
+export function toastError(message: unknown) {
+  if (typeof message === "string") {
     toast.error(message || "An error occurred");
   } else {
-    toast.error(
-      message.response?.data?.error ||
-        message.response?.data?.message ||
-        "An error occurred"
-    );
+    toast.error(getErrorMessage(message) || "An error occurred");
   }
 }
 

--- a/src/pages/Settings/ConnectionsPage.tsx
+++ b/src/pages/Settings/ConnectionsPage.tsx
@@ -119,7 +119,7 @@ export function ConnectionsPage() {
         toastSuccess("Connection added successfully");
       },
       onError: (ex) => {
-        toastError((ex as Error).message);
+        toastError(ex);
       }
     });
 
@@ -138,7 +138,7 @@ export function ConnectionsPage() {
         toastSuccess("Connection updated successfully");
       },
       onError: (ex) => {
-        toastError((ex as Error).message);
+        toastError(ex);
       }
     });
 
@@ -156,7 +156,7 @@ export function ConnectionsPage() {
       toastSuccess("Connection deleted successfully");
     },
     onError: (ex) => {
-      toastError((ex as Error).message);
+      toastError(ex);
     }
   });
 

--- a/src/pages/applications/ApplicationsPage.tsx
+++ b/src/pages/applications/ApplicationsPage.tsx
@@ -86,7 +86,7 @@ export function ApplicationsPage() {
         toastSuccess("Application added successfully");
       },
       onError: (ex) => {
-        toastError((ex as Error).message);
+        toastError(ex);
       }
     });
 
@@ -105,7 +105,7 @@ export function ApplicationsPage() {
         toastSuccess("Application updated successfully");
       },
       onError: (ex) => {
-        toastError((ex as Error).message);
+        toastError(ex);
       }
     });
 
@@ -123,7 +123,7 @@ export function ApplicationsPage() {
       toastSuccess("Application deleted successfully");
     },
     onError: (ex) => {
-      toastError((ex as Error).message);
+      toastError(ex);
     }
   });
 

--- a/src/pages/config/settings/ConfigPluginsPage.tsx
+++ b/src/pages/config/settings/ConfigPluginsPage.tsx
@@ -8,10 +8,8 @@ import {
 import ConfigPageTabs from "@flanksource-ui/components/Configs/ConfigPageTabs";
 import { AuthorizationAccessCheck } from "@flanksource-ui/components/Permissions/AuthorizationAccessCheck";
 import PluginsFormModal from "@flanksource-ui/components/Plugins/PluginsFormModal";
-import {
-  toastError,
-  toastSuccess
-} from "@flanksource-ui/components/Toast/toast";
+import { toastSuccess } from "@flanksource-ui/components/Toast/toast";
+import { getErrorMessage } from "@flanksource-ui/api/types/error";
 import { useUser } from "@flanksource-ui/context";
 import { tables } from "@flanksource-ui/context/UserAccessContext/permissions";
 import {
@@ -27,7 +25,7 @@ import { Head } from "@flanksource-ui/ui/Head";
 import { SearchLayout } from "@flanksource-ui/ui/Layout/SearchLayout";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { MRT_ColumnDef } from "mantine-react-table";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AiFillPlusCircle } from "react-icons/ai";
 import CRDSource from "@flanksource-ui/components/Settings/CRDSource";
 
@@ -140,6 +138,9 @@ export default function ConfigPluginsPage() {
   const user = useUser();
   const [isOpen, setIsOpen] = useState(false);
   const [editedRow, setEditedRow] = useState<ScrapePlugin>();
+  const [formError, setFormError] = useState<string>();
+
+  const clearFormError = useCallback(() => setFormError(undefined), []);
   const [sortState] = useReactTableSortState();
   const { pageIndex, pageSize } = useReactTablePaginationState();
 
@@ -160,7 +161,7 @@ export default function ConfigPluginsPage() {
       const payload = buildPluginPayload(values.name, values.spec);
       const response = await createScrapePlugin({
         ...payload,
-        created_by: user.user,
+        created_by: user.user?.id,
         source: payload.source || "UI"
       });
       return response?.data;
@@ -171,7 +172,7 @@ export default function ConfigPluginsPage() {
       toastSuccess("Plugin added successfully");
     },
     onError: (ex) => {
-      toastError((ex as Error).message);
+      setFormError(getErrorMessage(ex));
     }
   });
 
@@ -193,7 +194,7 @@ export default function ConfigPluginsPage() {
       toastSuccess("Plugin updated successfully");
     },
     onError: (ex) => {
-      toastError((ex as Error).message);
+      setFormError(getErrorMessage(ex));
     }
   });
 
@@ -208,7 +209,7 @@ export default function ConfigPluginsPage() {
       toastSuccess("Plugin deleted successfully");
     },
     onError: (ex) => {
-      toastError((ex as Error).message);
+      setFormError(getErrorMessage(ex));
     }
   });
 
@@ -280,6 +281,7 @@ export default function ConfigPluginsPage() {
           isOpen={isOpen}
           setIsOpen={setIsOpen}
           onSubmit={(values: { name: string; spec: Record<string, any> }) => {
+            clearFormError();
             if (editedRow?.id) {
               updatePlugin(values);
             } else {
@@ -290,6 +292,7 @@ export default function ConfigPluginsPage() {
           isSubmitting={isSubmitting}
           isDeleting={isDeleting}
           formValue={editedRow}
+          errorMessage={formError}
           key={editedRow?.id || "plugin-form"}
         />
       </SearchLayout>

--- a/src/pages/views/ViewsPage.tsx
+++ b/src/pages/views/ViewsPage.tsx
@@ -75,7 +75,7 @@ export function ViewsPage() {
       toastSuccess("View added successfully");
     },
     onError: (ex) => {
-      toastError((ex as Error).message);
+      toastError(ex);
     }
   });
 
@@ -93,7 +93,7 @@ export function ViewsPage() {
       toastSuccess("View updated successfully");
     },
     onError: (ex) => {
-      toastError((ex as Error).message);
+      toastError(ex);
     }
   });
 
@@ -108,7 +108,7 @@ export function ViewsPage() {
       toastSuccess("View deleted successfully");
     },
     onError: (ex) => {
-      toastError((ex as Error).message);
+      toastError(ex);
     }
   });
 

--- a/src/ui/ToasterWithCloseButton.tsx
+++ b/src/ui/ToasterWithCloseButton.tsx
@@ -13,47 +13,54 @@ export function ToasterWithCloseButton() {
         duration: 5000
       }}
     >
-      {(t) => (
-        <ToastBar toast={t}>
-          {({ message }) => (
-            <div>
-              <div className="flex items-center">
-                <div className="flex-shrink-0">
-                  {t.type === "success" && (
-                    <FaCheckCircle className="h-5 w-5 text-green-400" />
-                  )}
-                  {t.type === "error" && (
-                    <IoCloseCircleSharp className="h-5 w-5 text-red-500" />
-                  )}
-                  {t.type === "loading" && (
-                    <AiOutlineLoading3Quarters className="h-5 w-5 animate-spin" />
-                  )}
-                </div>
+      {(t) => {
+        const resolved = resolveValue(t.message, t);
+        const textLen = typeof resolved === "string" ? resolved.length : 40;
+        const widthClass =
+          textLen > 200 ? "max-w-2xl" : textLen > 80 ? "max-w-lg" : "max-w-xs";
 
-                <div className="ml-1 max-w-60 flex-1">
-                  <p className="text-sm font-medium text-gray-900">
-                    {resolveValue(message, t)}
-                  </p>
-                </div>
-                {t.type !== "loading" && (
-                  <div className="ml-4 flex flex-shrink-0">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        toast.dismiss(t.id);
-                      }}
-                      className="inline-flex rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                    >
-                      <span className="sr-only">Close</span>
-                      <XIcon aria-hidden="true" className="h-5 w-5" />
-                    </button>
+        return (
+          <ToastBar toast={t}>
+            {({ message }) => (
+              <div>
+                <div className="flex items-start">
+                  <div className="flex-shrink-0 pt-0.5">
+                    {t.type === "success" && (
+                      <FaCheckCircle className="h-5 w-5 text-green-400" />
+                    )}
+                    {t.type === "error" && (
+                      <IoCloseCircleSharp className="h-5 w-5 text-red-500" />
+                    )}
+                    {t.type === "loading" && (
+                      <AiOutlineLoading3Quarters className="h-5 w-5 animate-spin" />
+                    )}
                   </div>
-                )}
+
+                  <div className={`ml-1 flex-1 ${widthClass}`}>
+                    <p className="break-words text-sm font-medium text-gray-900">
+                      {resolveValue(message, t)}
+                    </p>
+                  </div>
+                  {t.type !== "loading" && (
+                    <div className="ml-4 flex flex-shrink-0">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          toast.dismiss(t.id);
+                        }}
+                        className="inline-flex rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                      >
+                        <span className="sr-only">Close</span>
+                        <XIcon aria-hidden="true" className="h-5 w-5" />
+                      </button>
+                    </div>
+                  )}
+                </div>
               </div>
-            </div>
-          )}
-        </ToastBar>
-      )}
+            )}
+          </ToastBar>
+        );
+      }}
     </Toaster>
   );
 }


### PR DESCRIPTION
Improves UI error handling for API failures and plugin form submissions.

   ## Changes

   - Uses `getErrorMessage` for API error extraction in toast flows
   - Shows plugin create/update/delete errors inline in the plugin modal
   - Sends creator user ID for new scrape plugins instead of the full user object