### PR TITLE
feat: enable csp via property

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,17 @@ const config = {
       "https://audit-report.app.flanksource.com",
     NEXT_PUBLIC_ACCOUNTS_URL: "https://accounts.flanksource.com"
   },
+  headers: async () => [
+    {
+      source: "/:path*",
+      headers: [
+        {
+          key: "X-Content-Type-Options",
+          value: "nosniff"
+        }
+      ]
+    }
+  ],
   redirects: async () => {
     if (process.env.NEXT_PUBLIC_APP_DEPLOYMENT === "CANARY_CHECKER") {
       return [];

--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,11 @@ const config = {
         {
           key: "X-Content-Type-Options",
           value: "nosniff"
+        },
+        // Plugin UIs are embedded from same-origin /api/plugins routes.
+        {
+          key: "X-Frame-Options",
+          value: "SAMEORIGIN"
         }
       ]
     }

--- a/next.config.js
+++ b/next.config.js
@@ -22,11 +22,6 @@ const config = {
         {
           key: "X-Content-Type-Options",
           value: "nosniff"
-        },
-        // Plugin UIs are embedded from same-origin /api/plugins routes.
-        {
-          key: "X-Frame-Options",
-          value: "SAMEORIGIN"
         }
       ]
     }
@@ -214,8 +209,8 @@ const config = {
   // https://github.com/vercel/next.js/tree/canary/examples/with-docker#in-existing-projects
   ...(process.env.NEXT_STANDALONE_DEPLOYMENT === "true"
     ? {
-        output: "standalone"
-      }
+      output: "standalone"
+    }
     : {}),
   experimental: {
     // increase the default timeout for the proxy from 30s to 10m to allow for

--- a/src/context/FeatureFlagsContext.tsx
+++ b/src/context/FeatureFlagsContext.tsx
@@ -1,10 +1,17 @@
-import React, { createContext, useCallback, useContext, useMemo } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo
+} from "react";
 import { useGetFeatureFlagsFromAPI } from "../api/query-hooks/useFeatureFlags";
 import { features } from "../services/permissions/features";
 import {
   FeatureFlag,
   permissionService
 } from "../services/permissions/permissionsService";
+import { updateContentSecurityPolicy } from "../utils/contentSecurityPolicy";
 
 export type FeatureFlagsState = {
   featureFlags: FeatureFlag[];
@@ -29,9 +36,19 @@ export const FeatureFlagsContextProvider = ({
 }) => {
   const {
     data: featureFlags = [],
+    isError,
     isSuccess,
     refetch
   } = useGetFeatureFlagsFromAPI();
+
+  useEffect(() => {
+    if (isSuccess) {
+      updateContentSecurityPolicy(featureFlags);
+    } else if (isError) {
+      // The policy is enabled by default if properties cannot be loaded.
+      updateContentSecurityPolicy([]);
+    }
+  }, [featureFlags, isError, isSuccess]);
 
   const refreshFeatureFlags = useCallback(() => {
     refetch();

--- a/src/utils/__tests__/contentSecurityPolicy.unit.test.ts
+++ b/src/utils/__tests__/contentSecurityPolicy.unit.test.ts
@@ -1,0 +1,43 @@
+import { updateContentSecurityPolicy } from "../contentSecurityPolicy";
+
+const CSP_SELECTOR = 'meta[data-flanksource-csp="true"]';
+
+describe("updateContentSecurityPolicy", () => {
+  beforeEach(() => {
+    document.head.querySelector(CSP_SELECTOR)?.remove();
+  });
+
+  it("enables CSP by default", () => {
+    updateContentSecurityPolicy([]);
+
+    const meta = document.head.querySelector<HTMLMetaElement>(CSP_SELECTOR);
+    expect(meta).not.toBeNull();
+    expect(meta).toHaveAttribute("http-equiv", "Content-Security-Policy");
+    expect(meta?.content).toContain("default-src 'self'");
+  });
+
+  it("disables CSP only when the Mission Control property is false", () => {
+    updateContentSecurityPolicy([
+      { name: "ui.content_security_policy", value: "false" }
+    ]);
+
+    expect(document.head.querySelector(CSP_SELECTOR)).toBeNull();
+  });
+
+  it("keeps CSP enabled when the Mission Control property is true", () => {
+    updateContentSecurityPolicy([
+      { name: "ui.content_security_policy", value: "true" }
+    ]);
+
+    expect(document.head.querySelector(CSP_SELECTOR)).not.toBeNull();
+  });
+
+  it("removes the managed CSP meta tag when the property changes to false", () => {
+    updateContentSecurityPolicy([]);
+    updateContentSecurityPolicy([
+      { name: "ui.content_security_policy", value: false }
+    ]);
+
+    expect(document.head.querySelector(CSP_SELECTOR)).toBeNull();
+  });
+});

--- a/src/utils/contentSecurityPolicy.ts
+++ b/src/utils/contentSecurityPolicy.ts
@@ -1,0 +1,53 @@
+const CSP_PROPERTY = "ui.content_security_policy";
+const CSP_META_SELECTOR = 'meta[data-flanksource-csp="true"]';
+
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "form-action 'self'",
+  // Next.js emits inline bootstrap data, and the UI uses inline styles.
+  "script-src 'self' 'unsafe-inline' https:",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' data: https://fonts.gstatic.com",
+  "img-src 'self' data: blob: https:",
+  "connect-src 'self' https: wss:",
+  "worker-src 'self' blob:",
+  "frame-src 'self' data: blob: https:",
+  "media-src 'self' data: blob: https:"
+].join("; ");
+
+type MissionControlProperty = {
+  name: string;
+  value: unknown;
+};
+
+export function updateContentSecurityPolicy(
+  properties: MissionControlProperty[]
+) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const existingMeta =
+    document.head.querySelector<HTMLMetaElement>(CSP_META_SELECTOR);
+  const cspProperty = properties.find(
+    (property) => property.name === CSP_PROPERTY
+  );
+  const isEnabled =
+    !cspProperty || String(cspProperty.value).trim().toLowerCase() !== "false";
+
+  if (!isEnabled) {
+    existingMeta?.remove();
+    return;
+  }
+
+  const meta = existingMeta ?? document.createElement("meta");
+  meta.httpEquiv = "Content-Security-Policy";
+  meta.content = CONTENT_SECURITY_POLICY;
+  meta.dataset.flanksourceCsp = "true";
+
+  if (!existingMeta) {
+    document.head.prepend(meta);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Content Security Policy management driven by the `ui.content_security_policy` setting.
  * CSP meta tag is created/removed based on the setting and updates when feature-flag loading succeeds or fails.
* **Security / Configuration**
  * Enabled `X-Content-Type-Options: nosniff` across all routes.
* **Tests**
  * Added unit coverage for creating, enabling, and disabling Content Security Policy behavior based on configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->