### PR TITLE
fix: add Clerk OIDC callback relay

### DIFF
--- a/pages/api/oidc/clerk/callback.ts
+++ b/pages/api/oidc/clerk/callback.ts
@@ -1,9 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const BACKEND_CALLBACK_PATH = "/oidc/clerk/callback";
+const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
 
 function isValidBackendOrigin(url: URL) {
-  return url.protocol === "https:";
+  return (
+    url.protocol === "https:" ||
+    (url.protocol === "http:" && LOCALHOST_HOSTNAMES.has(url.hostname))
+  );
 }
 
 function getBackendCallbackURL(orgBackendURL?: string) {

--- a/pages/api/oidc/clerk/callback.ts
+++ b/pages/api/oidc/clerk/callback.ts
@@ -1,13 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const BACKEND_CALLBACK_PATH = "/oidc/clerk/callback";
-const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
 
 function isValidBackendOrigin(url: URL) {
-  return (
-    url.protocol === "https:" ||
-    (url.protocol === "http:" && LOCALHOST_HOSTNAMES.has(url.hostname))
-  );
+  return url.protocol === "https:";
 }
 
 function getBackendCallbackURL(orgBackendURL?: string) {

--- a/pages/api/oidc/clerk/callback.ts
+++ b/pages/api/oidc/clerk/callback.ts
@@ -1,0 +1,84 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+function isAllowedBackendCallback(rawURL: string, orgBackendURL?: string) {
+  try {
+    const url = new URL(rawURL);
+    const isLocalhost = ["localhost", "127.0.0.1"].includes(url.hostname);
+    const isValidProtocol =
+      url.protocol === "https:" || (url.protocol === "http:" && isLocalhost);
+
+    if (url.pathname !== "/oidc/clerk/callback" || !isValidProtocol) {
+      return false;
+    }
+
+    if (isLocalhost) {
+      return true;
+    }
+
+    if (!orgBackendURL) {
+      return false;
+    }
+
+    return url.origin === new URL(orgBackendURL).origin;
+  } catch {
+    return false;
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "method not allowed" });
+  }
+
+  const authRequestID = String(req.body?.auth_request_id || "");
+  const backendCallback = String(req.body?.backend_callback || "");
+
+  if (!authRequestID || !backendCallback) {
+    return res.status(400).json({ error: "missing callback parameters" });
+  }
+
+  const { clerkClient, getAuth } = await import("@clerk/nextjs/server");
+  const auth = getAuth(req);
+
+  if (!auth.userId || !auth.orgId) {
+    return res.status(401).json({ error: "not signed in" });
+  }
+
+  const org = await clerkClient.organizations.getOrganization({
+    organizationId: auth.orgId
+  });
+  const orgBackendURL = org.publicMetadata?.backend_url as string | undefined;
+
+  if (!isAllowedBackendCallback(backendCallback, orgBackendURL)) {
+    return res.status(400).json({ error: "invalid backend callback" });
+  }
+
+  const token = await auth.getToken({ template: "Backend" });
+  if (!token) {
+    return res.status(401).json({ error: "unable to get session token" });
+  }
+
+  const callbackURL = new URL(backendCallback);
+  callbackURL.searchParams.set("auth_request_id", authRequestID);
+
+  const backendResp = await fetch(callbackURL.toString(), {
+    method: "POST",
+    redirect: "manual",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded"
+    },
+    body: new URLSearchParams({ clerk_session_token: token })
+  });
+
+  const location = backendResp.headers.get("location");
+  if (location && backendResp.status >= 300 && backendResp.status < 400) {
+    return res.redirect(backendResp.status, location);
+  }
+
+  const body = await backendResp.text();
+  return res.status(backendResp.status).send(body);
+}

