### PR TITLE
feat(playbooks): add support to render html

### DIFF
--- a/src/components/Playbooks/Runs/Actions/PlaybookResultsDropdownButton.tsx
+++ b/src/components/Playbooks/Runs/Actions/PlaybookResultsDropdownButton.tsx
@@ -16,14 +16,7 @@ type Props = {
   activeTab: string;
   activeTabContentRef: React.RefObject<HTMLDivElement>;
   artifactID?: string;
-  contentType?:
-    | "application/sql"
-    | "text/markdown"
-    | "text/x-shellscript"
-    | "text/plain"
-    | "application/yaml"
-    | "application/log+json"
-    | "application/json";
+  contentType?: string;
 };
 
 // Downloads the rendered content or the artifact
@@ -70,7 +63,9 @@ export default function TabContentDownloadButton({
 }
 
 function getContentTypeExtension(contentType: string) {
-  switch (contentType) {
+  switch (contentType.split(";")[0].trim().toLowerCase()) {
+    case "text/html":
+      return "html";
     case "text/markdown":
       return "md";
     case "text/x-shellscript":

--- a/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
+++ b/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
@@ -453,7 +453,11 @@ function renderContent(
           // sanitized since playbook output can embed untrusted data
           sandbox=""
           srcDoc={DOMPurify.sanitize(String(content), {
-            WHOLE_DOCUMENT: true
+            WHOLE_DOCUMENT: true,
+            // Allow external and inline stylesheets so HTML reports keep
+            // their styling. Scripts are still stripped by default.
+            ADD_TAGS: ["link"],
+            ADD_ATTR: ["rel", "href"]
           })}
         />
       );

--- a/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
+++ b/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
@@ -1,4 +1,5 @@
 import Convert from "ansi-to-html";
+import DOMPurify from "dompurify";
 import linkifyHtml from "linkify-html";
 import { Opts } from "linkifyjs";
 import clsx from "clsx";
@@ -448,8 +449,12 @@ function renderContent(
         <iframe
           title={title}
           className="h-full min-h-[60vh] w-full rounded bg-white"
-          sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
-          srcDoc={String(content)}
+          // Empty sandbox applies all restrictions; the content is also
+          // sanitized since playbook output can embed untrusted data
+          sandbox=""
+          srcDoc={DOMPurify.sanitize(String(content), {
+            WHOLE_DOCUMENT: true
+          })}
         />
       );
 

--- a/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
+++ b/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
@@ -449,13 +449,15 @@ function renderContent(
         <iframe
           title={title}
           className="h-full min-h-[60vh] w-full rounded bg-white"
-          // Empty sandbox applies all restrictions; the content is also
-          // sanitized since playbook output can embed untrusted data
-          sandbox=""
+          // The sandbox stays permissive for styling, links and same-origin
+          // resources but withholds allow-scripts so no JavaScript can run.
+          // DOMPurify also strips scripts, inline handlers and javascript:
+          // URLs from the content while keeping all CSS intact.
+          sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
           srcDoc={DOMPurify.sanitize(String(content), {
             WHOLE_DOCUMENT: true,
-            // Allow external and inline stylesheets so HTML reports keep
-            // their styling. Scripts are still stripped by default.
+            // Keep external and inline stylesheets so HTML reports retain
+            // their styling.
             ADD_TAGS: ["link"],
             ADD_ATTR: ["rel", "href"]
           })}

--- a/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
+++ b/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
@@ -121,6 +121,8 @@ type Props = {
   className?: string;
 };
 
+type DisplayContentType = string;
+
 type PlaybookActionTab = {
   label: string;
   type?: "artifact" | "error";
@@ -128,15 +130,34 @@ type PlaybookActionTab = {
   content: any;
   artifactID?: string;
   className?: string;
-  displayContentType:
-    | "text/markdown"
-    | "text/x-shellscript"
-    | "text/plain"
-    | "application/yaml"
-    | "application/log+json"
-    | "application/json"
-    | "application/sql";
+  displayContentType: DisplayContentType;
 };
+
+function normalizeContentType(contentType?: string): DisplayContentType {
+  const baseContentType = contentType?.split(";")[0].trim().toLowerCase();
+
+  if (baseContentType === "markdown") {
+    return "text/markdown";
+  }
+
+  return baseContentType || "text/plain";
+}
+
+function isPreviewableContentType(contentType?: string) {
+  switch (normalizeContentType(contentType)) {
+    case "text/html":
+    case "text/markdown":
+    case "text/x-shellscript":
+    case "text/plain":
+    case "application/yaml":
+    case "application/log+json":
+    case "application/json":
+    case "application/sql":
+      return true;
+    default:
+      return false;
+  }
+}
 
 export default function PlaybooksRunActionsResults({
   action,
@@ -267,8 +288,7 @@ export default function PlaybooksRunActionsResults({
             (key === "stdout" || key === "body") &&
             tab.displayContentType === "text/plain"
           ) {
-            tab.displayContentType =
-              resultContentType as PlaybookActionTab["displayContentType"];
+            tab.displayContentType = resultContentType;
           }
 
           if (key === "error") {
@@ -301,13 +321,7 @@ export default function PlaybooksRunActionsResults({
           artifactID: artifact.id,
           type: "artifact",
           content: artifact,
-          displayContentType: artifact.content_type as
-            | "text/markdown"
-            | "text/x-shellscript"
-            | "text/plain"
-            | "application/yaml"
-            | "application/log+json"
-            | "application/json"
+          displayContentType: normalizeContentType(artifact.content_type)
         });
       }
     }
@@ -410,7 +424,7 @@ function renderContent(
   content: any,
   className?: string
 ) {
-  switch (contentType) {
+  switch (normalizeContentType(contentType)) {
     case "text/plain":
     case "text/x-shellscript":
       return <DisplayLogs className={className} logs={String(content)} />;
@@ -427,8 +441,17 @@ function renderContent(
       );
 
     case "text/markdown":
-    case "markdown": // for backwards compatibility
       return <DisplayMarkdown className={className} md={content} />;
+
+    case "text/html":
+      return (
+        <iframe
+          title={title}
+          className="h-full min-h-[60vh] w-full rounded bg-white"
+          sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+          srcDoc={String(content)}
+        />
+      );
 
     case "application/yaml":
     case "application/json":
@@ -450,10 +473,55 @@ function renderContent(
       );
 
     default:
-      throw new Error(
-        `Unknown display content type for tab ${title}: ${contentType}`
+      return (
+        <PreviewNotAvailable
+          content={String(content)}
+          contentType={contentType}
+          filename={title}
+        />
       );
   }
+}
+
+function PreviewNotAvailable({
+  content,
+  contentType,
+  downloadURL,
+  filename
+}: {
+  content?: string;
+  contentType: string;
+  downloadURL?: string;
+  filename: string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center py-8 text-center text-gray-500">
+      <p className="mb-4">
+        Preview not available for {contentType || "this file type"}. Click to
+        download.
+      </p>
+      <Button
+        onClick={() => {
+          if (downloadURL) {
+            window.open(downloadURL, "_blank");
+            return;
+          }
+
+          const file = new Blob([content || ""], {
+            type: contentType || "application/octet-stream"
+          });
+          const a = document.createElement("a");
+          a.href = URL.createObjectURL(file);
+          a.download = filename;
+          a.click();
+          URL.revokeObjectURL(a.href);
+        }}
+      >
+        <IoMdDownload className="mr-2" />
+        Download
+      </Button>
+    </div>
+  );
 }
 
 function ArtifactContent({
@@ -467,6 +535,7 @@ function ArtifactContent({
 
   const maxFileSize = 50 * 1024 * 1024; // 50MB
   const isSmallFile = artifact.size < maxFileSize;
+  const canPreview = isPreviewableContentType(artifact.content_type);
 
   const {
     data: artifactContent,
@@ -475,7 +544,7 @@ function ArtifactContent({
   } = useQuery({
     queryKey: ["artifact", artifact.id],
     queryFn: () => downloadArtifact(artifact.id),
-    enabled: isSmallFile, // Only fetch if it's a small file
+    enabled: isSmallFile && canPreview, // Only fetch if it's a small file and supported
     staleTime: Infinity, // Artifacts don't change once created
     cacheTime: 1000 * 60 * 60 * 24, // Cache for 24 hours
     retry: 1, // Only retry once on failure
@@ -509,6 +578,16 @@ function ArtifactContent({
             Download
           </Button>
         </div>
+      );
+    }
+
+    if (!canPreview) {
+      return (
+        <PreviewNotAvailable
+          contentType={artifact.content_type}
+          downloadURL={downloadURL}
+          filename={artifact.filename}
+        />
       );
     }
 

--- a/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
+++ b/src/components/Playbooks/Runs/Actions/PlaybooksActionsResults.tsx
@@ -1,5 +1,4 @@
 import Convert from "ansi-to-html";
-import DOMPurify from "dompurify";
 import linkifyHtml from "linkify-html";
 import { Opts } from "linkifyjs";
 import clsx from "clsx";
@@ -449,18 +448,12 @@ function renderContent(
         <iframe
           title={title}
           className="h-full min-h-[60vh] w-full rounded bg-white"
-          // The sandbox stays permissive for styling, links and same-origin
-          // resources but withholds allow-scripts so no JavaScript can run.
-          // DOMPurify also strips scripts, inline handlers and javascript:
-          // URLs from the content while keeping all CSS intact.
-          sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-          srcDoc={DOMPurify.sanitize(String(content), {
-            WHOLE_DOCUMENT: true,
-            // Keep external and inline stylesheets so HTML reports retain
-            // their styling.
-            ADD_TAGS: ["link"],
-            ADD_ATTR: ["rel", "href"]
-          })}
+          // The iframe renders untrusted playbook HTML. Omitting allow-scripts
+          // means the browser blocks all JavaScript (scripts, inline handlers,
+          // javascript: URLs) while CSS, images and links still render. Popups
+          // are allowed so report links can open in a new tab.
+          sandbox="allow-popups allow-popups-to-escape-sandbox"
+          srcDoc={String(content)}
         />
       );
 

--- a/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
+++ b/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
@@ -262,7 +262,7 @@ describe("PlaybooksRunActionsResults", () => {
     );
   });
 
-  it("sanitizes javascript out of html and blocks scripts in the sandbox", () => {
+  it("blocks javascript by withholding allow-scripts from the iframe sandbox", () => {
     const html =
       '<h1 onclick="alert(1)">Report</h1><script>alert("xss")</script>';
     const action = {
@@ -281,19 +281,22 @@ describe("PlaybooksRunActionsResults", () => {
     render(<PlaybooksRunActionsResults action={action} />);
 
     const iframe = screen.getByTitle("Stdout");
-    const srcDoc = iframe.getAttribute("srcdoc");
-    expect(srcDoc).toContain("Report");
-    expect(srcDoc).not.toContain("<script");
-    expect(srcDoc).not.toContain("onclick");
-    // The sandbox must never grant allow-scripts so no JavaScript can run.
+    // The sandbox must never grant allow-scripts; the browser then refuses to
+    // execute any script, inline handler or javascript: URL in the content.
     expect(iframe.getAttribute("sandbox")).not.toContain("allow-scripts");
   });
 
-  it("preserves css when rendering html", () => {
+  it("preserves css verbatim when rendering html", () => {
+    // Tailwind-style resets with empty custom properties and pseudo-element
+    // selectors must survive untouched.
+    const css =
+      "*, ::before, ::after { --tw-ring-color: rgb(59 130 246 / 0.5); --tw-pan-x:  ; }" +
+      "::backdrop { --tw-translate-x: 0; }" +
+      "@media (max-width: 600px) { .box { color: blue; } }";
     const html =
       "<html><head>" +
       '<link rel="stylesheet" href="https://cdn.example.com/report.css">' +
-      "<style>.box { color: red; }</style>" +
+      `<style>${css}</style>` +
       '</head><body><div class="box" style="font-weight:bold;">Styled</div></body></html>';
     const action = {
       id: "1",
@@ -311,12 +314,12 @@ describe("PlaybooksRunActionsResults", () => {
     render(<PlaybooksRunActionsResults action={action} />);
 
     const srcDoc = screen.getByTitle("Stdout").getAttribute("srcdoc");
-    expect(srcDoc).toContain("<style>.box { color: red; }</style>");
+    expect(srcDoc).toContain(`<style>${css}</style>`);
     expect(srcDoc).toContain('style="font-weight:bold;"');
     expect(srcDoc).toContain('class="box"');
-    expect(srcDoc).toContain("<link ");
-    expect(srcDoc).toContain('href="https://cdn.example.com/report.css"');
-    expect(srcDoc).toContain('rel="stylesheet"');
+    expect(srcDoc).toContain(
+      '<link rel="stylesheet" href="https://cdn.example.com/report.css">'
+    );
   });
 
   it("does not show contentType as its own tab", () => {

--- a/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
+++ b/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
@@ -288,6 +288,36 @@ describe("PlaybooksRunActionsResults", () => {
     expect(iframe).toHaveAttribute("sandbox", "");
   });
 
+  it("preserves css when rendering html", () => {
+    const html =
+      "<html><head>" +
+      '<link rel="stylesheet" href="https://cdn.example.com/report.css">' +
+      "<style>.box { color: red; }</style>" +
+      '</head><body><div class="box" style="font-weight:bold;">Styled</div></body></html>';
+    const action = {
+      id: "1",
+      name: "exec html",
+      status: "completed" as const,
+      playbook_run_id: "1",
+      start_time: "2024-01-01",
+      type: "exec" as const,
+      result: {
+        stdout: html,
+        contentType: "text/html"
+      }
+    };
+
+    render(<PlaybooksRunActionsResults action={action} />);
+
+    const srcDoc = screen.getByTitle("Stdout").getAttribute("srcdoc");
+    expect(srcDoc).toContain("<style>.box { color: red; }</style>");
+    expect(srcDoc).toContain('style="font-weight:bold;"');
+    expect(srcDoc).toContain('class="box"');
+    expect(srcDoc).toContain("<link ");
+    expect(srcDoc).toContain('href="https://cdn.example.com/report.css"');
+    expect(srcDoc).toContain('rel="stylesheet"');
+  });
+
   it("does not show contentType as its own tab", () => {
     const action = {
       id: "1",

--- a/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
+++ b/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
@@ -262,7 +262,7 @@ describe("PlaybooksRunActionsResults", () => {
     );
   });
 
-  it("sanitizes html and keeps the iframe sandbox fully restrictive", () => {
+  it("sanitizes javascript out of html and blocks scripts in the sandbox", () => {
     const html =
       '<h1 onclick="alert(1)">Report</h1><script>alert("xss")</script>';
     const action = {
@@ -285,7 +285,8 @@ describe("PlaybooksRunActionsResults", () => {
     expect(srcDoc).toContain("Report");
     expect(srcDoc).not.toContain("<script");
     expect(srcDoc).not.toContain("onclick");
-    expect(iframe).toHaveAttribute("sandbox", "");
+    // The sandbox must never grant allow-scripts so no JavaScript can run.
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-scripts");
   });
 
   it("preserves css when rendering html", () => {

--- a/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
+++ b/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
@@ -237,6 +237,28 @@ describe("PlaybooksRunActionsResults", () => {
     expect(screen.getByText("hello world")).toBeInTheDocument();
   });
 
+  it("renders html content types with charset in an iframe", () => {
+    const html = "<html><body><h1>HTML Report</h1></body></html>";
+    const action = {
+      id: "1",
+      name: "exec html",
+      status: "completed" as const,
+      playbook_run_id: "1",
+      start_time: "2024-01-01",
+      type: "exec" as const,
+      result: {
+        stdout: html,
+        contentType: "text/html; charset=UTF-8"
+      }
+    };
+
+    render(<PlaybooksRunActionsResults action={action} />);
+
+    const iframe = screen.getByTitle("Stdout");
+    expect(iframe).toBeInTheDocument();
+    expect(iframe).toHaveAttribute("srcdoc", html);
+  });
+
   it("does not show contentType as its own tab", () => {
     const action = {
       id: "1",

--- a/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
+++ b/src/components/Playbooks/Runs/Actions/__tests__/PlaybooksActionsResults.unit.test.tsx
@@ -256,7 +256,36 @@ describe("PlaybooksRunActionsResults", () => {
 
     const iframe = screen.getByTitle("Stdout");
     expect(iframe).toBeInTheDocument();
-    expect(iframe).toHaveAttribute("srcdoc", html);
+    expect(iframe).toHaveAttribute(
+      "srcdoc",
+      expect.stringContaining("<h1>HTML Report</h1>")
+    );
+  });
+
+  it("sanitizes html and keeps the iframe sandbox fully restrictive", () => {
+    const html =
+      '<h1 onclick="alert(1)">Report</h1><script>alert("xss")</script>';
+    const action = {
+      id: "1",
+      name: "exec html",
+      status: "completed" as const,
+      playbook_run_id: "1",
+      start_time: "2024-01-01",
+      type: "exec" as const,
+      result: {
+        stdout: html,
+        contentType: "text/html"
+      }
+    };
+
+    render(<PlaybooksRunActionsResults action={action} />);
+
+    const iframe = screen.getByTitle("Stdout");
+    const srcDoc = iframe.getAttribute("srcdoc");
+    expect(srcDoc).toContain("Report");
+    expect(srcDoc).not.toContain("<script");
+    expect(srcDoc).not.toContain("onclick");
+    expect(iframe).toHaveAttribute("sandbox", "");
   });
 
   it("does not show contentType as its own tab", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline rendering for HTML output using a sandboxed iframe (including stdout).
  * Improved “Preview Unavailable” experience for unsupported/non-previewable content while keeping a download option.

* **Bug Fixes**
  * Improved content-type parsing by normalizing values (trimming, lowercasing, removing parameters) to drive preview/download behavior consistently.
  * Refined preview eligibility for artifacts using content-type suitability and artifact size.

* **Tests**
  * Added unit tests covering HTML stdout iframe rendering, sandbox restrictions, and `srcdoc` output for markup and styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->