### PR TITLE
chore: show linked crd when editing playbooks (and be read only)

### DIFF
--- a/src/api/query-hooks/playbooks.tsx
+++ b/src/api/query-hooks/playbooks.tsx
@@ -7,6 +7,7 @@ import {
 import { SubmitPlaybookRunFormValues } from "../../components/Playbooks/Runs/Submit/SubmitPlaybookRunForm";
 import {
   getAllPlaybookNames,
+  getAllPlaybookSummaries,
   getPlaybookSpec,
   getPlaybookSpecsByIDs,
   getPlaybookToRunForResource,
@@ -15,15 +16,16 @@ import {
 import {
   PlaybookNames,
   PlaybookSpec,
+  PlaybookSummary,
   RunnablePlaybook
 } from "../types/playbooks";
 
 export function useGetAllPlaybookSpecs(
-  options: UseQueryOptions<PlaybookNames[], Error> = {}
+  options: UseQueryOptions<PlaybookSummary[], Error> = {}
 ) {
-  return useQuery<PlaybookNames[], Error>(
+  return useQuery<PlaybookSummary[], Error>(
     ["playbooks", "all"],
-    getAllPlaybookNames,
+    getAllPlaybookSummaries,
     {
       cacheTime: 0,
       staleTime: 0,

--- a/src/api/services/playbooks.ts
+++ b/src/api/services/playbooks.ts
@@ -13,6 +13,7 @@ import {
   CategorizedPlaybookRunAction,
   PlaybookRunWithActions,
   PlaybookSpec,
+  PlaybookSummary,
   RunnablePlaybook,
   UpdatePlaybookSpec,
   Playbook
@@ -21,6 +22,17 @@ import {
 export async function getAllPlaybooksSpecs() {
   const res = await IncidentCommander.get<PlaybookSpec[] | null>(
     `/playbooks?select=*,created_by(${AVATAR_INFO})&deleted_at=is.null&order=created_at.desc`
+  );
+  return res.data ?? [];
+}
+
+/*
+ * The playbook_names view does not expose the source, so the listing reads the
+ * same columns off the table, minus the spec.
+ */
+export async function getAllPlaybookSummaries() {
+  const res = await IncidentCommander.get<PlaybookSummary[] | null>(
+    `/playbooks?select=id,name,namespace,title,icon,category,description,source&deleted_at=is.null&order=title.asc`
   );
   return res.data ?? [];
 }

--- a/src/api/types/playbooks.ts
+++ b/src/api/types/playbooks.ts
@@ -175,6 +175,10 @@ export type PlaybookNames = {
   description?: string;
 };
 
+export type PlaybookSummary = PlaybookNames & {
+  source: PlaybookSpec["source"];
+};
+
 export type PlaybookParamCommonFields = {
   name: string;
   label: string;

--- a/src/components/Playbooks/Settings/PlaybookCardMenu.tsx
+++ b/src/components/Playbooks/Settings/PlaybookCardMenu.tsx
@@ -1,7 +1,7 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { DotsVerticalIcon } from "@heroicons/react/solid";
 import { BsTrash } from "react-icons/bs";
-import { MdEdit, MdSecurity } from "react-icons/md";
+import { MdEdit, MdSecurity, MdVisibility } from "react-icons/md";
 import { IconButton } from "../../../ui/Buttons/IconButton";
 
 type PlaybookCardMenuDropdownProps = {
@@ -9,16 +9,21 @@ type PlaybookCardMenuDropdownProps = {
   onEditPlaybook?: () => void;
   onManagePermissions?: () => void;
   onHistory?: () => void;
+  isReadOnly?: boolean;
 };
 
 export default function PlaybookCardMenuDropdown({
   onDeletePlaybook = () => {},
   onEditPlaybook = () => {},
-  onManagePermissions = () => {}
+  onManagePermissions = () => {},
+  isReadOnly = false
 }: PlaybookCardMenuDropdownProps) {
   return (
     <Menu>
-      <MenuButton className="min-w-7 rounded-full p-0.5 text-gray-400 hover:text-gray-500">
+      <MenuButton
+        aria-label="Playbook options"
+        className="min-w-7 rounded-full p-0.5 text-gray-400 hover:text-gray-500"
+      >
         <DotsVerticalIcon className="h-6 w-6" />
       </MenuButton>
       <MenuItems
@@ -43,13 +48,20 @@ export default function PlaybookCardMenuDropdown({
                 fill: "transparent"
               }}
               icon={
-                <MdEdit
-                  className="border-l-1 border-0 border-gray-200 text-gray-600"
-                  size={16}
-                />
+                isReadOnly ? (
+                  <MdVisibility
+                    className="border-l-1 border-0 border-gray-200 text-gray-600"
+                    size={16}
+                  />
+                ) : (
+                  <MdEdit
+                    className="border-l-1 border-0 border-gray-200 text-gray-600"
+                    size={16}
+                  />
+                )
               }
             />
-            <span>Edit</span>
+            <span>{isReadOnly ? "View" : "Edit"}</span>
           </>
         </MenuItem>
         <MenuItem
@@ -67,21 +79,23 @@ export default function PlaybookCardMenuDropdown({
             <span>Permissions</span>
           </>
         </MenuItem>
-        <MenuItem
-          as="div"
-          className="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-sm leading-5 text-gray-700 hover:bg-gray-200"
-          onClick={() => {
-            onDeletePlaybook();
-          }}
-        >
-          <>
-            <BsTrash
-              className="border-l-1 border-0 border-gray-200 text-gray-600"
-              size={16}
-            />
-            <span>Delete</span>
-          </>
-        </MenuItem>
+        {!isReadOnly && (
+          <MenuItem
+            as="div"
+            className="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-sm leading-5 text-gray-700 hover:bg-gray-200"
+            onClick={() => {
+              onDeletePlaybook();
+            }}
+          >
+            <>
+              <BsTrash
+                className="border-l-1 border-0 border-gray-200 text-gray-600"
+                size={16}
+              />
+              <span>Delete</span>
+            </>
+          </MenuItem>
+        )}
       </MenuItems>
     </Menu>
   );

--- a/src/components/Playbooks/Settings/PlaybookSpecCard.tsx
+++ b/src/components/Playbooks/Settings/PlaybookSpecCard.tsx
@@ -16,7 +16,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { deletePlaybookSpec } from "../../../api/services/playbooks";
-import { PlaybookNames } from "../../../api/types/playbooks";
+import { PlaybookSummary } from "../../../api/types/playbooks";
 import { Icon } from "../../../ui/Icons/Icon";
 import { toastError, toastSuccess } from "../../Toast/toast";
 import SubmitPlaybookRunForm from "../Runs/Submit/SubmitPlaybookRunForm";
@@ -25,7 +25,7 @@ import PlaybookPermissionsModal from "./PlaybookPermissionsModal";
 import PlaybookSpecFormModal from "./PlaybookSpecFormModal";
 
 type PlaybookSpecCardProps = {
-  playbook: PlaybookNames;
+  playbook: PlaybookSummary;
   refetch?: () => void;
 };
 
@@ -45,6 +45,10 @@ export default function PlaybookSpecCard({
       isSubmitPlaybookRunFormOpen ||
       isPermissionsModalOpen
   });
+
+  // Only playbooks created in the UI can be changed from here, everything else
+  // is reconciled from its source.
+  const isReadOnly = playbook.source !== "UI";
 
   const { permissions, roles } = useUser();
   const isAdminOrEditor = roles.includes("admin") || roles.includes("editor");
@@ -87,6 +91,7 @@ export default function PlaybookSpecCard({
             key="add-connection"
           >
             <PlaybookCardMenu
+              isReadOnly={isReadOnly}
               onEditPlaybook={() => setIsEditPlaybookFormOpen(true)}
               onManagePermissions={() => setIsPermissionsModalOpen(true)}
               onDeletePlaybook={() => setIsDeleteConfirmOpen(true)}

--- a/src/components/Playbooks/Settings/PlaybookSpecsForm.tsx
+++ b/src/components/Playbooks/Settings/PlaybookSpecsForm.tsx
@@ -16,6 +16,7 @@ import { Form, Formik } from "formik";
 import { FaTrash } from "react-icons/fa";
 import { FormikCodeEditor } from "../../Forms/Formik/FormikCodeEditor";
 import FormikTextInput from "../../Forms/Formik/FormikTextInput";
+import CanEditResource from "../../Settings/CanEditResource";
 import { toastError, toastSuccess } from "../../Toast/toast";
 
 type PlaybookSpecsFormProps = {
@@ -30,6 +31,17 @@ export default function PlaybookSpecsForm({
   refresh = () => {}
 }: PlaybookSpecsFormProps) {
   const { user } = useUser();
+
+  // Only playbooks created in the UI are editable. Everything else is
+  // reconciled from its source, so an edit here would be reverted.
+  const isReadOnly = !!playbook && playbook.source !== "UI";
+
+  const readOnlyOwner =
+    playbook?.source === "ConfigFile"
+      ? "a local file"
+      : playbook?.source === "KubernetesCRD"
+        ? "Kubernetes CRD"
+        : "an external source";
 
   const { mutate: createPlaybook } = useMutation({
     mutationFn: async (payload: NewPlaybookSpec) => {
@@ -135,7 +147,20 @@ export default function PlaybookSpecsForm({
               className={clsx("mb-2 flex flex-1 flex-col overflow-y-auto px-2")}
             >
               <div className="flex flex-1 flex-col space-y-4 overflow-y-auto p-4">
-                <FormikTextInput name="title" label="Title" required />
+                {isReadOnly && (
+                  <div className="rounded-md border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-900">
+                    <p className="font-medium">
+                      Read-Only Mode: This playbook is managed by{" "}
+                      {readOnlyOwner} and cannot be edited from the UI.
+                    </p>
+                  </div>
+                )}
+                <FormikTextInput
+                  name="title"
+                  label="Title"
+                  required
+                  disabled={isReadOnly}
+                />
                 <FormikCodeEditor
                   fieldName="spec"
                   label="Spec"
@@ -144,28 +169,48 @@ export default function PlaybookSpecsForm({
                   jsonSchemaUrl="/api/schemas/playbook-spec.schema.json"
                   required
                   enableSpecUnwrap
+                  disabled={isReadOnly}
                 />
               </div>
             </div>
           </div>
           <div className="flex items-center justify-between bg-gray-100 px-5 py-4">
             {playbook?.id && (
-              <Button
-                type="button"
-                text={isDeleting ? "Deleting..." : "Delete"}
-                icon={<FaTrash />}
-                onClick={() => {
-                  deletePlaybook(playbook.id);
-                }}
-                className="btn-danger"
-              />
+              <CanEditResource
+                id={playbook.id}
+                namespace={playbook.namespace}
+                name={playbook.name}
+                resourceType="playbooks"
+                source={playbook.source}
+                hideSourceLink
+                className="flex flex-row gap-2"
+              >
+                <Button
+                  type="button"
+                  text={isDeleting ? "Deleting..." : "Delete"}
+                  icon={<FaTrash />}
+                  onClick={() => {
+                    deletePlaybook(playbook.id);
+                  }}
+                  className="btn-danger"
+                />
+              </CanEditResource>
             )}
 
-            <Button
-              type="submit"
-              text={playbook?.id ? "Update" : "Save"}
-              className="btn-primary ml-auto"
-            />
+            <CanEditResource
+              id={playbook?.id}
+              namespace={playbook?.namespace}
+              name={playbook?.name}
+              resourceType="playbooks"
+              source={playbook?.source}
+              className="ml-auto flex flex-row gap-2"
+            >
+              <Button
+                type="submit"
+                text={playbook?.id ? "Update" : "Save"}
+                className="btn-primary"
+              />
+            </CanEditResource>
           </div>
         </Form>
       )}

--- a/src/components/Playbooks/Settings/PlaybookSpecsForm.tsx
+++ b/src/components/Playbooks/Settings/PlaybookSpecsForm.tsx
@@ -9,6 +9,7 @@ import {
   UpdatePlaybookSpec
 } from "@flanksource-ui/api/types/playbooks";
 import { useUser } from "@flanksource-ui/context";
+import { tables } from "@flanksource-ui/context/UserAccessContext/permissions";
 import { Button } from "@flanksource-ui/ui/Buttons/Button";
 import { useMutation } from "@tanstack/react-query";
 import clsx from "clsx";
@@ -16,6 +17,7 @@ import { Form, Formik } from "formik";
 import { FaTrash } from "react-icons/fa";
 import { FormikCodeEditor } from "../../Forms/Formik/FormikCodeEditor";
 import FormikTextInput from "../../Forms/Formik/FormikTextInput";
+import { AuthorizationAccessCheck } from "../../Permissions/AuthorizationAccessCheck";
 import CanEditResource from "../../Settings/CanEditResource";
 import { toastError, toastSuccess } from "../../Toast/toast";
 
@@ -176,41 +178,51 @@ export default function PlaybookSpecsForm({
           </div>
           <div className="flex items-center justify-between bg-gray-100 px-5 py-4">
             {playbook?.id && (
-              <CanEditResource
-                id={playbook.id}
-                namespace={playbook.namespace}
-                name={playbook.name}
-                resourceType="playbooks"
-                source={playbook.source}
-                hideSourceLink
-                className="flex flex-row gap-2"
+              <AuthorizationAccessCheck
+                resource={tables.playbooks}
+                action="write"
               >
-                <Button
-                  type="button"
-                  text={isDeleting ? "Deleting..." : "Delete"}
-                  icon={<FaTrash />}
-                  onClick={() => {
-                    deletePlaybook(playbook.id);
-                  }}
-                  className="btn-danger"
-                />
-              </CanEditResource>
+                <CanEditResource
+                  id={playbook.id}
+                  namespace={playbook.namespace}
+                  name={playbook.name}
+                  resourceType="playbooks"
+                  source={playbook.source}
+                  hideSourceLink
+                  className="flex flex-row gap-2"
+                >
+                  <Button
+                    type="button"
+                    text={isDeleting ? "Deleting..." : "Delete"}
+                    icon={<FaTrash />}
+                    onClick={() => {
+                      deletePlaybook(playbook.id);
+                    }}
+                    className="btn-danger"
+                  />
+                </CanEditResource>
+              </AuthorizationAccessCheck>
             )}
 
-            <CanEditResource
-              id={playbook?.id}
-              namespace={playbook?.namespace}
-              name={playbook?.name}
-              resourceType="playbooks"
-              source={playbook?.source}
-              className="ml-auto flex flex-row gap-2"
+            <AuthorizationAccessCheck
+              resource={tables.playbooks}
+              action="write"
             >
-              <Button
-                type="submit"
-                text={playbook?.id ? "Update" : "Save"}
-                className="btn-primary"
-              />
-            </CanEditResource>
+              <CanEditResource
+                id={playbook?.id}
+                namespace={playbook?.namespace}
+                name={playbook?.name}
+                resourceType="playbooks"
+                source={playbook?.source}
+                className="ml-auto flex flex-row gap-2"
+              >
+                <Button
+                  type="submit"
+                  text={playbook?.id ? "Update" : "Save"}
+                  className="btn-primary"
+                />
+              </CanEditResource>
+            </AuthorizationAccessCheck>
           </div>
         </Form>
       )}

--- a/src/components/Playbooks/Settings/PlaybookSpecsList.tsx
+++ b/src/components/Playbooks/Settings/PlaybookSpecsList.tsx
@@ -1,13 +1,13 @@
 import { useMemo } from "react";
-import { PlaybookNames } from "../../../api/types/playbooks";
+import { PlaybookSummary } from "../../../api/types/playbooks";
 import PlaybookSpecCard from "./PlaybookSpecCard";
 
 type GroupedPlaybooks = {
-  [key: string]: PlaybookNames[];
+  [key: string]: PlaybookSummary[];
 };
 
 type Props = {
-  data: PlaybookNames[];
+  data: PlaybookSummary[];
   refetch?: () => void;
 } & Omit<React.HTMLProps<HTMLDivElement>, "data">;
 

--- a/src/components/Playbooks/Settings/__tests__/PlaybookSpecCard.unit.test.tsx
+++ b/src/components/Playbooks/Settings/__tests__/PlaybookSpecCard.unit.test.tsx
@@ -153,6 +153,65 @@ describe("PlaybookSpecCard", () => {
     fireEvent.click(screen.getByText("History"));
   });
 
+  describe("card menu", () => {
+    // The authorization check resolves asynchronously, so the menu button only
+    // appears once it has granted write access.
+    const renderCard = async (playbook: PlaybookSpec) => {
+      const queryClient = createQueryClient();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <AuthContext.Provider value={FakeUser([Roles.admin])}>
+            <UserAccessStateContextProvider>
+              <MemoryRouter>
+                <PlaybookSpecCard playbook={playbook} />
+              </MemoryRouter>
+            </UserAccessStateContextProvider>
+          </AuthContext.Provider>
+        </QueryClientProvider>
+      );
+      fireEvent.click(
+        await screen.findByRole("button", { name: /Playbook options/i })
+      );
+    };
+
+    it("offers edit and delete for a playbook created in the UI", async () => {
+      await renderCard(mockPlaybook);
+      expect(
+        await screen.findByRole("menuitem", { name: /Edit/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("menuitem", { name: /Delete/i })
+      ).toBeInTheDocument();
+    });
+
+    it("offers view instead of edit for a playbook managed by a CRD", async () => {
+      await renderCard({ ...mockPlaybook, source: "KubernetesCRD" });
+      expect(
+        await screen.findByRole("menuitem", { name: /View/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", { name: /Edit/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not offer delete for a playbook managed by a CRD", async () => {
+      await renderCard({ ...mockPlaybook, source: "KubernetesCRD" });
+      expect(
+        await screen.findByRole("menuitem", { name: /View/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", { name: /Delete/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("still offers permissions for a playbook managed by a CRD", async () => {
+      await renderCard({ ...mockPlaybook, source: "KubernetesCRD" });
+      expect(
+        await screen.findByRole("menuitem", { name: /Permissions/i })
+      ).toBeInTheDocument();
+    });
+  });
+
   it("opens the SubmitPlaybookRunForm when the Run button is clicked", async () => {
     const queryClient = createQueryClient();
     render(

--- a/src/components/Playbooks/Settings/__tests__/PlaybookSpecsForm.unit.test.tsx
+++ b/src/components/Playbooks/Settings/__tests__/PlaybookSpecsForm.unit.test.tsx
@@ -1,0 +1,165 @@
+// ABOUTME: Tests that the playbook spec form is read-only for playbooks owned
+// outside the UI, and stays fully editable for UI-created playbooks.
+import { PlaybookSpec } from "@flanksource-ui/api/types/playbooks";
+import { AuthContext, FakeUser, Roles } from "@flanksource-ui/context";
+import { UserAccessStateContextProvider } from "@flanksource-ui/context/UserAccessContext/UserAccessContext";
+import { QueryClient } from "@tanstack/query-core";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import PlaybookSpecsForm from "./../PlaybookSpecsForm";
+
+// The spec editor lazy-loads Monaco, which never mounts under jsdom. Stub it so
+// the `disabled` prop the form passes down is observable.
+jest.mock("../../../Forms/Formik/FormikCodeEditor", () => ({
+  FormikCodeEditor: ({
+    fieldName,
+    label,
+    disabled
+  }: {
+    fieldName: string;
+    label?: string;
+    disabled?: boolean;
+  }) => (
+    <textarea
+      aria-label={label ?? fieldName}
+      disabled={disabled}
+      readOnly
+      value=""
+    />
+  )
+}));
+
+const client = new QueryClient();
+
+const mockPlaybook: PlaybookSpec = {
+  id: "018cf7b8-9379-a943-4640-70b80e97c158",
+  name: "Test Playbook",
+  namespace: "mission-control",
+  title: "Test Playbook",
+  description: "Test Description",
+  spec: {
+    actions: [{ name: "test-action", exec: { script: "echo hello" } }]
+  },
+  source: "UI",
+  created_at: "2024-01-11T08:51:57.945373+00:00",
+  updated_at: "2024-01-14T23:18:26.592563+00:00"
+};
+
+function renderForm(playbook?: PlaybookSpec) {
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <AuthContext.Provider value={FakeUser([Roles.admin])}>
+          <UserAccessStateContextProvider>
+            <PlaybookSpecsForm playbook={playbook} onClose={() => {}} />
+          </UserAccessStateContextProvider>
+        </AuthContext.Provider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("PlaybookSpecsForm", () => {
+  describe("when the playbook is managed by a Kubernetes CRD", () => {
+    const crdPlaybook: PlaybookSpec = {
+      ...mockPlaybook,
+      source: "KubernetesCRD"
+    };
+
+    it("shows a read-only notice", () => {
+      renderForm(crdPlaybook);
+      expect(
+        screen.getByText(/managed by Kubernetes CRD and cannot be edited/i)
+      ).toBeInTheDocument();
+    });
+
+    it("disables the title and spec fields", () => {
+      renderForm(crdPlaybook);
+      expect(screen.getByLabelText("Title")).toBeDisabled();
+      expect(screen.getByLabelText("Spec")).toBeDisabled();
+    });
+
+    it("replaces the update button with a link to the CRD", () => {
+      renderForm(crdPlaybook);
+      expect(
+        screen.queryByRole("button", { name: /Update/i })
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(/CRD linked to/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /mission-control\/Test Playbook/i })
+      ).toHaveAttribute("href", `/catalog/${crdPlaybook.id}`);
+    });
+
+    it("hides the delete button", () => {
+      renderForm(crdPlaybook);
+      expect(
+        screen.queryByRole("button", { name: /Delete/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when the playbook is managed by a config file", () => {
+    const configFilePlaybook: PlaybookSpec = {
+      ...mockPlaybook,
+      source: "ConfigFile"
+    };
+
+    it("shows a read-only notice and disables the fields", () => {
+      renderForm(configFilePlaybook);
+      expect(
+        screen.getByText(/managed by a local file and cannot be edited/i)
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Title")).toBeDisabled();
+      expect(screen.getByLabelText("Spec")).toBeDisabled();
+    });
+
+    it("replaces the update button with the source of the playbook", () => {
+      renderForm(configFilePlaybook);
+      expect(
+        screen.queryByRole("button", { name: /Update/i })
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(/Linked to local file/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when the playbook has no source", () => {
+    it("is read-only, since only UI playbooks are editable", () => {
+      renderForm({ ...mockPlaybook, source: undefined as any });
+      expect(
+        screen.getByText(/cannot be edited from the UI/i)
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Title")).toBeDisabled();
+      expect(screen.getByLabelText("Spec")).toBeDisabled();
+    });
+  });
+
+  describe("when creating a new playbook", () => {
+    it("keeps the form editable", () => {
+      renderForm(undefined);
+      expect(
+        screen.queryByText(/cannot be edited from the UI/i)
+      ).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Title")).toBeEnabled();
+      expect(screen.getByLabelText("Spec")).toBeEnabled();
+      expect(screen.getByRole("button", { name: /Save/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("when the playbook was created in the UI", () => {
+    it("keeps the form editable", () => {
+      renderForm(mockPlaybook);
+      expect(
+        screen.queryByText(/cannot be edited from the UI/i)
+      ).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Title")).toBeEnabled();
+      expect(screen.getByLabelText("Spec")).toBeEnabled();
+      expect(
+        screen.getByRole("button", { name: /Update/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Delete/i })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Playbooks/Settings/__tests__/PlaybookSpecsForm.unit.test.tsx
+++ b/src/components/Playbooks/Settings/__tests__/PlaybookSpecsForm.unit.test.tsx
@@ -5,7 +5,7 @@ import { AuthContext, FakeUser, Roles } from "@flanksource-ui/context";
 import { UserAccessStateContextProvider } from "@flanksource-ui/context/UserAccessContext/UserAccessContext";
 import { QueryClient } from "@tanstack/query-core";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import PlaybookSpecsForm from "./../PlaybookSpecsForm";
 
@@ -46,11 +46,11 @@ const mockPlaybook: PlaybookSpec = {
   updated_at: "2024-01-14T23:18:26.592563+00:00"
 };
 
-function renderForm(playbook?: PlaybookSpec) {
+function renderForm(playbook?: PlaybookSpec, roles: string[] = [Roles.admin]) {
   return render(
     <MemoryRouter>
       <QueryClientProvider client={client}>
-        <AuthContext.Provider value={FakeUser([Roles.admin])}>
+        <AuthContext.Provider value={FakeUser(roles)}>
           <UserAccessStateContextProvider>
             <PlaybookSpecsForm playbook={playbook} onClose={() => {}} />
           </UserAccessStateContextProvider>
@@ -80,12 +80,12 @@ describe("PlaybookSpecsForm", () => {
       expect(screen.getByLabelText("Spec")).toBeDisabled();
     });
 
-    it("replaces the update button with a link to the CRD", () => {
+    it("replaces the update button with a link to the CRD", async () => {
       renderForm(crdPlaybook);
+      expect(await screen.findByText(/CRD linked to/i)).toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: /Update/i })
       ).not.toBeInTheDocument();
-      expect(screen.getByText(/CRD linked to/i)).toBeInTheDocument();
       expect(
         screen.getByRole("link", { name: /mission-control\/Test Playbook/i })
       ).toHaveAttribute("href", `/catalog/${crdPlaybook.id}`);
@@ -114,12 +114,39 @@ describe("PlaybookSpecsForm", () => {
       expect(screen.getByLabelText("Spec")).toBeDisabled();
     });
 
-    it("replaces the update button with the source of the playbook", () => {
+    it("replaces the update button with the source of the playbook", async () => {
       renderForm(configFilePlaybook);
+      expect(
+        await screen.findByText(/Linked to local file/i)
+      ).toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: /Update/i })
       ).not.toBeInTheDocument();
-      expect(screen.getByText(/Linked to local file/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("when the user cannot write playbooks", () => {
+    it("renders neither mutation button for an existing playbook", async () => {
+      renderForm(mockPlaybook, [Roles.viewer]);
+      expect(await screen.findByLabelText("Title")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /Update/i })
+        ).not.toBeInTheDocument();
+      });
+      expect(
+        screen.queryByRole("button", { name: /Delete/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders no save button when creating a playbook", async () => {
+      renderForm(undefined, [Roles.viewer]);
+      expect(await screen.findByLabelText("Title")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /Save/i })
+        ).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -135,19 +162,21 @@ describe("PlaybookSpecsForm", () => {
   });
 
   describe("when creating a new playbook", () => {
-    it("keeps the form editable", () => {
+    it("keeps the form editable", async () => {
       renderForm(undefined);
       expect(
         screen.queryByText(/cannot be edited from the UI/i)
       ).not.toBeInTheDocument();
       expect(screen.getByLabelText("Title")).toBeEnabled();
       expect(screen.getByLabelText("Spec")).toBeEnabled();
-      expect(screen.getByRole("button", { name: /Save/i })).toBeInTheDocument();
+      expect(
+        await screen.findByRole("button", { name: /Save/i })
+      ).toBeInTheDocument();
     });
   });
 
   describe("when the playbook was created in the UI", () => {
-    it("keeps the form editable", () => {
+    it("keeps the form editable", async () => {
       renderForm(mockPlaybook);
       expect(
         screen.queryByText(/cannot be edited from the UI/i)
@@ -155,7 +184,7 @@ describe("PlaybookSpecsForm", () => {
       expect(screen.getByLabelText("Title")).toBeEnabled();
       expect(screen.getByLabelText("Spec")).toBeEnabled();
       expect(
-        screen.getByRole("button", { name: /Update/i })
+        await screen.findByRole("button", { name: /Update/i })
       ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: /Delete/i })

--- a/src/components/SchemaResourcePage/resourceTypes.tsx
+++ b/src/components/SchemaResourcePage/resourceTypes.tsx
@@ -34,6 +34,7 @@ export type SchemaResourceType = {
     | "notifications"
     | "properties"
     | "permissions"
+    | "playbooks"
     | "views"
     | "scopes";
   api: "incident-commander" | "canary-checker" | "config-db";

--- a/src/components/Settings/ResourceTable.tsx
+++ b/src/components/Settings/ResourceTable.tsx
@@ -270,6 +270,7 @@ const permanentlyHiddenColumnsForTableMap: Record<
   incident_rules: ["schedule", "namespace"],
   teams: ["schedule", "namespace"],
   permissions: ["schedule", "namespace"],
+  playbooks: [],
   views: [],
   scopes: ["namespace"]
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed playbook summaries, including source information.
  - Playbooks managed by Kubernetes CRDs or local files are now clearly marked as read-only.
  - Read-only playbooks support viewing but prevent editing, saving, or deleting.
  - UI-created playbooks retain full editing and deletion controls.
  - Added ownership notices and links to the managing resource where applicable.

- **Bug Fixes**
  - Playbook listings now exclude deleted entries and sort by title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->