### PR TITLE
fix: use cross-env for dev scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@flanksource/flanksource-ui",
-      "version": "1.4.232",
+      "version": "1.4.255",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.1",
         "@ai-sdk/mcp": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -163,9 +163,9 @@
     ]
   },
   "scripts": {
-    "dev": "dotenv run cross-env next dev",
+    "dev": "cross-env next dev",
     "dev:canary": "cross-env NEXT_PUBLIC_APP_DEPLOYMENT=CANARY_CHECKER next dev",
-    "dev:basic": "cp middleware.basic.ts middleware.ts && dotenv run cross-env next dev",
+    "dev:basic": "cp middleware.basic.ts middleware.ts && cross-env next dev",
     "dev:clerk": "cp middleware.clerk.ts middleware.ts && cross-env next dev",
     "start": "cross-env next start",
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 node -v && cross-env NODE_OPTIONS=--max-old-space-size=8192 NODE_ENV=production next build",


### PR DESCRIPTION
`npm run dev` failed because the script invoked `dotenv`, but `dotenv-cli` is not installed in the project.\n\nThe dev scripts already use `cross-env` elsewhere, so this removes the `dotenv` wrapper from the default and basic auth dev commands.