### PR TITLE
fix: rely on runnable playbooks API for dropdown visibility

### DIFF
--- a/src/api/query-hooks/playbooks.tsx
+++ b/src/api/query-hooks/playbooks.tsx
@@ -72,10 +72,14 @@ export function useGetPlaybooksToRun(
       // this is a bit of a hack, but we need to get the specs because that's
       // where the icon is stored
       const specs = await getPlaybookSpecsByIDs(ids);
-      return res.map((playbook) => ({
-        ...playbook,
-        title: specs.find((spec) => spec.id === playbook.id)!.title,
-        spec: specs.find((spec) => spec.id === playbook.id)!.spec
+      const playbooksByID = new Map(
+        res.map((playbook) => [playbook.id, playbook])
+      );
+
+      return specs.map((playbookSpec) => ({
+        ...playbooksByID.get(playbookSpec.id),
+        title: playbookSpec.title,
+        spec: playbookSpec.spec
       })) as (RunnablePlaybook & {
         spec: any;
       })[];

--- a/src/components/Playbooks/Runs/Submit/PlaybooksDropdownMenu.tsx
+++ b/src/components/Playbooks/Runs/Submit/PlaybooksDropdownMenu.tsx
@@ -1,4 +1,3 @@
-import { AuthorizationAccessCheck } from "@flanksource-ui/components/Permissions/AuthorizationAccessCheck";
 import { Icon } from "@flanksource-ui/ui/Icons/Icon";
 import {
   Menu,
@@ -61,58 +60,56 @@ export default function PlaybooksDropdownMenu({
   );
 
   return (
-    <AuthorizationAccessCheck resource={"playbook_runs"} action={"write"}>
-      <div className={containerClassName}>
-        <Menu as="div" className="relative inline-block text-left">
-          <MenuButton className={buttonClassName}>
-            <Icon name="playbook" className="mr-2 mt-0.5 h-5 w-5" />
-            <span>Playbooks</span>
-            <ChevronDownIcon
-              className={clsx(
-                "-mr-1 ml-2 h-5 w-5",
-                highlight ? "text-blue-500" : "text-gray-400"
-              )}
-              aria-hidden="true"
-            />
-          </MenuButton>
-
-          {/* @ts-ignore */}
-          <Transition
-            as={Fragment as any}
-            enter="transition ease-out duration-100"
-            enterFrom="transform opacity-0 scale-95"
-            enterTo="transform opacity-100 scale-100"
-            leave="transition ease-in duration-75"
-            leaveFrom="transform opacity-100 scale-100"
-            leaveTo="transform opacity-0 scale-95"
-          >
-            <MenuItems portal className="menu-items" anchor="bottom start">
-              {playbooks?.map((playbook) => (
-                <MenuItem
-                  as="button"
-                  className="menu-item w-full"
-                  onClick={() => setSelectedPlaybookSpec(playbook)}
-                  key={playbook.id}
-                >
-                  <PlaybookSpecIcon playbook={playbook} showLabel showTag />
-                </MenuItem>
-              ))}
-            </MenuItems>
-          </Transition>
-        </Menu>
-        {selectedPlaybookSpec && (
-          <SubmitPlaybookRunForm
-            componentId={component_id}
-            checkId={check_id}
-            configId={config_id}
-            isOpen={!!selectedPlaybookSpec}
-            onClose={() => {
-              setSelectedPlaybookSpec(undefined);
-            }}
-            playbook={selectedPlaybookSpec}
+    <div className={containerClassName}>
+      <Menu as="div" className="relative inline-block text-left">
+        <MenuButton className={buttonClassName}>
+          <Icon name="playbook" className="mr-2 mt-0.5 h-5 w-5" />
+          <span>Playbooks</span>
+          <ChevronDownIcon
+            className={clsx(
+              "-mr-1 ml-2 h-5 w-5",
+              highlight ? "text-blue-500" : "text-gray-400"
+            )}
+            aria-hidden="true"
           />
-        )}
-      </div>
-    </AuthorizationAccessCheck>
+        </MenuButton>
+
+        {/* @ts-ignore */}
+        <Transition
+          as={Fragment as any}
+          enter="transition ease-out duration-100"
+          enterFrom="transform opacity-0 scale-95"
+          enterTo="transform opacity-100 scale-100"
+          leave="transition ease-in duration-75"
+          leaveFrom="transform opacity-100 scale-100"
+          leaveTo="transform opacity-0 scale-95"
+        >
+          <MenuItems portal className="menu-items" anchor="bottom start">
+            {playbooks?.map((playbook) => (
+              <MenuItem
+                as="button"
+                className="menu-item w-full"
+                onClick={() => setSelectedPlaybookSpec(playbook)}
+                key={playbook.id}
+              >
+                <PlaybookSpecIcon playbook={playbook} showLabel showTag />
+              </MenuItem>
+            ))}
+          </MenuItems>
+        </Transition>
+      </Menu>
+      {selectedPlaybookSpec && (
+        <SubmitPlaybookRunForm
+          componentId={component_id}
+          checkId={check_id}
+          configId={config_id}
+          isOpen={!!selectedPlaybookSpec}
+          onClose={() => {
+            setSelectedPlaybookSpec(undefined);
+          }}
+          playbook={selectedPlaybookSpec}
+        />
+      )}
+    </div>
   );
 }

--- a/src/components/Playbooks/Runs/Submit/PlaybooksDropdownMenu.tsx
+++ b/src/components/Playbooks/Runs/Submit/PlaybooksDropdownMenu.tsx
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "@flanksource-ui/api/types/error";
 import { Icon } from "@flanksource-ui/ui/Icons/Icon";
 import {
   Menu,
@@ -47,7 +48,15 @@ export default function PlaybooksDropdownMenu({
     config_id
   });
 
-  if (error || playbooks?.length === 0 || isLoading) {
+  if (error) {
+    return (
+      <div className={clsx(containerClassName, "text-sm text-red-600")}>
+        Failed to load playbooks: {getErrorMessage(error)}
+      </div>
+    );
+  }
+
+  if (playbooks?.length === 0 || isLoading) {
     return null;
   }
 


### PR DESCRIPTION
Playbook dropdown visibility was gated by a frontend-only `playbook_runs:write` permission, which does not reflect the backend RBAC/ABAC model for `playbook:run`.

Remove the synthetic frontend authorization guard so the dropdown is shown only when `/playbooks/list` returns runnable playbooks for the current resource. If the backend returns no playbooks, the dropdown remains hidden.

related: https://github.com/flanksource/mission-control/issues/3037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed authorization restrictions from the playbooks dropdown menu, making it accessible without permission gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->