### PR TITLE
fix: label quote escaping in config list filter

### DIFF
--- a/src/api/utils/__tests__/labels.unit.test.ts
+++ b/src/api/utils/__tests__/labels.unit.test.ts
@@ -1,0 +1,9 @@
+import { buildLabelFilterQueries } from "../labels";
+
+describe("label filter queries", () => {
+  it("quotes JSON path keys containing a slash", () => {
+    expect(
+      buildLabelFilterQueries("labels", "topic/mission-control____true:1")
+    ).toEqual(['labels->>"topic/mission-control".eq.true']);
+  });
+});

--- a/src/api/utils/labels.ts
+++ b/src/api/utils/labels.ts
@@ -1,3 +1,16 @@
+const quoteJsonPathKey = (key: string) =>
+  key.includes("/")
+    ? `"${key.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`
+    : key;
+
+const buildColumnFilter = (
+  columnName: string,
+  key: string,
+  operator: "eq" | "neq",
+  value: string
+) =>
+  `${columnName}->>${quoteJsonPathKey(key)}.${operator}.${encodeURIComponent(value)}`;
+
 export const buildLabelFilterQueries = (
   columnName: string,
   rawValue?: string | null
@@ -16,9 +29,7 @@ export const buildLabelFilterQueries = (
     }
 
     const operator = parseInt(operand ?? "", 10) === -1 ? "neq" : "eq";
-    filterQueries.push(
-      `${columnName}->>${key}.${operator}.${encodeURIComponent(value)}`
-    );
+    filterQueries.push(buildColumnFilter(columnName, key, operator, value));
   });
 
   return filterQueries;

--- a/src/pages/config/ConfigList.tsx
+++ b/src/pages/config/ConfigList.tsx
@@ -28,12 +28,13 @@ export function ConfigListPage() {
 
   const configType = searchParams.get("configType") ?? undefined;
   const search = searchParams.get("search") ?? undefined;
+  const labels = searchParams.get("labels") ?? undefined;
   const groupBy = useGroupBySearchParam();
 
-  // Show summary if no search, tag or configType is provided
+  // Show summary if no search, tag/label, or configType is provided
   const showConfigSummaryList = useMemo(
-    () => !configType && !search,
-    [configType, search]
+    () => !configType && !search && !labels,
+    [configType, labels, search]
   );
 
   const {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed label-based filtering when JSON path keys contain slashes or special characters.
  * Improved handling of quoted and escaped label keys in filter queries.
  * Configuration summaries now display correctly when filtering by labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->