### PR TITLE
fix(oidc): navigate backend callbacks with full reload

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         run: npm i
-      - uses: chromaui/action@5f2cdb26c04c0364f5c8ca3fc41627a83d6ffc8a # v1
+      - uses: chromaui/action@v17.4.1
         with:
           projectToken: ${{ secrets.CHROMATIC_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/components/Authentication/Kratos/ory/errors.tsx
+++ b/src/components/Authentication/Kratos/ory/errors.tsx
@@ -19,10 +19,18 @@ export function handleGetFlowError<S>(
         return;
       case "session_already_available": {
         // User is already signed in; continue the requested flow when return_to is present.
-        const returnTo = new URLSearchParams(window.location.search).get(
-          "return_to"
+        const returnTo = sanitizeReturnTo(
+          new URLSearchParams(window.location.search).get("return_to")
         );
-        await router.push(sanitizeReturnTo(returnTo));
+
+        // /oidc/* is served by the backend via Next rewrites, which only fire on
+        // real navigations, not client-side router.push.
+        if (returnTo.startsWith("/oidc/")) {
+          window.location.assign(returnTo);
+          return;
+        }
+
+        await router.push(returnTo);
         return;
       }
       case "session_refresh_required":

--- a/src/components/Authentication/Kratos/ory/hooks.ts
+++ b/src/components/Authentication/Kratos/ory/hooks.ts
@@ -35,10 +35,18 @@ export function handleGetFlowError<S>(
         return;
       case "session_already_available": {
         // User is already signed in; continue the requested flow when return_to is present.
-        const returnTo = new URLSearchParams(window.location.search).get(
-          "return_to"
+        const returnTo = sanitizeReturnTo(
+          new URLSearchParams(window.location.search).get("return_to")
         );
-        await router.push(sanitizeReturnTo(returnTo));
+
+        // /oidc/* is served by the backend via Next rewrites, which only fire on
+        // real navigations, not client-side router.push.
+        if (returnTo.startsWith("/oidc/")) {
+          window.location.assign(returnTo);
+          return;
+        }
+
+        await router.push(returnTo);
         return;
       }
       case "session_refresh_required":


### PR DESCRIPTION
resolves: https://github.com/flanksource/mission-control/issues/3230

When Kratos reports an existing session, the login page used client-side routing for `return_to`. OIDC callback return paths are served by the backend through Next rewrites, so `router.push` could leave the browser on the callback URL without completing the flow.

Force a document navigation for `/oidc/*` return paths while keeping client-side navigation for normal app routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication flow security by implementing improved validation of return-to URLs, preventing unauthorized navigation while ensuring secure user redirects after successful login completion.
  * Optimized OIDC authentication redirect behavior with improved session management capabilities, providing more reliable application navigation, better session state handling, and an enhanced user experience throughout the complete authentication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->