### PR TITLE
chore: add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mission Control Frontend
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/flanksource/flanksource-ui/badge)](https://securityscorecards.dev/viewer/?uri=github.com/flanksource/flanksource-ui)
+
 ## Contributing
 
 See [javascript style guide](https://github.com/flanksource/style-guide/blob/master/docs/front-end.md)


### PR DESCRIPTION
Add the OpenSSF Scorecard badge to the README so the repository security score is visible from the project homepage.