--- a/pages/api/oidc/clerk/callback.ts
+++ b/pages/api/oidc/clerk/callback.ts
@@ -1,27 +1,30 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-function isAllowedBackendCallback(rawURL: string, orgBackendURL?: string) {
+const BACKEND_CALLBACK_PATH = "/oidc/clerk/callback";
+const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
+
+function isValidBackendOrigin(url: URL) {
+  return (
+    url.protocol === "https:" ||
+    (url.protocol === "http:" && LOCALHOST_HOSTNAMES.has(url.hostname))
+  );
+}
+
+function getBackendCallbackURL(orgBackendURL?: string) {
+  if (!orgBackendURL) {
+    return undefined;
+  }
+
   try {
-    const url = new URL(rawURL);
-    const isLocalhost = ["localhost", "127.0.0.1"].includes(url.hostname);
-    const isValidProtocol =
-      url.protocol === "https:" || (url.protocol === "http:" && isLocalhost);
+    const backendURL = new URL(orgBackendURL);
 
-    if (url.pathname !== "/oidc/clerk/callback" || !isValidProtocol) {
-      return false;
+    if (!isValidBackendOrigin(backendURL)) {
+      return undefined;
     }
 
-    if (isLocalhost) {
-      return true;
-    }
-
-    if (!orgBackendURL) {
-      return false;
-    }
-
-    return url.origin === new URL(orgBackendURL).origin;
+    return new URL(BACKEND_CALLBACK_PATH, backendURL.origin);
   } catch {
-    return false;
+    return undefined;
   }
 }
 
@@ -35,10 +38,9 @@ export default async function handler(
   }
 
   const authRequestID = String(req.body?.auth_request_id || "");
-  const backendCallback = String(req.body?.backend_callback || "");
 
-  if (!authRequestID || !backendCallback) {
-    return res.status(400).json({ error: "missing callback parameters" });
+  if (!authRequestID) {
+    return res.status(400).json({ error: "missing auth_request_id" });
   }
 
   const { clerkClient, getAuth } = await import("@clerk/nextjs/server");
@@ -53,7 +55,9 @@ export default async function handler(
   });
   const orgBackendURL = org.publicMetadata?.backend_url as string | undefined;
 
-  if (!isAllowedBackendCallback(backendCallback, orgBackendURL)) {
+  const callbackURL = getBackendCallbackURL(orgBackendURL);
+
+  if (!callbackURL) {
     return res.status(400).json({ error: "invalid backend callback" });
   }
 
@@ -62,7 +66,6 @@ export default async function handler(
     return res.status(401).json({ error: "unable to get session token" });
   }
 
-  const callbackURL = new URL(backendCallback);
   callbackURL.searchParams.set("auth_request_id", authRequestID);
 
   const backendResp = await fetch(callbackURL.toString(), {

--- a/pages/oidc/clerk/callback.tsx
+++ b/pages/oidc/clerk/callback.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@clerk/nextjs";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 
@@ -6,7 +7,7 @@ function getQueryValue(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value;
 }
 
-export default function ClerkOIDCCallback() {
+function ClerkOIDCCallbackContent() {
   const router = useRouter();
   const { isLoaded, isSignedIn } = useAuth();
   const formRef = useRef<HTMLFormElement>(null);
@@ -58,3 +59,7 @@ export default function ClerkOIDCCallback() {
     </>
   );
 }
+
+export default dynamic(() => Promise.resolve(ClerkOIDCCallbackContent), {
+  ssr: false
+});

--- a/pages/oidc/clerk/callback.tsx
+++ b/pages/oidc/clerk/callback.tsx
@@ -1,76 +1,27 @@
-import { useAuth, useOrganization } from "@clerk/nextjs";
+import { useAuth } from "@clerk/nextjs";
 import { useRouter } from "next/router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 function getQueryValue(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value;
 }
 
-function isAllowedBackendCallback(rawURL: string, orgBackendURL?: string) {
-  try {
-    const url = new URL(rawURL);
-    const isLocalhost = ["localhost", "127.0.0.1"].includes(url.hostname);
-    const isValidProtocol =
-      url.protocol === "https:" || (url.protocol === "http:" && isLocalhost);
-
-    if (url.pathname !== "/oidc/clerk/callback" || !isValidProtocol) {
-      return false;
-    }
-
-    if (isLocalhost) {
-      return true;
-    }
-
-    if (!orgBackendURL) {
-      return false;
-    }
-
-    return url.origin === new URL(orgBackendURL).origin;
-  } catch {
-    return false;
-  }
-}
-
 export default function ClerkOIDCCallback() {
   const router = useRouter();
   const { isLoaded, isSignedIn } = useAuth();
-  const { isLoaded: isOrganizationLoaded, organization } = useOrganization();
   const formRef = useRef<HTMLFormElement>(null);
   const [shouldSubmit, setShouldSubmit] = useState(false);
   const [error, setError] = useState<string>();
 
   const authRequestID = getQueryValue(router.query.auth_request_id);
-  const backendCallback = getQueryValue(router.query.backend_callback);
-  const orgBackendURL = organization?.publicMetadata.backend_url as
-    | string
-    | undefined;
-
-  const action = useMemo(() => {
-    if (
-      !backendCallback ||
-      !authRequestID ||
-      !isAllowedBackendCallback(backendCallback, orgBackendURL)
-    ) {
-      return undefined;
-    }
-
-    const url = new URL(backendCallback);
-    url.searchParams.set("auth_request_id", authRequestID);
-    return url.toString();
-  }, [authRequestID, backendCallback, orgBackendURL]);
 
   useEffect(() => {
-    if (!router.isReady || !isLoaded || !isOrganizationLoaded) {
+    if (!router.isReady || !isLoaded) {
       return;
     }
 
-    if (!authRequestID || !backendCallback) {
+    if (!authRequestID) {
       setError("Missing OIDC callback parameters");
-      return;
-    }
-
-    if (!action) {
-      setError("Invalid backend callback URL");
       return;
     }
 
@@ -80,15 +31,7 @@ export default function ClerkOIDCCallback() {
     }
 
     setShouldSubmit(true);
-  }, [
-    action,
-    authRequestID,
-    backendCallback,
-    isLoaded,
-    isOrganizationLoaded,
-    isSignedIn,
-    router
-  ]);
+  }, [authRequestID, isLoaded, isSignedIn, router]);
 
   useEffect(() => {
     if (shouldSubmit && formRef.current) {
@@ -103,10 +46,13 @@ export default function ClerkOIDCCallback() {
   return (
     <>
       <div className="p-6">Completing login...</div>
-      {action && shouldSubmit ? (
+      {shouldSubmit ? (
         <form ref={formRef} method="post" action="/api/oidc/clerk/callback">
-          <input type="hidden" name="auth_request_id" value={authRequestID || ""} />
-          <input type="hidden" name="backend_callback" value={backendCallback || ""} />
+          <input
+            type="hidden"
+            name="auth_request_id"
+            value={authRequestID || ""}
+          />
         </form>
       ) : null}
     </>

--- a/pages/oidc/clerk/callback.tsx
+++ b/pages/oidc/clerk/callback.tsx
@@ -1,0 +1,114 @@
+import { useAuth, useOrganization } from "@clerk/nextjs";
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+function getQueryValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function isAllowedBackendCallback(rawURL: string, orgBackendURL?: string) {
+  try {
+    const url = new URL(rawURL);
+    const isLocalhost = ["localhost", "127.0.0.1"].includes(url.hostname);
+    const isValidProtocol =
+      url.protocol === "https:" || (url.protocol === "http:" && isLocalhost);
+
+    if (url.pathname !== "/oidc/clerk/callback" || !isValidProtocol) {
+      return false;
+    }
+
+    if (isLocalhost) {
+      return true;
+    }
+
+    if (!orgBackendURL) {
+      return false;
+    }
+
+    return url.origin === new URL(orgBackendURL).origin;
+  } catch {
+    return false;
+  }
+}
+
+export default function ClerkOIDCCallback() {
+  const router = useRouter();
+  const { isLoaded, isSignedIn } = useAuth();
+  const { isLoaded: isOrganizationLoaded, organization } = useOrganization();
+  const formRef = useRef<HTMLFormElement>(null);
+  const [shouldSubmit, setShouldSubmit] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const authRequestID = getQueryValue(router.query.auth_request_id);
+  const backendCallback = getQueryValue(router.query.backend_callback);
+  const orgBackendURL = organization?.publicMetadata.backend_url as
+    | string
+    | undefined;
+
+  const action = useMemo(() => {
+    if (
+      !backendCallback ||
+      !authRequestID ||
+      !isAllowedBackendCallback(backendCallback, orgBackendURL)
+    ) {
+      return undefined;
+    }
+
+    const url = new URL(backendCallback);
+    url.searchParams.set("auth_request_id", authRequestID);
+    return url.toString();
+  }, [authRequestID, backendCallback, orgBackendURL]);
+
+  useEffect(() => {
+    if (!router.isReady || !isLoaded || !isOrganizationLoaded) {
+      return;
+    }
+
+    if (!authRequestID || !backendCallback) {
+      setError("Missing OIDC callback parameters");
+      return;
+    }
+
+    if (!action) {
+      setError("Invalid backend callback URL");
+      return;
+    }
+
+    if (!isSignedIn) {
+      router.replace(`/login?return_to=${encodeURIComponent(router.asPath)}`);
+      return;
+    }
+
+    setShouldSubmit(true);
+  }, [
+    action,
+    authRequestID,
+    backendCallback,
+    isLoaded,
+    isOrganizationLoaded,
+    isSignedIn,
+    router
+  ]);
+
+  useEffect(() => {
+    if (shouldSubmit && formRef.current) {
+      formRef.current.submit();
+    }
+  }, [shouldSubmit]);
+
+  if (error) {
+    return <div className="p-6 text-red-700">{error}</div>;
+  }
+
+  return (
+    <>
+      <div className="p-6">Completing login...</div>
+      {action && shouldSubmit ? (
+        <form ref={formRef} method="post" action="/api/oidc/clerk/callback">
+          <input type="hidden" name="auth_request_id" value={authRequestID || ""} />
+          <input type="hidden" name="backend_callback" value={backendCallback || ""} />
+        </form>
+      ) : null}
+    </>
+  );
+}


### PR DESCRIPTION
MCP OAuth login starts on the tenant backend, but Clerk login happens on the shared frontend.

A direct redirect to the backend cannot include the frontend-scoped Clerk session, so the frontend needs to bridge the completed login back to the tenant backend.

Add a Clerk OIDC callback page and API relay that validate the backend callback against the selected org, obtain a Clerk Backend token server-side, post it to the tenant backend, and forward the resulting OAuth redirect.