### PR TITLE
fix: show UI version in Clerk profile menu

### DIFF
--- a/src/components/Users/UserProfile.tsx
+++ b/src/components/Users/UserProfile.tsx
@@ -1,12 +1,13 @@
 import { OrganizationSwitcher, UserButton } from "@clerk/nextjs";
 import { lazy, Suspense, useEffect, useState } from "react";
-import { Search } from "lucide-react";
+import { Info, Search } from "lucide-react";
 import { IoMdAirplane, IoMdDownload, IoMdSwap } from "react-icons/io";
 import { MdSecurity } from "react-icons/md";
 import { useFeatureFlagsContext } from "../../context/FeatureFlagsContext";
 import { isNewUIPreferred, setNewUIPreference } from "../../utils/uiPreference";
 import { hasImpersonatedScopes } from "../Scopes/Impersonation/scopeImpersonationStore";
 import { KratosUserProfileDropdown } from "../Authentication/Kratos/KratosUserProfileDropdown";
+import { frontendVersion } from "../VersionInfo/VersionInfo";
 import useDetermineAuthSystem from "../Authentication/useDetermineAuthSystem";
 import AddKubeConfigModal from "../KubeConfig/AddKubeConfigModal";
 import ScopeImpersonationModal from "../Scopes/Impersonation/ScopeImpersonationModal";
@@ -85,6 +86,11 @@ export function UserProfileDropdown() {
                   onClick={() => setIsScopeImpersonationModalOpen(true)}
                 />
               )}
+              <UserButton.Action
+                label={`UI Version: ${frontendVersion}`}
+                labelIcon={<Info className="h-4 w-4" />}
+                onClick={() => {}}
+              />
             </UserButton.MenuItems>
           </UserButton>
         </div>

--- a/src/components/VersionInfo/VersionInfo.tsx
+++ b/src/components/VersionInfo/VersionInfo.tsx
@@ -2,7 +2,7 @@ import packageJson from "../../../package.json";
 import { useVersionInfo } from "../../api/query-hooks";
 
 // This is static version from package.json and doesn't change after build
-const frontendVersion = packageJson.version;
+export const frontendVersion = packageJson.version;
 
 export function VersionInfo() {
   const { data, isLoading, isRefetching } = useVersionInfo();


### PR DESCRIPTION
Clerk-authenticated deployments use Clerk's profile menu, which was missing the UI version shown in the Kratos menu.

Export the existing frontend package version and add it as a Clerk menu item so users can identify the deployed UI build.