### PR TITLE
feat: add plugin operation actions to permission form

### DIFF
--- a/src/components/Permissions/ManagePermissions/Forms/PermissionForm.tsx
+++ b/src/components/Permissions/ManagePermissions/Forms/PermissionForm.tsx
@@ -2,7 +2,8 @@ import {
   addPermission,
   updatePermission,
   fetchPermissionById,
-  recheckPermission
+  recheckPermission,
+  fetchPluginPermissionListings
 } from "@flanksource-ui/api/services/permissions";
 import { PermissionTable } from "@flanksource-ui/api/types/permissions";
 import FormikCheckbox from "@flanksource-ui/components/Forms/Formik/FormikCheckbox";
@@ -23,7 +24,11 @@ import { Form, Formik, useFormikContext } from "formik";
 import { useMemo } from "react";
 import { FaSpinner } from "react-icons/fa";
 import { AuthorizationAccessCheck } from "../../AuthorizationAccessCheck";
-import { getActionsForResourceType, ResourceType } from "../../PermissionsView";
+import {
+  getActionsForResourceType,
+  getPluginOperationActions,
+  ResourceType
+} from "../../PermissionsView";
 import DeletePermission from "./DeletePermission";
 import FormikPermissionSelectResourceFields from "./FormikPermissionSelectResourceFields";
 import PermissionResource from "./PermissionResource";
@@ -39,6 +44,16 @@ type PermissionFormProps = {
 
 function PermissionActionDropdown({ isDisabled }: { isDisabled?: boolean }) {
   const { values } = useFormikContext<Partial<PermissionTable>>();
+  const { data: plugins = [] } = useQuery({
+    queryKey: ["permissions", "plugins", "actions"],
+    queryFn: fetchPluginPermissionListings,
+    staleTime: 60_000
+  });
+
+  const pluginActions = useMemo(
+    () => getPluginOperationActions(plugins),
+    [plugins]
+  );
 
   const resourceType = useMemo<ResourceType | undefined>(() => {
     if (values.playbook_id) return "playbook";
@@ -58,7 +73,15 @@ function PermissionActionDropdown({ isDisabled }: { isDisabled?: boolean }) {
       return [{ value: "mcp:use", label: "mcp:use" }];
     }
 
-    const actions = getActionsForResourceType(resourceType);
+    const canUsePluginActions =
+      resourceType === "catalog" &&
+      (values.subject_type === "person" ||
+        values.subject_type === "team" ||
+        values.subject_type === "role");
+
+    const actions = canUsePluginActions
+      ? [...getActionsForResourceType(resourceType), ...pluginActions]
+      : getActionsForResourceType(resourceType);
 
     // mcp:run is only valid for playbook permissions assigned to person/team subjects.
     if (
@@ -70,7 +93,13 @@ function PermissionActionDropdown({ isDisabled }: { isDisabled?: boolean }) {
     }
 
     return actions;
-  }, [resourceType, values.object, values.playbook_id, values.subject_type]);
+  }, [
+    pluginActions,
+    resourceType,
+    values.object,
+    values.playbook_id,
+    values.subject_type
+  ]);
 
   if (!resourceType) {
     return null;

--- a/src/components/Permissions/PermissionsView.tsx
+++ b/src/components/Permissions/PermissionsView.tsx
@@ -1,6 +1,8 @@
 import {
   fetchPermissions,
-  FetchPermissionsInput
+  FetchPermissionsInput,
+  type PluginOperationDefinition,
+  type PluginPermissionSubject
 } from "@flanksource-ui/api/services/permissions";
 import {
   PermissionsSummary,
@@ -58,6 +60,44 @@ export type ResourceType =
   | "canary"
   | "view"
   | "global";
+
+function getPluginOperationName(operation: PluginOperationDefinition | string) {
+  if (typeof operation === "string") {
+    return operation.trim();
+  }
+
+  return operation.name?.trim() ?? "";
+}
+
+export function getPluginOperationActions(
+  plugins: PluginPermissionSubject[] = []
+): FormikSelectDropdownOption[] {
+  const actions = plugins.flatMap((plugin) => {
+    const pluginName = (plugin.name ?? plugin.id)?.trim();
+
+    if (!pluginName) {
+      return [];
+    }
+
+    const wildcardAction = `invoke:${pluginName}:*`;
+    const operationActions = (plugin.operations ?? [])
+      .map(getPluginOperationName)
+      .filter(Boolean)
+      .map((operationName) => {
+        const action = `invoke:${pluginName}:${operationName}`;
+        return { value: action, label: action };
+      });
+
+    return [
+      { value: wildcardAction, label: wildcardAction },
+      ...operationActions
+    ];
+  });
+
+  return Array.from(
+    new Map(actions.map((action) => [action.value, action])).values()
+  ).sort((a, b) => a.value.localeCompare(b.value));
+}
 
 export function getActionsForResourceType(
   resourceType?: ResourceType


### PR DESCRIPTION
closes: https://github.com/flanksource/flanksource-ui/issues/3032

Permission actions for catalog resources now include plugin operations from the plugins endpoint.

Each plugin contributes `invoke:<plugin>:<operation>` actions plus `invoke:<plugin>:*` for wildcard access. These actions are only shown when the subject is a person, team, or role and the selected resource is catalog.