### PR TITLE
fix: preserve plugin API routes when proxying to mission-control

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -74,6 +74,16 @@ const config = {
       has: UI_REFERER_HAS,
       destination: `${backendURL}/:path*`
     };
+    const API_PLUGINS_REWRITES = [
+      {
+        source: "/api/plugins",
+        destination: `${backendURL}/api/plugins`
+      },
+      {
+        source: "/api/plugins/:path*",
+        destination: `${backendURL}/api/plugins/:path*`
+      }
+    ];
 
     // OIDC protocol endpoints are mounted at the root of the backend (matching the
     // issuer URL). These rewrites let the browser reach those endpoints through the
@@ -130,6 +140,7 @@ const config = {
     }
 
     const LOCALHOST_ENV_URL_REWRITES = [
+      ...API_PLUGINS_REWRITES,
       {
         source: "/api/:path*",
         destination: `${backendURL}/api/:path*`
@@ -148,6 +159,7 @@ const config = {
         source: "/api/.ory/:path*",
         destination: `${backendURL}/kratos/:path*`
       },
+      ...API_PLUGINS_REWRITES,
       // All other API requests are proxied to the backend on the same path
       // as the request.
       {

--- a/next.config.js
+++ b/next.config.js
@@ -76,6 +76,14 @@ const config = {
     };
     const API_PLUGINS_REWRITES = [
       {
+        source: "/api/plugins/:name/assets",
+        destination: `${backendURL}/api/plugins/:name/ui/assets`
+      },
+      {
+        source: "/api/plugins/:name/assets/:path*",
+        destination: `${backendURL}/api/plugins/:name/ui/assets/:path*`
+      },
+      {
         source: "/api/plugins",
         destination: `${backendURL}/api/plugins`
       },

--- a/pages/api/[...paths].ts
+++ b/pages/api/[...paths].ts
@@ -30,6 +30,15 @@ async function getTargetURL(req: NextApiRequest) {
 }
 
 function getPathRewrites(req: NextApiRequest) {
+  if (/^\/api\/plugins\/[^/]+\/assets(?:\/|$)/.test(req.url ?? "")) {
+    return [
+      {
+        patternStr: "^/api/plugins/([^/]+)/assets",
+        replaceStr: "/api/plugins/$1/ui/assets"
+      }
+    ];
+  }
+
   if (req.url?.startsWith("/api/plugins")) {
     return [{ patternStr: "^/api/plugins", replaceStr: "/api/plugins" }];
   }

--- a/pages/api/[...paths].ts
+++ b/pages/api/[...paths].ts
@@ -29,7 +29,11 @@ async function getTargetURL(req: NextApiRequest) {
   return process.env.BACKEND_URL;
 }
 
-function getPathRewrites() {
+function getPathRewrites(req: NextApiRequest) {
+  if (req.url?.startsWith("/api/plugins")) {
+    return [{ patternStr: "^/api/plugins", replaceStr: "/api/plugins" }];
+  }
+
   return [{ patternStr: "^/api", replaceStr: "/" }];
 }
 
@@ -46,6 +50,6 @@ export default async function handler(
   return httpProxyMiddleware(req, res, {
     target: target!,
     xfwd: true,
-    pathRewrite: getPathRewrites()
+    pathRewrite: getPathRewrites(req)
   });
 }


### PR DESCRIPTION
Embedded mission-control UI calls plugin endpoints under `/api/plugins/*`.\n\nflanksource-ui's generic API proxy stripped `/api`, forwarding those requests to `/plugins/*`, while mission-control serves plugin APIs at `/api/plugins/*`. This broke plugin listing and UI requests when accessed through flanksource-ui.\n\nAdd a higher-priority rewrite and API proxy exception so `/api/plugins/*` is forwarded to mission-control unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined API request routing configuration to ensure plugin requests are properly handled in authenticated and production environments.
  * Optimized request proxy configuration for improved backend integration across different deployment states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flanksource/flanksource-ui/pull/3029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->