### PR TITLE
fix: plugin redirection call in clerk

### DIFF
--- a/src/api/services/__tests__/configPlugins.unit.test.ts
+++ b/src/api/services/__tests__/configPlugins.unit.test.ts
@@ -17,9 +17,10 @@ const mockedGet = apiBase.get as jest.MockedFunction<typeof apiBase.get>;
 describe("getPluginsForConfig", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    window.history.pushState({}, "", "/catalog/abc");
   });
 
-  it("requests /plugins with an encoded config_id and returns the listings", async () => {
+  it("requests /plugins through the /api prefix and returns the listings", async () => {
     const listings = [
       { name: "kubernetes-logs", tabs: [{ name: "Logs", path: "/" }] }
     ];
@@ -27,8 +28,22 @@ describe("getPluginsForConfig", () => {
 
     const result = await getPluginsForConfig("abc 123");
 
-    expect(mockedGet).toHaveBeenCalledWith("/plugins?config_id=abc%20123");
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/plugins?config_id=abc%20123",
+      undefined
+    );
     expect(result).toEqual(listings);
+  });
+
+  it("requests the bare /plugins path when served from the /ui proxy", async () => {
+    window.history.pushState({}, "", "/ui/catalog/abc");
+    mockedGet.mockResolvedValue({ data: [] } as any);
+
+    await getPluginsForConfig("abc 123");
+
+    expect(mockedGet).toHaveBeenCalledWith("/plugins?config_id=abc%20123", {
+      baseURL: ""
+    });
   });
 
   it("returns an empty array when the response carries no data", async () => {
@@ -39,6 +54,10 @@ describe("getPluginsForConfig", () => {
 });
 
 describe("pluginUiSrc", () => {
+  beforeEach(() => {
+    window.history.pushState({}, "", "/catalog/abc");
+  });
+
   it("keeps a leading-slash path without doubling the separator", () => {
     expect(pluginUiSrc("k8s-logs", "/index.html", "cfg-1")).toBe(
       "/api/plugins/k8s-logs/ui/index.html?config_id=cfg-1"
@@ -54,6 +73,13 @@ describe("pluginUiSrc", () => {
   it("encodes the plugin name and config id", () => {
     expect(pluginUiSrc("a b", "/", "c/d")).toBe(
       "/api/plugins/a%20b/ui/?config_id=c%2Fd"
+    );
+  });
+
+  it("drops the /api prefix when served from the /ui proxy", () => {
+    window.history.pushState({}, "", "/ui/catalog/abc");
+    expect(pluginUiSrc("k8s-logs", "/index.html", "cfg-1")).toBe(
+      "/plugins/k8s-logs/ui/index.html?config_id=cfg-1"
     );
   });
 });

--- a/src/api/services/configPlugins.ts
+++ b/src/api/services/configPlugins.ts
@@ -16,6 +16,17 @@ export type PluginListing = {
 };
 
 /**
+ * When the app is served from the backend's own /ui proxy, XHRs hit bare
+ * backend paths (no /api prefix); the backend resolves them directly. Match
+ * that here so the plugins listing behaves like every other backend call under
+ * /ui. Every other deployment keeps apiBase's /api baseURL.
+ */
+const isUiProxy = (): boolean =>
+  typeof window !== "undefined" &&
+  (window.location.pathname === "/ui" ||
+    window.location.pathname.startsWith("/ui/"));
+
+/**
  * Lists the plugins whose resource selector matches the given config item.
  * Each plugin contributes zero or more tabs rendered on the catalog detail
  * page. Served by mission-control at GET /api/plugins?config_id=X.
@@ -24,7 +35,8 @@ export const getPluginsForConfig = async (
   configId: string
 ): Promise<PluginListing[]> => {
   const res = await apiBase.get<PluginListing[]>(
-    `/plugins?config_id=${encodeURIComponent(configId)}`
+    `/plugins?config_id=${encodeURIComponent(configId)}`,
+    isUiProxy() ? { baseURL: "" } : undefined
   );
   return res.data ?? [];
 };
@@ -41,7 +53,8 @@ export const pluginUiSrc = (
   configId: string
 ): string => {
   const sep = path.startsWith("/") ? "" : "/";
-  return `/api/plugins/${encodeURIComponent(pluginName)}/ui${sep}${path}?config_id=${encodeURIComponent(configId)}`;
+  const prefix = isUiProxy() ? "" : "/api";
+  return `${prefix}/plugins/${encodeURIComponent(pluginName)}/ui${sep}${path}?config_id=${encodeURIComponent(configId)}`;
 };
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin requests now correctly resolve in both direct-hosting and backend-proxy deployment modes. Plugin configurations and UI sources properly adapt to their hosting environment, ensuring compatibility across different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->