### PR TITLE
fix: use Flanksource semantic release workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,34 +9,21 @@ permissions:
 
 jobs:
   semantic-release:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      release-version: ${{ steps.semantic.outputs.release-version }}
-      new-release-published: ${{ steps.semantic.outputs.new-release-published }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@446798f8213ac2e75931c1b0769676d927801858 # v2.10.3
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          token: ${{ secrets.FLANKBOT }}
-
-      - uses: codfish/semantic-release-action@cbd853afe12037afb1306caca9d6b1ab6a58cf2a # v1.10.0
-        id: semantic
-        with:
-          additional_packages: |
-            ['@semantic-release/git']
-        env:
-          GITHUB_TOKEN: ${{ secrets.FLANKBOT }}
+      issues: write
+      pull-requests: write
+    uses: flanksource/action-workflows/.github/workflows/create-release.yml@main
+    with:
+      extra_plugins: |
+        @semantic-release/git
+    secrets:
+      token: ${{ secrets.FLANKBOT }}
 
   docker:
     needs: semantic-release
     runs-on: ubuntu-latest
-    if: ${{ needs.semantic-release.outputs.new-release-published == 'true' }}
+    if: ${{ needs.semantic-release.outputs.published == 'true' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@446798f8213ac2e75931c1b0769676d927801858 # v2.10.3
@@ -77,9 +64,9 @@ jobs:
           push: true
           tags: |
             flanksource/canary-checker-ui:latest
-            flanksource/canary-checker-ui:v${{ needs.semantic-release.outputs.release-version }}
+            flanksource/canary-checker-ui:v${{ needs.semantic-release.outputs.version }}
             ${{ steps.login-ecr-public.outputs.registry }}/k4y9r6y5/canary-checker-ui:latest
-            ${{ steps.login-ecr-public.outputs.registry }}/k4y9r6y5/canary-checker-ui:v${{ needs.semantic-release.outputs.release-version }}
+            ${{ steps.login-ecr-public.outputs.registry }}/k4y9r6y5/canary-checker-ui:v${{ needs.semantic-release.outputs.version }}
           build-args: |
             APP_DEPLOYMENT=CANARY_CHECKER
             WITHOUT_AUTH=true
@@ -91,9 +78,9 @@ jobs:
           push: true
           tags: |
             flanksource/incident-manager-ui:latest
-            flanksource/incident-manager-ui:v${{ needs.semantic-release.outputs.release-version }}
+            flanksource/incident-manager-ui:v${{ needs.semantic-release.outputs.version }}
             ${{ steps.login-ecr-public.outputs.registry }}/k4y9r6y5/incident-manager-ui:latest
-            ${{ steps.login-ecr-public.outputs.registry }}/k4y9r6y5/incident-manager-ui:v${{ needs.semantic-release.outputs.release-version }}
+            ${{ steps.login-ecr-public.outputs.registry }}/k4y9r6y5/incident-manager-ui:v${{ needs.semantic-release.outputs.version }}
           build-args: |
             APP_DEPLOYMENT=INCIDENT_MANAGER
             WITHOUT_AUTH=false
@@ -103,9 +90,9 @@ jobs:
     permissions:
       contents: read
     needs: [semantic-release, docker]
-    if: ${{ needs.semantic-release.outputs.new-release-published == 'true' }}
+    if: ${{ needs.semantic-release.outputs.published == 'true' }}
     outputs:
-      release-version: ${{ needs.semantic-release.outputs.release-version }}
+      release-version: ${{ needs.semantic-release.outputs.version }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@446798f8213ac2e75931c1b0769676d927801858 # v2.10.3
@@ -116,15 +103,15 @@ jobs:
       - name: Update chart version
         uses: mikefarah/yq@7ccaf8e700ce99eb3f0f6cef7f5930a0b3c827cd # v4.49.2
         with:
-          cmd: yq -i '.version = "${{ needs.semantic-release.outputs.release-version }}"' chart/Chart.yaml
+          cmd: yq -i '.version = "${{ needs.semantic-release.outputs.version }}"' chart/Chart.yaml
       - name: Update app version
         uses: mikefarah/yq@7ccaf8e700ce99eb3f0f6cef7f5930a0b3c827cd # v4.49.2
         with:
-          cmd: yq -i '.appVersion = "${{ needs.semantic-release.outputs.release-version }}"' chart/Chart.yaml
+          cmd: yq -i '.appVersion = "${{ needs.semantic-release.outputs.version }}"' chart/Chart.yaml
       - name: Update image tags
         uses: mikefarah/yq@7ccaf8e700ce99eb3f0f6cef7f5930a0b3c827cd # v4.49.2
         with:
-          cmd: yq -i '.image.tag = "v${{ needs.semantic-release.outputs.release-version }}"' chart/values.yaml
+          cmd: yq -i '.image.tag = "v${{ needs.semantic-release.outputs.version }}"' chart/values.yaml
       - name: Set up Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
       - name: Package Helm chart
@@ -155,7 +142,7 @@ jobs:
       contents: write
       pull-requests: write
     needs: [docker, push-helm-chart, semantic-release]
-    if: ${{ needs.semantic-release.outputs.new-release-published == 'true' }}
+    if: ${{ needs.semantic-release.outputs.published == 'true' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@446798f8213ac2e75931c1b0769676d927801858 # v2.10.3
@@ -177,12 +164,12 @@ jobs:
       - name: Update flanksource-ui version in canary-checker
         run: |
           cd canary-checker
-          yq eval-all -i  '(.dependencies[] | select(.name == "flanksource-ui")) ref $d | $d.version = "${{ needs.semantic-release.outputs.release-version }}"' chart/Chart.yaml
+          yq eval-all -i  '(.dependencies[] | select(.name == "flanksource-ui")) ref $d | $d.version = "${{ needs.semantic-release.outputs.version }}"' chart/Chart.yaml
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "chore: update flanksource-ui to ${{ needs.semantic-release.outputs.release-version }}"
+          commit-message: "chore: update flanksource-ui to ${{ needs.semantic-release.outputs.version }}"
           token: ${{ secrets.FLANKBOT }}
-          title: "chore: update flanksource-ui to ${{ needs.semantic-release.outputs.release-version }}"
+          title: "chore: update flanksource-ui to ${{ needs.semantic-release.outputs.version }}"
           branch: "update-flanksource-ui"
           path: ./canary-checker


### PR DESCRIPTION
The release workflow still used the codfish semantic-release action.

Switch semantic release to Flanksource's reusable create-release workflow, matching mission-control. Update downstream jobs to use the reusable workflow's `published` and `version` outputs.