### PR TITLE
chore: add js cdn to csp allowlist

### DIFF
--- a/src/utils/__tests__/contentSecurityPolicy.unit.test.ts
+++ b/src/utils/__tests__/contentSecurityPolicy.unit.test.ts
@@ -14,6 +14,15 @@ describe("updateContentSecurityPolicy", () => {
     expect(meta).not.toBeNull();
     expect(meta).toHaveAttribute("http-equiv", "Content-Security-Policy");
     expect(meta?.content).toContain("default-src 'self'");
+    expect(meta?.content).toContain(
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:"
+    );
+    expect(meta?.content).toContain(
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net"
+    );
+    expect(meta?.content).toContain(
+      "font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net"
+    );
   });
 
   it("disables CSP only when the Mission Control property is false", () => {

--- a/src/utils/contentSecurityPolicy.ts
+++ b/src/utils/contentSecurityPolicy.ts
@@ -6,10 +6,12 @@ const CONTENT_SECURITY_POLICY = [
   "base-uri 'self'",
   "object-src 'none'",
   "form-action 'self'",
-  // Next.js emits inline bootstrap data, and the UI uses inline styles.
-  "script-src 'self' 'unsafe-inline' https:",
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-  "font-src 'self' data: https://fonts.gstatic.com",
+  // Next.js emits inline bootstrap data. UI snippets and Ory WebAuthn use
+  // dynamic functions, while Shiki compiles its syntax highlighter from WASM.
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
+  // Monaco's CDN stylesheet loads its codicon font from the same origin.
+  "font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net",
   "img-src 'self' data: blob: https:",
   "connect-src 'self' https: wss:",
   "worker-src 'self' blob:",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content security policy compatibility for application functionality.
  * Enabled required script execution and styling resources, including Google Fonts and approved CDN assets.
  * Allowed fonts needed for syntax highlighting and editor icons to load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->