### PR TITLE
fix: preserve Kratos invite during login and registration flows

### DIFF
--- a/src/components/Authentication/Kratos/KratosLogin.tsx
+++ b/src/components/Authentication/Kratos/KratosLogin.tsx
@@ -34,6 +34,7 @@ const KratosLogin = () => {
   const searchParams = useSearchParams();
 
   const flowId = searchParams.get("flow") || undefined;
+  const invite = searchParams.get("invite") || undefined;
   const returnTo = sanitizeReturnTo(searchParams.get("return_to"));
   const username = searchParams.get("username");
   const password = searchParams.get("password");
@@ -71,11 +72,15 @@ const KratosLogin = () => {
   const createFlow = useCallback(
     async (refresh: boolean, aal: string, returnTo?: string) => {
       try {
+        const flowReturnTo = invite
+          ? `${returnTo}${returnTo.includes("?") ? "&" : "?"}invite=${encodeURIComponent(invite)}`
+          : returnTo;
+
         const { data } = await ory.createBrowserLoginFlow({
           refresh: refresh,
           // Check for two-factor authentication
           aal: aal,
-          ...(returnTo ? { returnTo } : {})
+          returnTo: flowReturnTo
         });
         setFlow(data);
         if (flowId !== data.id) {
@@ -88,7 +93,7 @@ const KratosLogin = () => {
         handleError(error as AxiosError);
       }
     },
-    [flowId, handleError, replace, router.pathname, searchParams]
+    [flowId, handleError, invite, replace, router.pathname, searchParams]
   );
 
   useEffect(() => {

--- a/src/components/Authentication/Kratos/KratosLogin.tsx
+++ b/src/components/Authentication/Kratos/KratosLogin.tsx
@@ -70,7 +70,7 @@ const KratosLogin = () => {
   );
 
   const createFlow = useCallback(
-    async (refresh: boolean, aal: string, returnTo?: string) => {
+    async (refresh: boolean, aal: string, returnTo: string) => {
       try {
         const flowReturnTo = invite
           ? `${returnTo}${returnTo.includes("?") ? "&" : "?"}invite=${encodeURIComponent(invite)}`

--- a/src/components/Authentication/Kratos/KratosRegistration.tsx
+++ b/src/components/Authentication/Kratos/KratosRegistration.tsx
@@ -19,7 +19,7 @@ export default function KratosRegistration() {
   const [flow, setFlow] = useState<RegistrationFlow>();
 
   // Get ?flow=... from the URL
-  const { flow: flowId, return_to: returnTo } = router.query;
+  const { flow: flowId, invite, return_to: returnTo } = router.query;
 
   // In this effect we either initiate a new registration flow, or we fetch an existing registration flow.
   useEffect(() => {
@@ -41,21 +41,32 @@ export default function KratosRegistration() {
     }
 
     // Otherwise we initialize it
+    const registrationReturnTo = invite
+      ? `/registration?invite=${encodeURIComponent(String(invite))}`
+      : returnTo
+        ? String(returnTo)
+        : undefined;
+
     ory
       .createBrowserRegistrationFlow({
+        returnTo: registrationReturnTo,
         afterVerificationReturnTo: returnTo ? String(returnTo) : undefined
       })
       .then(({ data }) => {
         setFlow(data);
       })
       .catch(handleFlowError(router, "registration", setFlow));
-  }, [flowId, router, router.isReady, returnTo, flow]);
+  }, [flowId, router, router.isReady, returnTo, invite, flow]);
 
   const onSubmit = (values: UpdateRegistrationFlowBody) =>
     router
       // On submission, add the flow ID to the URL but do not navigate. This prevents the user loosing
       // his data when she/he reloads the page.
-      .push(`/registration?flow=${flow?.id}`, undefined, { shallow: true })
+      .push(
+        `/registration?flow=${flow?.id}${invite ? `&invite=${encodeURIComponent(String(invite))}` : ""}`,
+        undefined,
+        { shallow: true }
+      )
       .then(() =>
         ory
           .updateRegistrationFlow({


### PR DESCRIPTION
Invite links now route users through login instead of showing the registration form directly.

The Kratos login and registration flows preserve the invite ID in flow return URLs so backend registration hooks can validate invited signups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invite query parameters are now supported throughout authentication flows and are automatically preserved across login and registration processes.
  * Login flows now read and include invite parameters when initializing new authentication flows.
  * Registration flows maintain invite parameters throughout the entire process, including flow initialization, form submissions, and return URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->