### PR TITLE
fix: redirect homepage to accessible page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { Canary, Icon } from "./components";
 import AuthProviderWrapper from "./components/Authentication/AuthProviderWrapper";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { HomepageRedirect } from "./components/HomepageRedirect";
+import { NoPermissionsOnboardingPage } from "./components/NoPermissionsOnboardingPage";
 import {
   DASHBOARD_VIEW_PROPERTY,
   FALLBACK_VIEW_NAME,
@@ -43,7 +44,10 @@ import { ConfigPageContextProvider } from "./context/ConfigPageContext";
 import { useFeatureFlagsContext } from "./context/FeatureFlagsContext";
 import { HealthPageContextProvider } from "./context/HealthPageContext";
 import { IncidentPageContextProvider } from "./context/IncidentPageContext";
-import { UserAccessStateContextProvider } from "./context/UserAccessContext/UserAccessContext";
+import {
+  UserAccessStateContextProvider,
+  useUserAccessStateContext
+} from "./context/UserAccessContext/UserAccessContext";
 import { tables } from "./context/UserAccessContext/permissions";
 
 import { ArtifactsPage } from "./pages/Settings/ArtifactsPage";
@@ -515,6 +519,42 @@ const settingsNav: SettingsNavigationItems = {
   ].sort((v1, v2) => stringSortHelper(v1.name, v2.name))
 };
 
