### PR TITLE
fix: preserve timezone offsets in check status age

### DIFF
--- a/src/components/Canary/CanaryPopup/StatusHistory/StatusHistory.tsx
+++ b/src/components/Canary/CanaryPopup/StatusHistory/StatusHistory.tsx
@@ -31,7 +31,7 @@ const columns: ColumnDef<HealthCheckStatus, any>[] = [
       return (
         <>
           <span data-tooltip-id={`age-tooltip-${status.time}`}>
-            {format(`${status.time} UTC`)}
+            {format(status.time)}
           </span>
           <Tooltip
             id={`age-tooltip-${status.time}`}


### PR DESCRIPTION
Check status history can receive timestamps with non-UTC offsets.

The Age column appended "UTC" before formatting, causing timeago parsing to ignore the original offset and display incorrect relative times.

Pass the timestamp through unchanged so timezone offsets from the API are preserved.