### PR TITLE
feat(artifacts): add artifacts settings page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import React, { ReactNode, useEffect, useState, useMemo } from "react";
 import { IconType } from "react-icons";
 import { AiFillHeart } from "react-icons/ai";
 import { BsLink, BsToggles } from "react-icons/bs";
-import { FaBell, FaCrosshairs, FaTasks } from "react-icons/fa";
+import { FaArchive, FaBell, FaCrosshairs, FaTasks } from "react-icons/fa";
 import { HiUser } from "react-icons/hi";
 import { ImLifebuoy } from "react-icons/im";
 import {
@@ -46,6 +46,7 @@ import { IncidentPageContextProvider } from "./context/IncidentPageContext";
 import { UserAccessStateContextProvider } from "./context/UserAccessContext/UserAccessContext";
 import { tables } from "./context/UserAccessContext/permissions";
 
+import { ArtifactsPage } from "./pages/Settings/ArtifactsPage";
 import { PermissionsPage } from "./pages/Settings/PermissionsPage";
 import { PermissionsSubjectsPage } from "./pages/Settings/PermissionsSubjectsPage";
 import McpOverviewPage from "./pages/Settings/mcp/McpOverviewPage";
@@ -392,6 +393,13 @@ const settingsNav: SettingsNavigationItems = {
   checkPath: false,
   submenu: [
     {
+      name: "Artifacts",
+      href: "/settings/artifacts",
+      icon: FaArchive,
+      featureName: features["settings.artifacts"],
+      resourceName: tables.artifacts
+    },
+    {
       name: "Connections",
       href: "/settings/connections",
       icon: BsLink,
@@ -737,6 +745,15 @@ export function IncidentManagerRoutes({ sidebar }: { sidebar: ReactNode }) {
       </Route>
 
       <Route path="settings" element={sidebar}>
+        <Route
+          path="artifacts"
+          element={withAuthorizationAccessCheck(
+            <ArtifactsPage />,
+            tables.artifacts,
+            "read",
+            true
+          )}
+        />
         <Route
           path="connections"
           element={withAuthorizationAccessCheck(

--- a/src/api/services/artifacts.ts
+++ b/src/api/services/artifacts.ts
@@ -1,8 +1,67 @@
-import { ArtifactAPI } from "../axios";
+import { SortingState } from "@tanstack/react-table";
+import { Artifact, ArtifactSummary } from "../types/artifacts";
+import { ArtifactAPI, IncidentCommander } from "../axios";
+import { resolvePostGrestRequestWithPagination } from "../resolve";
+
+export function artifactDownloadURL(artifactId: string, filename?: string) {
+  const params = filename ? `?filename=${encodeURIComponent(filename)}` : "";
+  return `/api/artifacts/download/${artifactId}${params}`;
+}
 
 export async function downloadArtifact(artifactId: string) {
   const response = await ArtifactAPI.get(`/download/${artifactId}`, {
     responseType: "text"
   });
   return response.data;
+}
+
+export async function fetchArtifacts({
+  pageIndex = 0,
+  pageSize = 50,
+  sortBy,
+  contentType,
+  filenameSearch
+}: {
+  pageIndex?: number;
+  pageSize?: number;
+  sortBy?: SortingState;
+  contentType?: string;
+  filenameSearch?: string;
+}) {
+  const query = new URLSearchParams({
+    select:
+      "*,playbook_run_action:playbook_run_actions(id,name,playbook_run_id),config_change:config_changes(id,config_id,change_type)"
+  });
+
+  query.set("limit", pageSize.toString());
+  query.set("offset", (pageIndex * pageSize).toString());
+
+  if (sortBy && sortBy.length > 0) {
+    query.set("order", `${sortBy[0].id}.${sortBy[0].desc ? "desc" : "asc"}`);
+  } else {
+    query.set("order", "created_at.desc");
+  }
+
+  if (contentType && contentType !== "all") {
+    query.set("content_type", `eq.${contentType}`);
+  }
+
+  if (filenameSearch) {
+    query.set("filename", `ilike.*${filenameSearch}*`);
+  }
+
+  return resolvePostGrestRequestWithPagination(
+    IncidentCommander.get<Artifact[]>(`/artifacts?${query.toString()}`, {
+      headers: {
+        Prefer: "count=exact"
+      }
+    })
+  );
+}
+
+export async function fetchArtifactSummary() {
+  const res = await IncidentCommander.get<ArtifactSummary[]>(
+    "/artifact_summary?select=*"
+  );
+  return res.data ?? [];
 }

--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -382,7 +382,7 @@ export const getConfigListFilteredByType = (types: string[]) => {
 
 export const getConfigChangeById = async (id: string) => {
   const res = await ConfigDB.get<ConfigChange[] | null>(
-    `/config_changes?id=eq.${id}&select=id,config_id,change_type,created_at,external_created_by,source,diff,details,patches,created_by,config:configs(id,name,type,config_class)`
+    `/config_changes?id=eq.${id}&select=id,config_id,change_type,created_at,external_created_by,source,diff,details,patches,created_by,config:configs(id,name,type,config_class),artifacts:artifacts(*)::jsonb`
   );
   return res.data?.[0] ?? null;
 };

--- a/src/api/types/artifacts.ts
+++ b/src/api/types/artifacts.ts
@@ -1,0 +1,25 @@
+export type Artifact = {
+  id: string;
+  filename: string;
+  path: string;
+  content_type: string;
+  checksum: string;
+  size: number;
+  playbook_run_action_id?: string;
+  config_change_id?: string;
+  connection_id?: string;
+  created_at: string;
+  // PostgREST embedded joins
+  playbook_run_action?: { id: string; name: string; playbook_run_id: string };
+  config_change?: { id: string; config_id: string; change_type: string };
+};
+
+export type ArtifactSummary = {
+  content_type: string;
+  storage: "inline" | "external";
+  connection_id: string | null;
+  connection_name: string | null;
+  connection_type: string | null;
+  total_count: number;
+  total_size: number;
+};

--- a/src/api/types/configs.ts
+++ b/src/api/types/configs.ts
@@ -1,5 +1,6 @@
 import { Agent, Avatar, CreatedAt, Timestamped } from "../traits";
 import { HealthCheckSummary } from "./health";
+import { PlaybookArtifact } from "./playbooks";
 import { Property } from "./topology";
 
 export interface ConfigChange extends CreatedAt {
@@ -24,6 +25,7 @@ export interface ConfigChange extends CreatedAt {
   first_observed?: string;
   count?: number;
   inserted_at?: string;
+  artifacts?: PlaybookArtifact[];
 }
 
 export interface Change {

--- a/src/components/Artifacts/ArtifactPreviewModal.tsx
+++ b/src/components/Artifacts/ArtifactPreviewModal.tsx
@@ -1,0 +1,161 @@
+import { Artifact } from "@flanksource-ui/api/types/artifacts";
+import {
+  artifactDownloadURL,
+  downloadArtifact
+} from "@flanksource-ui/api/services/artifacts";
+import { formatBytes } from "@flanksource-ui/utils/common";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@flanksource-ui/components/ui/dialog";
+import { Button } from "@flanksource-ui/ui/Buttons/Button";
+import CodeBlock from "@flanksource-ui/ui/Code/CodeBlock";
+import { darkTheme } from "@flanksource-ui/ui/Code/JSONViewerTheme";
+import { JSONViewer } from "@flanksource-ui/ui/Code/JSONViewer";
+import { DisplayMarkdown } from "@flanksource-ui/components/Utils/Markdown";
+import { useQuery } from "@tanstack/react-query";
+import { IoMdDownload } from "react-icons/io";
+
+type ArtifactPreviewModalProps = {
+  artifact: Artifact | undefined;
+  onClose: () => void;
+};
+
+const MAX_PREVIEW_SIZE = 50 * 1024 * 1024; // 50MB
+
+function isImageContentType(contentType: string) {
+  return contentType.startsWith("image/");
+}
+
+export function ArtifactPreviewModal({
+  artifact,
+  onClose
+}: ArtifactPreviewModalProps) {
+  const isSmallFile = artifact ? artifact.size < MAX_PREVIEW_SIZE : false;
+
+  const isImage = artifact ? isImageContentType(artifact.content_type) : false;
+
+  const { data: content, isFetching: isLoading } = useQuery({
+    queryKey: ["artifact", artifact?.id],
+    queryFn: () => downloadArtifact(artifact!.id),
+    enabled: !!artifact && isSmallFile && !isImage,
+    staleTime: Infinity,
+    cacheTime: 1000 * 60 * 60 * 24
+  });
+
+  const downloadURL = artifact
+    ? artifactDownloadURL(artifact.id, artifact.filename)
+    : undefined;
+
+  return (
+    <Dialog open={!!artifact} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-h-[80vh] max-w-4xl overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <span>{artifact?.filename}</span>
+            {artifact && (
+              <span className="text-sm font-normal text-gray-500">
+                ({formatBytes(artifact.size)})
+              </span>
+            )}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="max-h-[60vh] overflow-auto">
+          {artifact && !isSmallFile && (
+            <div className="py-8 text-center text-gray-500">
+              <p className="mb-4">
+                File is too large to preview. Maximum file size is 50MB.
+              </p>
+              <a href={downloadURL} target="_blank" rel="noreferrer">
+                <Button text="Download" icon={<IoMdDownload />} />
+              </a>
+            </div>
+          )}
+
+          {isLoading && (
+            <div className="flex items-center justify-center py-8">
+              <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-500" />
+              <span className="ml-2">Loading...</span>
+            </div>
+          )}
+
+          {isImage && artifact && downloadURL && (
+            <img
+              src={downloadURL}
+              alt={artifact.filename}
+              className="max-h-[60vh] max-w-full object-contain"
+            />
+          )}
+
+          {content &&
+            artifact &&
+            !isImage &&
+            renderContent(artifact.content_type, content)}
+        </div>
+
+        <DialogFooter className="pt-2">
+          {downloadURL && (
+            <a href={downloadURL} target="_blank" rel="noreferrer">
+              <Button
+                text="Download"
+                icon={<IoMdDownload />}
+                className="btn-secondary"
+              />
+            </a>
+          )}
+          <Button text="Close" onClick={onClose} className="btn-primary" />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function renderContent(contentType: string, content: string) {
+  switch (contentType) {
+    case "text/x-shellscript":
+      return (
+        <CodeBlock
+          code={content}
+          language="bash"
+          className="bg-black text-white"
+          codeBlockClassName="whitespace-pre"
+          theme={darkTheme}
+        />
+      );
+
+    case "application/sql":
+      return (
+        <CodeBlock
+          code={content}
+          language="sql"
+          className="bg-black text-white"
+          codeBlockClassName="whitespace-pre"
+          theme={darkTheme}
+        />
+      );
+
+    case "text/markdown":
+    case "markdown":
+      return <DisplayMarkdown md={content} />;
+
+    case "application/yaml":
+    case "application/json":
+      return (
+        <pre>
+          <JSONViewer format="json" code={content} convertToYaml />
+        </pre>
+      );
+
+    case "text/plain":
+    default:
+      return (
+        <pre className="whitespace-pre-wrap bg-gray-50 p-4 text-sm">
+          {content}
+        </pre>
+      );
+  }
+}

--- a/src/components/Artifacts/ArtifactsSummaryCards.tsx
+++ b/src/components/Artifacts/ArtifactsSummaryCards.tsx
@@ -1,0 +1,141 @@
+import { ArtifactSummary } from "@flanksource-ui/api/types/artifacts";
+import { fetchArtifactSummary } from "@flanksource-ui/api/services/artifacts";
+import { formatBytes } from "@flanksource-ui/utils/common";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+type StorageBreakdown = {
+  label: string;
+  count: number;
+  size: number;
+};
+
+type ContentTypeBreakdown = {
+  contentType: string;
+  count: number;
+  size: number;
+};
+
+function aggregateSummary(rows: ArtifactSummary[]) {
+  let totalCount = 0;
+  let totalSize = 0;
+
+  const storageMap = new Map<string, StorageBreakdown>();
+  const typeMap = new Map<string, ContentTypeBreakdown>();
+
+  for (const row of rows) {
+    totalCount += row.total_count;
+    totalSize += row.total_size;
+
+    // Storage breakdown
+    const storageKey =
+      row.storage === "inline"
+        ? "inline"
+        : (row.connection_name ?? row.connection_id ?? "external");
+    const existing = storageMap.get(storageKey) ?? {
+      label:
+        row.storage === "inline"
+          ? "Inline (Database)"
+          : (row.connection_name ?? "External"),
+      count: 0,
+      size: 0
+    };
+    existing.count += row.total_count;
+    existing.size += row.total_size;
+    storageMap.set(storageKey, existing);
+
+    // Content type breakdown
+    const ct = row.content_type || "unknown";
+    const existingType = typeMap.get(ct) ?? {
+      contentType: ct,
+      count: 0,
+      size: 0
+    };
+    existingType.count += row.total_count;
+    existingType.size += row.total_size;
+    typeMap.set(ct, existingType);
+  }
+
+  return {
+    totalCount,
+    totalSize,
+    storage: [...storageMap.values()].sort((a, b) => b.size - a.size),
+    contentTypes: [...typeMap.values()].sort((a, b) => b.count - a.count)
+  };
+}
+
+export function ArtifactsSummaryCards() {
+  const { data: summaryRows = [] } = useQuery({
+    queryKey: ["artifact_summary"],
+    queryFn: fetchArtifactSummary
+  });
+
+  const summary = useMemo(() => aggregateSummary(summaryRows), [summaryRows]);
+
+  if (summary.totalCount === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-row flex-wrap gap-4 py-4">
+      {/* Total */}
+      <SummaryCard
+        title="Total"
+        value={`${summary.totalCount}`}
+        subtitle={formatBytes(summary.totalSize)}
+      />
+
+      {/* Storage breakdown */}
+      {summary.storage.map((s) => (
+        <SummaryCard
+          key={s.label}
+          title={s.label}
+          value={`${s.count}`}
+          subtitle={formatBytes(s.size)}
+        />
+      ))}
+
+      {/* Content type breakdown */}
+      {summary.contentTypes.map((ct) => (
+        <SummaryCard
+          key={ct.contentType}
+          title={formatContentType(ct.contentType)}
+          value={`${ct.count}`}
+          subtitle={formatBytes(ct.size)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  value,
+  subtitle
+}: {
+  title: string;
+  value: string;
+  subtitle: string;
+}) {
+  return (
+    <div className="flex min-w-[120px] flex-col rounded-md border border-gray-200 bg-white px-4 py-3 shadow-sm">
+      <span className="text-xs text-gray-500">{title}</span>
+      <span className="text-lg font-semibold text-gray-900">{value}</span>
+      <span className="text-xs text-gray-400">{subtitle}</span>
+    </div>
+  );
+}
+
+const CONTENT_TYPE_LABELS: Record<string, string> = {
+  "application/json": "JSON",
+  "application/yaml": "YAML",
+  "text/plain": "Text",
+  "text/markdown": "Markdown",
+  "application/sql": "SQL",
+  "text/x-shellscript": "Shell",
+  "application/log+json": "Log JSON"
+};
+
+function formatContentType(ct: string): string {
+  return CONTENT_TYPE_LABELS[ct] ?? ct;
+}

--- a/src/components/Artifacts/ArtifactsTable.tsx
+++ b/src/components/Artifacts/ArtifactsTable.tsx
@@ -1,0 +1,105 @@
+import { Artifact } from "@flanksource-ui/api/types/artifacts";
+import { formatBytes } from "@flanksource-ui/utils/common";
+import { MRTDateCell } from "@flanksource-ui/ui/MRTDataTable/Cells/MRTDateCells";
+import { MRTCellProps } from "@flanksource-ui/ui/MRTDataTable/MRTCellProps";
+import MRTDataTable from "@flanksource-ui/ui/MRTDataTable/MRTDataTable";
+import { MRT_ColumnDef } from "mantine-react-table";
+import { Link } from "react-router-dom";
+
+function SizeCell({ row }: MRTCellProps<Artifact>) {
+  return <span className="text-xs">{formatBytes(row.original.size)}</span>;
+}
+
+function SourceCell({ row }: MRTCellProps<Artifact>) {
+  const { playbook_run_action, config_change } = row.original;
+
+  if (playbook_run_action) {
+    return (
+      <Link
+        to={`/playbooks/runs/${playbook_run_action.playbook_run_id}`}
+        className="text-xs text-blue-500 hover:underline"
+        onClick={(e) => e.stopPropagation()}
+      >
+        Playbook: {playbook_run_action.name}
+      </Link>
+    );
+  }
+
+  if (config_change) {
+    return (
+      <Link
+        to={`/catalog/${config_change.config_id}/changes`}
+        className="text-xs text-blue-500 hover:underline"
+        onClick={(e) => e.stopPropagation()}
+      >
+        Config Change: {config_change.change_type}
+      </Link>
+    );
+  }
+
+  return <span className="text-xs text-gray-400">-</span>;
+}
+
+const columns: MRT_ColumnDef<Artifact>[] = [
+  {
+    header: "Filename",
+    accessorKey: "filename",
+    minSize: 200,
+    enableResizing: true
+  },
+  {
+    header: "Content Type",
+    accessorKey: "content_type",
+    maxSize: 120
+  },
+  {
+    header: "Size",
+    accessorKey: "size",
+    Cell: SizeCell,
+    maxSize: 80
+  },
+  {
+    header: "Source",
+    accessorKey: "playbook_run_action_id",
+    Cell: SourceCell,
+    enableSorting: false,
+    minSize: 150
+  },
+  {
+    header: "Created",
+    accessorKey: "created_at",
+    Cell: MRTDateCell,
+    sortingFn: "datetime",
+    maxSize: 100
+  }
+];
+
+type ArtifactsTableProps = {
+  artifacts: Artifact[];
+  isLoading?: boolean;
+  pageCount?: number;
+  totalRowCount?: number;
+  onRowClick?: (artifact: Artifact) => void;
+};
+
+export function ArtifactsTable({
+  artifacts,
+  isLoading,
+  pageCount,
+  totalRowCount,
+  onRowClick
+}: ArtifactsTableProps) {
+  return (
+    <MRTDataTable
+      columns={columns}
+      data={artifacts}
+      isLoading={isLoading}
+      onRowClick={onRowClick}
+      enableServerSideSorting
+      enableServerSidePagination
+      manualPageCount={pageCount}
+      totalRowCount={totalRowCount}
+      defaultSorting={[{ id: "created_at", desc: true }]}
+    />
+  );
+}

--- a/src/components/Configs/Changes/ConfigDetailsChanges/ConfigDetailsChanges.tsx
+++ b/src/components/Configs/Changes/ConfigDetailsChanges/ConfigDetailsChanges.tsx
@@ -11,10 +11,14 @@ import { JSONViewer } from "@flanksource-ui/ui/Code/JSONViewer";
 import { ChangeIcon } from "@flanksource-ui/ui/Icons/ChangeIcon";
 import { ConfigIcon } from "@flanksource-ui/ui/Icons/ConfigIcon";
 import { Icon } from "@flanksource-ui/ui/Icons/Icon";
+import { artifactDownloadURL } from "@flanksource-ui/api/services/artifacts";
+import { formatBytes } from "@flanksource-ui/utils/common";
 import { Loading } from "@flanksource-ui/ui/Loading";
 import { Modal } from "@flanksource-ui/ui/Modal";
 import ModalTitleListItems from "@flanksource-ui/ui/Modal/ModalTitleListItems";
 import { Stat } from "@flanksource-ui/ui/stats/Stat";
+import { TbFileDescription } from "react-icons/tb";
+import { IoMdDownload } from "react-icons/io";
 import { useMemo, useState } from "react";
 import ConfigLink from "../../ConfigLink/ConfigLink";
 import ConfigChangeDetailSection from "./ConfigChangeDetailsSection";
@@ -109,6 +113,26 @@ export function ConfigDetailsChanges({
               }
             />
           </div>
+          {changeDetails?.artifacts && changeDetails.artifacts.length > 0 && (
+            <div className="flex flex-wrap gap-3 py-2">
+              {changeDetails.artifacts.map((artifact) => (
+                <a
+                  key={artifact.id}
+                  href={artifactDownloadURL(artifact.id, artifact.filename)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1.5 rounded border border-gray-200 px-2.5 py-1.5 text-sm text-gray-700 hover:border-blue-300 hover:bg-blue-50 hover:text-blue-600"
+                >
+                  <TbFileDescription className="h-4 w-4 shrink-0" />
+                  <span>{artifact.filename}</span>
+                  <span className="text-gray-400">
+                    ({formatBytes(artifact.size)})
+                  </span>
+                  <IoMdDownload className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+                </a>
+              ))}
+            </div>
+          )}
           {changeDetails?.details && (
             <ConfigChangeDetailSection label="Details">
               <JSONViewer

--- a/src/components/Playbooks/Runs/Actions/PlaybookResultsDropdownButton.tsx
+++ b/src/components/Playbooks/Runs/Actions/PlaybookResultsDropdownButton.tsx
@@ -41,8 +41,10 @@ export default function TabContentDownloadButton({
 
   const onDownloadLogs = useCallback(async () => {
     if (artifactID) {
-      const downloadURL = `/api/artifacts/download/${artifactID}`;
-      window.open(downloadURL, "_blank");
+      const { artifactDownloadURL } = await import(
+        "@flanksource-ui/api/services/artifacts"
+      );
+      window.open(artifactDownloadURL(artifactID, fileName), "_blank");
       return;
     }
 

--- a/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
+++ b/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
@@ -12,7 +12,10 @@ import TabContentDownloadButton from "./PlaybookResultsDropdownButton";
 import { Tab, Tabs } from "../../../../ui/Tabs/Tabs";
 import blockKitToMarkdown from "@flanksource-ui/utils/slack";
 import { DisplayMarkdown } from "@flanksource-ui/components/Utils/Markdown";
-import { downloadArtifact } from "../../../../api/services/artifacts";
+import {
+  artifactDownloadURL,
+  downloadArtifact
+} from "../../../../api/services/artifacts";
 import { TbAlertCircle, TbFileDescription } from "react-icons/tb";
 import { formatBytes } from "@flanksource-ui/utils/common";
 import { Button } from "@flanksource-ui/ui/Buttons/Button";
@@ -482,7 +485,7 @@ function ArtifactContent({
     }
   });
 
-  const downloadURL = `/api/artifacts/download/${artifact.id}`;
+  const downloadURL = artifactDownloadURL(artifact.id, artifact.filename);
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/src/context/UserAccessContext/permissions.ts
+++ b/src/context/UserAccessContext/permissions.ts
@@ -23,7 +23,8 @@ export const tables = {
   scopes: "scopes",
   views: "views",
   teams: "teams",
-  applications: "applications"
+  applications: "applications",
+  artifacts: "artifacts"
 };
 
 const viewerReadObjects = [

--- a/src/pages/Settings/ArtifactsPage.tsx
+++ b/src/pages/Settings/ArtifactsPage.tsx
@@ -1,0 +1,172 @@
+import { fetchArtifacts } from "@flanksource-ui/api/services/artifacts";
+import { Artifact } from "@flanksource-ui/api/types/artifacts";
+import { ArtifactPreviewModal } from "@flanksource-ui/components/Artifacts/ArtifactPreviewModal";
+import { ArtifactsTable } from "@flanksource-ui/components/Artifacts/ArtifactsTable";
+import { ArtifactsSummaryCards } from "@flanksource-ui/components/Artifacts/ArtifactsSummaryCards";
+import { ReactSelectDropdown } from "@flanksource-ui/components/ReactSelectDropdown";
+import {
+  BreadcrumbNav,
+  BreadcrumbRoot
+} from "@flanksource-ui/ui/BreadcrumbNav";
+import useReactTablePaginationState from "@flanksource-ui/ui/DataTable/Hooks/useReactTablePaginationState";
+import useReactTableSortState from "@flanksource-ui/ui/DataTable/Hooks/useReactTableSortState";
+import { Head } from "@flanksource-ui/ui/Head";
+import { SearchLayout } from "@flanksource-ui/ui/Layout/SearchLayout";
+import { TextInputClearable } from "@flanksource-ui/ui/FormControls/TextInputClearable";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+const contentTypeOptions = [
+  { id: "all", value: "all", label: "All", description: "All" },
+  {
+    id: "application/json",
+    value: "application/json",
+    label: "JSON",
+    description: "JSON"
+  },
+  {
+    id: "application/yaml",
+    value: "application/yaml",
+    label: "YAML",
+    description: "YAML"
+  },
+  {
+    id: "text/plain",
+    value: "text/plain",
+    label: "Text",
+    description: "Text"
+  },
+  {
+    id: "text/markdown",
+    value: "text/markdown",
+    label: "Markdown",
+    description: "Markdown"
+  },
+  {
+    id: "application/sql",
+    value: "application/sql",
+    label: "SQL",
+    description: "SQL"
+  },
+  {
+    id: "text/x-shellscript",
+    value: "text/x-shellscript",
+    label: "Shell",
+    description: "Shell"
+  }
+];
+
+export function ArtifactsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedArtifact, setSelectedArtifact] = useState<
+    Artifact | undefined
+  >();
+
+  const contentType = searchParams.get("content_type") ?? "all";
+  const filenameSearch = searchParams.get("search") ?? "";
+
+  const [sortState] = useReactTableSortState({
+    defaultSorting: [{ id: "created_at", desc: true }]
+  });
+  const { pageIndex, pageSize } = useReactTablePaginationState();
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: [
+      "artifacts",
+      { pageIndex, pageSize, sortState, contentType, filenameSearch }
+    ],
+    queryFn: () =>
+      fetchArtifacts({
+        pageIndex,
+        pageSize,
+        sortBy: sortState,
+        contentType,
+        filenameSearch: filenameSearch || undefined
+      }),
+    keepPreviousData: true
+  });
+
+  const artifacts = data?.data ?? [];
+  const totalEntries = data?.totalEntries ?? 0;
+  const pageCount = Math.ceil(totalEntries / pageSize);
+
+  return (
+    <>
+      <Head prefix="Artifacts" />
+      <SearchLayout
+        title={
+          <BreadcrumbNav
+            list={[
+              <BreadcrumbRoot link="/settings/artifacts" key="artifacts-root">
+                Artifacts
+              </BreadcrumbRoot>
+            ]}
+          />
+        }
+        onRefresh={() => refetch()}
+        contentClass="p-0 h-full"
+        loading={isLoading}
+      >
+        <div className="flex h-full flex-col overflow-y-auto px-6 pb-0">
+          <ArtifactsSummaryCards />
+          <div className="flex flex-row items-center gap-4 py-4">
+            <TextInputClearable
+              className="w-80"
+              placeholder="Search by filename..."
+              value={filenameSearch}
+              hideButton
+              onChange={(e) => {
+                const nextParams = new URLSearchParams(searchParams);
+                if (e.target.value) {
+                  nextParams.set("search", e.target.value);
+                } else {
+                  nextParams.delete("search");
+                }
+                setSearchParams(nextParams);
+              }}
+              onClear={() => {
+                const nextParams = new URLSearchParams(searchParams);
+                nextParams.delete("search");
+                setSearchParams(nextParams);
+              }}
+            />
+            <ReactSelectDropdown
+              name="content-type-filter"
+              items={contentTypeOptions}
+              value={contentType}
+              onChange={(value) => {
+                const nextParams = new URLSearchParams(searchParams);
+                if (!value || value === "all") {
+                  nextParams.delete("content_type");
+                } else {
+                  nextParams.set("content_type", value);
+                }
+                setSearchParams(nextParams);
+              }}
+              className="min-w-[180px]"
+              dropDownClassNames="w-[200px] left-0"
+              hideControlBorder
+              prefix={
+                <span className="text-xs text-gray-500">Content Type:</span>
+              }
+            />
+          </div>
+          <div className="flex h-full flex-col overflow-y-auto pb-6">
+            <ArtifactsTable
+              artifacts={artifacts}
+              isLoading={isLoading}
+              pageCount={pageCount}
+              totalRowCount={totalEntries}
+              onRowClick={setSelectedArtifact}
+            />
+          </div>
+        </div>
+        <ArtifactPreviewModal
+          artifact={selectedArtifact}
+          onClose={() => setSelectedArtifact(undefined)}
+        />
+      </SearchLayout>
+    </>
+  );
+}

--- a/src/services/permissions/features.ts
+++ b/src/services/permissions/features.ts
@@ -25,7 +25,8 @@ export const features = {
   "settings.playbooks": "settings.playbooks",
   "settings.integrations": "settings.integrations",
   "settings.permissions": "settings.permissions",
-  "settings.mcp": "settings.mcp"
+  "settings.mcp": "settings.mcp",
+  "settings.artifacts": "settings.artifacts"
 } as const;
 
 export const featureToParentMap = {


### PR DESCRIPTION
- Adds artifacts table with pagination and sorting
- Adds summary cards for artifact count, size, storage, and content type
- Adds filename search and content-type filtering
- Adds artifact preview modal for text, markdown, JSON/YAML, SQL, shell scripts, and images
- Adds download links with filename support
- Wires artifacts into settings navigation and permissions