+const GLOBAL_PAGE_ACCESS_RESOURCES = [
+  ...new Set([
+    ...navigation.map((item) => item.resourceName),
+    ...settingsNav.submenu.map((item) => item.resourceName),
+    tables.views
+  ])
+];
+
+function useHasAnyPageAccess() {
+  const { hasAnyResourceAccess, roles } = useUserAccessStateContext();
+  const [isCheckingAccess, setIsCheckingAccess] = useState(true);
+  const [hasAnyPageAccess, setHasAnyPageAccess] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsCheckingAccess(true);
+
+    hasAnyResourceAccess(GLOBAL_PAGE_ACCESS_RESOURCES, "read").then(
+      (hasAccess) => {
+        if (cancelled) {
+          return;
+        }
+
+        setHasAnyPageAccess(hasAccess);
+        setIsCheckingAccess(false);
+      }
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasAnyResourceAccess, roles]);
+
+  return { hasAnyPageAccess, isCheckingAccess };
+}
+
 const CANARY_API = "/api/canary/api/summary";
 
 export function HealthRoutes({ sidebar }: { sidebar: ReactNode }) {
@@ -534,12 +574,21 @@ export function HealthRoutes({ sidebar }: { sidebar: ReactNode }) {
 
 export function IncidentManagerRoutes({ sidebar }: { sidebar: ReactNode }) {
   const { featureFlagsLoaded } = useFeatureFlagsContext();
+  const { hasAnyPageAccess, isCheckingAccess } = useHasAnyPageAccess();
 
   if (
     !featureFlagsLoaded &&
     !window.location.pathname.startsWith("/view/topology")
   ) {
     return <FullPageSkeletonLoader />;
+  }
+
+  if (isCheckingAccess) {
+    return <FullPageSkeletonLoader />;
+  }
+
+  if (!hasAnyPageAccess) {
+    return <NoPermissionsOnboardingPage />;
   }
 
   return (

--- a/src/components/HomepageRedirect.tsx
+++ b/src/components/HomepageRedirect.tsx
@@ -5,18 +5,28 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
-import React, { Suspense } from "react";
+import React, { Suspense, useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
 import {
   getDashboard,
   DashboardResponse,
   getSectionResultByViewRef
 } from "../api/services/views";
-import { HealthPage } from "../pages/health";
+import { useUserAccessStateContext } from "../context/UserAccessContext/UserAccessContext";
+import { tables } from "../context/UserAccessContext/permissions";
 import FullPageSkeletonLoader from "../ui/SkeletonLoader/FullPageSkeletonLoader";
 
 const ViewContainer = React.lazy(
   () => import("../pages/views/components/ViewContainer")
 );
+
+const homepageFallbacks = [
+  { resource: tables.canaries, path: "/health" },
+  { resource: tables.incident, path: "/incidents" },
+  { resource: tables.catalog, path: "/catalog" },
+  { resource: tables.playbooks, path: "/playbooks" },
+  { resource: tables.applications, path: "/applications" }
+];
 
 /**
  * Pre-seed react-query cache with dashboard metadata so ViewContainer can
@@ -62,6 +72,39 @@ function seedDashboardCache(
 
 export function HomepageRedirect() {
   const queryClient = useQueryClient();
+  const { hasResourceAccess, roles } = useUserAccessStateContext();
+  const [fallbackPath, setFallbackPath] = useState<string | null>(null);
+  const [canReadViews, setCanReadViews] = useState(false);
+  const [isCheckingAccess, setIsCheckingAccess] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsCheckingAccess(true);
+
+    Promise.all([
+      hasResourceAccess(tables.views, "read"),
+      ...homepageFallbacks.map((item) =>
+        hasResourceAccess(item.resource, "read").then((hasAccess) => ({
+          ...item,
+          hasAccess
+        }))
+      )
+    ]).then(([hasViewsAccess, ...fallbackResults]) => {
+      if (cancelled) {
+        return;
+      }
+
+      setCanReadViews(Boolean(hasViewsAccess));
+      setFallbackPath(
+        fallbackResults.find((item) => item.hasAccess)?.path ?? null
+      );
+      setIsCheckingAccess(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasResourceAccess, roles]);
 
   const {
     data: dashboard,
@@ -77,18 +120,21 @@ export function HomepageRedirect() {
     staleTime: 5 * 60 * 1000
   });
 
-  if (isLoading) {
+  if (isLoading || isCheckingAccess) {
     return <FullPageSkeletonLoader />;
   }
 
-  // Fall back to health checks page when there's no dashboard view (404) or on error
-  if (error || !dashboard?.id) {
-    return <HealthPage url="/api/canary/api/summary" />;
+  if (!error && dashboard?.id && canReadViews) {
+    return (
+      <Suspense fallback={<FullPageSkeletonLoader />}>
+        <ViewContainer id={dashboard.id} />
+      </Suspense>
+    );
   }
 
-  return (
-    <Suspense fallback={<FullPageSkeletonLoader />}>
-      <ViewContainer id={dashboard.id} />
-    </Suspense>
-  );
+  if (fallbackPath) {
+    return <Navigate to={fallbackPath} replace />;
+  }
+
+  return <FullPageSkeletonLoader />;
 }

--- a/src/components/NoPermissionsOnboardingPage.tsx
+++ b/src/components/NoPermissionsOnboardingPage.tsx
@@ -1,0 +1,26 @@
+import { SearchLayout } from "@flanksource-ui/ui/Layout/SearchLayout";
+
+export function NoPermissionsOnboardingPage() {
+  return (
+    <div className="flex h-screen w-screen flex-col">
+      <SearchLayout contentClass="flex min-h-0 flex-1 items-center justify-center px-6 py-12">
+        <div className="w-full max-w-xl rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm">
+          <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-blue-50 text-2xl">
+            👋
+          </div>
+          <h1 className="text-xl font-semibold text-slate-900">
+            Welcome to Mission Control
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-slate-600">
+            Your account is set up, but you do not have access to any pages yet.
+            Ask an administrator to grant you access to Health, Catalog,
+            Playbooks, or another workspace area.
+          </p>
+          <p className="mt-6 text-xs text-slate-400">
+            This page will update automatically once permissions are assigned.
+          </p>
+        </div>
+      </SearchLayout>
+    </div>
+  );
+}

--- a/src/components/__tests__/HomepageRedirect.unit.test.tsx
+++ b/src/components/__tests__/HomepageRedirect.unit.test.tsx
@@ -3,7 +3,12 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import {
+  UserAccessStateContext,
+  type UserAccessState
+} from "../../context/UserAccessContext/UserAccessContext";
+import { tables } from "../../context/UserAccessContext/permissions";
 import { HomepageRedirect } from "../HomepageRedirect";
 import { getDashboard } from "../../api/services/views";
 import type { DashboardResponse } from "../../api/services/views";
@@ -38,13 +43,34 @@ function createQueryClient() {
   });
 }
 
-function renderWithProviders() {
+function renderWithProviders(accessOverrides?: Partial<UserAccessState>) {
   const queryClient = createQueryClient();
+  const accessState: UserAccessState = {
+    isAdmin: false,
+    isViewer: false,
+    roles: [],
+    hasResourceAccess: jest.fn((resourceName: string) =>
+      Promise.resolve(
+        resourceName === tables.views || resourceName === tables.canaries
+      )
+    ),
+    hasAnyResourceAccess: jest.fn(() => Promise.resolve(false)),
+    ...accessOverrides
+  };
+
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={["/"]}>
-        <HomepageRedirect />
-      </MemoryRouter>
+      <UserAccessStateContext.Provider value={accessState}>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route index element={<HomepageRedirect />} />
+            <Route
+              path="/health"
+              element={<div data-testid="health-page">Health</div>}
+            />
+          </Routes>
+        </MemoryRouter>
+      </UserAccessStateContext.Provider>
     </QueryClientProvider>
   );
 }
@@ -118,9 +144,30 @@ describe("HomepageRedirect", () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={["/"]}>
-          <HomepageRedirect />
-        </MemoryRouter>
+        <UserAccessStateContext.Provider
+          value={{
+            isAdmin: false,
+            isViewer: false,
+            roles: [],
+            hasResourceAccess: jest.fn((resourceName: string) =>
+              Promise.resolve(
+                resourceName === tables.views ||
+                  resourceName === tables.canaries
+              )
+            ),
+            hasAnyResourceAccess: jest.fn(() => Promise.resolve(false))
+          }}
+        >
+          <MemoryRouter initialEntries={["/"]}>
+            <Routes>
+              <Route index element={<HomepageRedirect />} />
+              <Route
+                path="/health"
+                element={<div data-testid="health-page">Health</div>}
+              />
+            </Routes>
+          </MemoryRouter>
+        </UserAccessStateContext.Provider>
       </QueryClientProvider>
     );
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react";
 import { User } from "../api/types/users";
 import { Authorizer as casbinAuthorizer } from "casbin.js";
-import { permDefs } from "./UserAccessContext/permissions";
+import { permDefs, tables } from "./UserAccessContext/permissions";
 import { WhoamiResponse } from "@flanksource-ui/api/services/users";
 export type ActionType = "write" | "read";
 
@@ -16,14 +16,75 @@ export const Roles = {
 
 export function createAuthorizer(ctx: WhoamiResponse["payload"]): Authorizer {
   const authorizer = new casbinAuthorizer("manual");
-  const builtPerms: Record<string, any> = {};
+  const builtPerms: Record<ActionType, string[]> = {
+    read: [],
+    write: []
+  };
+  const deniedPerms: Record<ActionType, Set<string>> = {
+    read: new Set(),
+    write: new Set()
+  };
+
+  const expandObjects = (object: string) => {
+    return object === "*" ? Object.values(tables) : [object];
+  };
+
+  const expandActions = (action: string): ActionType[] => {
+    const actions = action.split(",").map((item) => item.trim());
+    const expanded = new Set<ActionType>();
+
+    if (actions.includes("*") || actions.includes("read")) {
+      expanded.add("read");
+    }
+    if (
+      actions.includes("*") ||
+      actions.includes("write") ||
+      actions.includes("create") ||
+      actions.includes("update") ||
+      actions.includes("delete")
+    ) {
+      expanded.add("write");
+    }
+
+    return [...expanded];
+  };
 
   (ctx.roles ?? []).forEach((role) => {
     const permissions = permDefs[role as keyof typeof permDefs] ?? {};
     Object.entries(permissions).forEach(([key, value]) => {
-      builtPerms[key] = [...(builtPerms[key] || []), ...value];
+      builtPerms[key as ActionType] = [
+        ...builtPerms[key as ActionType],
+        ...(value as string[])
+      ];
     });
   });
+
+  (ctx.permissions ?? []).forEach((permission) => {
+    // Resource selector/ABAC permissions are evaluated by the backend against
+    // concrete resources. UI route guards only use simple global object grants.
+    if (!permission.object || permission.condition) {
+      return;
+    }
+
+    const objects = expandObjects(permission.object);
+    const actions = expandActions(permission.action);
+
+    actions.forEach((action) => {
+      if (permission.deny) {
+        objects.forEach((object) => deniedPerms[action].add(object));
+      } else {
+        builtPerms[action] = [...builtPerms[action], ...objects];
+      }
+    });
+  });
+
+  (Object.keys(builtPerms) as ActionType[]).forEach((action) => {
+    builtPerms[action] = [...new Set(builtPerms[action])].filter(
+      (object) =>
+        !deniedPerms[action].has("*") && !deniedPerms[action].has(object)
+    );
+  });
+
   authorizer.setPermission(builtPerms);
   return {
     hasResourceAccess: (resourceName, action) => {
@@ -51,6 +112,7 @@ export type Permission = {
   object: string;
   deny?: boolean;
   action: string;
+  condition?: string;
 };
 
 interface IAuthContext {


### PR DESCRIPTION
Homepage fallback rendered Health directly whenever dashboard loading failed or no dashboard was configured. Users without Health access could land on a page they should not see while other permitted pages such as Catalog or Playbooks were available.

Check view access before rendering the dashboard and redirect to the first globally readable page instead of defaulting to Health.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission-based access gating to restrict UI visibility based on user permissions.
  * Introduced a new onboarding page displayed when users lack required page access.
  * Added loading indicators while permission checks are in progress.

* **Tests**
  * Updated test suite to validate permission-driven access control flows.

* **Refactor**
  * Enhanced permission system to support deny rules and conditional access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->