### PR TITLE
fix: prevent duplicate api/notification/summary call on page load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@flanksource/flanksource-ui",
-      "version": "1.4.266",
+      "version": "1.4.277",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.1",
         "@ai-sdk/mcp": "^1.0.1",

--- a/src/components/Notifications/Filters/NotificationFilterBar.tsx
+++ b/src/components/Notifications/Filters/NotificationFilterBar.tsx
@@ -5,13 +5,16 @@ import NotificationResourceTypeDropdown from "./NotificationResourceTypeDropdown
 import NotificationStatusDropdown from "./NotificationStatusDropdown";
 import NotificationTagsDropdown from "./NotificationTagsDropdown";
 
+export const DEFAULT_NOTIFICATION_STATUS_FILTER =
+  "skipped:-1,silenced:-1,inhibited:-1,repeat-interval:-1";
+
 export default function NotificationFilterBar() {
   return (
     <FormikFilterForm
       paramsToReset={["pageIndex", "pageSize"]}
       filterFields={["status", "resource_type", "search", "tags"]}
       defaultFieldValues={{
-        status: "skipped:-1,silenced:-1,inhibited:-1,repeat-interval:-1"
+        status: DEFAULT_NOTIFICATION_STATUS_FILTER
       }}
     >
       <div className="flex flex-row gap-2 py-3">

--- a/src/pages/Settings/notifications/NotificationsPage.tsx
+++ b/src/pages/Settings/notifications/NotificationsPage.tsx
@@ -2,7 +2,9 @@ import { getNotificationSendHistorySummary } from "@flanksource-ui/api/services/
 import useReactTablePaginationState from "@flanksource-ui/ui/DataTable/Hooks/useReactTablePaginationState";
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
-import NotificationFilterBar from "../../../components/Notifications/Filters/NotificationFilterBar";
+import NotificationFilterBar, {
+  DEFAULT_NOTIFICATION_STATUS_FILTER
+} from "../../../components/Notifications/Filters/NotificationFilterBar";
 import NotificationTabsLinks from "../../../components/Notifications/NotificationTabsLinks";
 import NotificationSendHistorySummaryList from "@flanksource-ui/components/Notifications/NotificationSendHistorySummary";
 import { useShowDeletedConfigs } from "@flanksource-ui/store/preference.state";
@@ -12,7 +14,8 @@ export default function NotificationsPage() {
 
   const [searchParams] = useSearchParams();
   const resourceType = searchParams.get("resource_type") ?? undefined;
-  const status = searchParams.get("status") ?? undefined;
+  const status =
+    searchParams.get("status") ?? DEFAULT_NOTIFICATION_STATUS_FILTER;
   const search = searchParams.get("search") ?? undefined;
   const tags = searchParams.get("tags") ?? undefined;
 


### PR DESCRIPTION
## Problem

The notification send history summary API (POST ) was being called twice on initial page load.

## Root Cause

 reads the  filter from URL search params and includes it in the  key. On first render, the URL has no  param, so the query fires with .

Meanwhile,  renders a  with  including . On mount,  syncs this default to the URL via .

This URL change triggers a re-render of  where  now returns the default value, producing a different query key and firing a second API call.

## Fix

1. Extract the default status filter value to a shared constant  in 
2. Default to this same value in  so the query key is stable from the first render. When  writes the same value to the URL, React Query deduplicates and no second call occurs.

Closes #2931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized notification filtering by establishing a consistent default status filter across the application, improving compatibility between different notification management views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->