### PR TITLE
fix: load settings plugins from database

### DIFF
--- a/src/api/services/plugins.ts
+++ b/src/api/services/plugins.ts
@@ -1,13 +1,26 @@
-import { apiBase } from "../axios";
-import { AgentItem } from "../types/common";
+import { apiBase, ConfigDB } from "../axios";
+
+export type PluginSpec = {
+  source?: string;
+  address?: string;
+  version?: string;
+  description?: string;
+  [key: string]: unknown;
+};
 
 export type PluginListing = {
+  id: string;
   name: string;
+  namespace?: string;
+  source?: string | null;
+  spec?: PluginSpec | null;
+  installed_path?: string | null;
+  plugin_version?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  deleted_at?: string | null;
   description?: string;
   version?: string;
-  agent?: AgentItem;
-  tabs?: unknown[];
-  operations?: unknown[];
 };
 
 export type PluginUpgradeResult = {
@@ -25,8 +38,28 @@ const isUiProxy = (): boolean =>
 
 const pluginRequestConfig = () => (isUiProxy() ? { baseURL: "" } : undefined);
 
-export function getPlugins() {
-  return apiBase.get<PluginListing[]>("/plugins", pluginRequestConfig());
+function stringValue(value: unknown) {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+export async function getPlugins(): Promise<PluginListing[]> {
+  const params = new URLSearchParams({
+    select:
+      "id,name,namespace,source,spec,installed_path,plugin_version,created_at,updated_at,deleted_at",
+    deleted_at: "is.null",
+    order: "namespace.asc,name.asc"
+  });
+
+  const response = await ConfigDB.get<PluginListing[]>(
+    `/plugins?${params.toString()}`
+  );
+
+  return (response.data ?? []).map((plugin) => ({
+    ...plugin,
+    description: stringValue(plugin.spec?.description),
+    version:
+      stringValue(plugin.plugin_version) ?? stringValue(plugin.spec?.version)
+  }));
 }
 
 export function upgradePlugin(name: string) {

--- a/src/pages/Settings/PluginsPage.tsx
+++ b/src/pages/Settings/PluginsPage.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from "@flanksource-ui/ui/Buttons/Button";
 import { Head } from "@flanksource-ui/ui/Head";
 import { SearchLayout } from "@flanksource-ui/ui/Layout/SearchLayout";
+import { MRTDateCell } from "@flanksource-ui/ui/MRTDataTable/Cells/MRTDateCells";
 import MRTDataTable from "@flanksource-ui/ui/MRTDataTable/MRTDataTable";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import clsx from "clsx";
@@ -116,6 +117,14 @@ function PluginsList({
       {
         header: "Version",
         accessorKey: "version",
+        maxSize: 100,
+        enableResizing: true
+      },
+      {
+        header: "Created",
+        accessorKey: "created_at",
+        Cell: MRTDateCell,
+        sortingFn: "datetime",
         maxSize: 100,
         enableResizing: true
       },

--- a/src/pages/Settings/PluginsPage.tsx
+++ b/src/pages/Settings/PluginsPage.tsx
@@ -54,7 +54,7 @@ function PluginUpgradeButton({
   isUpgrading?: boolean;
   onUpgrade: (plugin: PluginListing) => void;
 }) {
-  const isRemotePlugin = Boolean(plugin.agent);
+  const isRemotePlugin = Boolean(plugin.spec?.address);
 
   return (
     <AuthorizationAccessCheck resource={tables.rbac} action="write">
@@ -64,7 +64,7 @@ function PluginUpgradeButton({
         disabled={isRemotePlugin || isUpgrading}
         disabledTooltip={
           isRemotePlugin
-            ? "Remote plugins must be upgraded on their owning agent"
+            ? "Remote plugins must be upgraded outside Mission Control"
             : undefined
         }
         onClick={(event) => {
@@ -102,20 +102,20 @@ function PluginsList({
         enableResizing: true
       },
       {
-        header: "Description",
-        accessorKey: "description",
+        header: "Namespace",
+        accessorKey: "namespace",
+        maxSize: 100,
+        enableResizing: true
+      },
+      {
+        header: "Source",
+        id: "source",
+        accessorFn: (row) => row.spec?.source ?? row.spec?.address ?? "",
         enableResizing: true
       },
       {
         header: "Version",
         accessorKey: "version",
-        maxSize: 100,
-        enableResizing: true
-      },
-      {
-        header: "Agent",
-        id: "agent",
-        accessorFn: (row) => row.agent?.name ?? "Local",
         maxSize: 100,
         enableResizing: true
       },
@@ -157,11 +157,8 @@ export function PluginsPage() {
     data: plugins,
     refetch
   } = useQuery({
-    queryKey: ["plugins", "all"],
-    queryFn: async () => {
-      const response = await getPlugins();
-      return response.data ?? [];
-    }
+    queryKey: ["plugins", "database"],
+    queryFn: getPlugins
   });
 
   const {


### PR DESCRIPTION
Settings → Plugins was still fetching from the runtime plugin registry.

The persisted `plugins` table is now the source of truth for configured plugins, so the page now reads non-deleted plugin rows from PostgREST instead. The UI maps DB fields into the existing listing shape and shows namespace/source/version from the stored plugin spec/status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The plugins page now shows plugin namespace and source details.
  * Plugin records are displayed using a richer backend-aligned structure, including version and timestamp information.

* **Bug Fixes**
  * Plugin version and description are now populated more reliably from available plugin data.
  * Remote plugin detection and upgrade messaging now use the updated source information for more accurate guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->