### PR TITLE
fix(playbooks): use rs search even when ids are given

### DIFF
--- a/src/components/Forms/Formik/FormikConfigsSelector.tsx
+++ b/src/components/Forms/Formik/FormikConfigsSelector.tsx
@@ -23,7 +23,6 @@ import { IoMdClose } from "react-icons/io";
 
 type ConfigsSelector = {
   search?: string;
-  id?: string;
 };
 
 // Playbook parameters are stored as strings, so the selector travels as JSON.
@@ -38,16 +37,35 @@ function parseSelector(value?: string): ConfigsSelector {
   }
 }
 
+const configIDPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function idSearch(ids: string[]) {
+  return ids.map((id) => `id=${id}`).join(";");
+}
+
 function selectorIds(selector: ConfigsSelector) {
-  return (selector.id ?? "")
-    .split(",")
-    .map((id) => id.trim())
+  const clauses = (selector.search ?? "")
+    .split(";")
+    .map((clause) => clause.trim())
     .filter(Boolean);
+  if (clauses.length === 0) {
+    return [];
+  }
+
+  const ids = clauses.map((clause) => {
+    const match = clause.match(/^id\s*=\s*(.+)$/i);
+    const id = match?.[1]?.trim() ?? "";
+    return configIDPattern.test(id) ? id : undefined;
+  });
+  return ids.every((id): id is string => Boolean(id)) ? ids : [];
 }
 
 function serializeSelector(selected: SearchedResource[], search: string) {
   if (selected.length > 0) {
-    return JSON.stringify({ id: selected.map((c) => c.id).join(",") });
+    return JSON.stringify({
+      search: idSearch(selected.map((config) => config.id))
+    });
   }
   const trimmed = search.trim();
   return trimmed ? JSON.stringify({ search: trimmed }) : undefined;
@@ -91,12 +109,12 @@ export default function FormikConfigsSelector({
     [initialSelector]
   );
 
-  const [query, setQuery] = useState(initialSelector.search ?? "");
-  const [searchText, setSearchText] = useState(initialSelector.search ?? "");
+  const initialQuery =
+    initialIds.length > 0 ? "" : (initialSelector.search ?? "");
+  const [query, setQuery] = useState(initialQuery);
+  const [searchText, setSearchText] = useState(initialQuery);
   // the last query the user explicitly committed via the query option
-  const [committedQuery, setCommittedQuery] = useState(
-    initialSelector.search ?? ""
-  );
+  const [committedQuery, setCommittedQuery] = useState(initialQuery);
   const [selected, setSelected] = useState<SearchedResource[]>(() =>
     initialIds.map((id) => ({ id }) as SearchedResource)
   );
@@ -146,7 +164,7 @@ export default function FormikConfigsSelector({
     queryKey: ["searchResources", "configs", "byId", preselectedIds],
     queryFn: () =>
       searchResources({
-        configs: [{ search: `id=${preselectedIds.join(",")}`, agent: "all" }]
+        configs: [{ search: idSearch(preselectedIds), agent: "all" }]
       }),
     select: (data) => data?.configs ?? [],
     enabled: preselectedIds.length > 0
@@ -185,7 +203,7 @@ export default function FormikConfigsSelector({
 
     const selector = parseSelector(field.value);
     const ids = selectorIds(selector);
-    const nextQuery = selector.search ?? "";
+    const nextQuery = ids.length > 0 ? "" : (selector.search ?? "");
 
     handleSearchDebounced.cancel();
     setQuery(nextQuery);
@@ -293,11 +311,7 @@ export default function FormikConfigsSelector({
   return (
     <div className={className}>
       {label && <label className="form-label">{label}</label>}
-      <div
-        className="flex flex-col gap-2"
-        onFocus={() => setIsOpen(true)}
-        onBlur={handleBlur}
-      >
+      <div className="flex flex-col gap-2" onBlur={handleBlur}>
         <input
           type="text"
           name={name}
@@ -305,6 +319,7 @@ export default function FormikConfigsSelector({
           placeholder="Search catalog e.g. type=Kubernetes::Deployment grafana"
           className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
           onChange={(e) => handleQueryChange(e.target.value)}
+          onFocus={() => setIsOpen(true)}
           onKeyDown={handleKeyDown}
           // the input can already hold focus while the results are closed, so
           // a click has to reopen them on its own

--- a/src/components/Forms/Formik/__tests__/FormikConfigsSelector.unit.test.tsx
+++ b/src/components/Forms/Formik/__tests__/FormikConfigsSelector.unit.test.tsx
@@ -89,7 +89,7 @@ beforeEach(() => {
 describe("FormikConfigsSelector", () => {
   it("does not rewrite the unchanged field value on mount", async () => {
     const validate = jest.fn(() => ({}));
-    const initialValue = JSON.stringify({ id: grafana.id });
+    const initialValue = JSON.stringify({ search: `id=${grafana.id}` });
 
     renderSelector(initialValue, { validate });
 
@@ -106,7 +106,7 @@ describe("FormikConfigsSelector", () => {
       externalValues: [
         {
           label: "Select prometheus externally",
-          value: JSON.stringify({ id: prometheus.id })
+          value: JSON.stringify({ search: `id=${prometheus.id}` })
         },
         {
           label: "Set query externally",
@@ -173,7 +173,7 @@ describe("FormikConfigsSelector", () => {
 
     await user.click(checkbox(/grafana/));
 
-    await expectValue({ id: grafana.id });
+    await expectValue({ search: `id=${grafana.id}` });
   });
 
   it("keeps checked items when the search query changes", async () => {
@@ -190,7 +190,7 @@ describe("FormikConfigsSelector", () => {
     await waitFor(() => expect(checkbox(/prometheus/)).toBeInTheDocument());
     await user.click(checkbox(/prometheus/));
 
-    await expectValue({ id: `${grafana.id},${prometheus.id}` });
+    await expectValue({ search: `id=${grafana.id};id=${prometheus.id}` });
   });
 
   it("falls back to the search query when the last item is unchecked", async () => {
@@ -201,14 +201,14 @@ describe("FormikConfigsSelector", () => {
     await waitFor(() => expect(checkbox(/grafana/)).toBeInTheDocument());
 
     await user.click(checkbox(/grafana/));
-    await expectValue({ id: grafana.id });
+    await expectValue({ search: `id=${grafana.id}` });
 
     await user.click(checkbox(/grafana/));
     await expectValue({ search: "grafana" });
   });
 
   it("hydrates pre-selected items into chips without opening the results", async () => {
-    renderSelector(JSON.stringify({ id: grafana.id }));
+    renderSelector(JSON.stringify({ search: `id=${grafana.id}` }));
 
     await waitFor(() => expect(removeButton("grafana")).toBeInTheDocument());
 
@@ -252,7 +252,7 @@ describe("FormikConfigsSelector", () => {
     await user.click(document.body);
 
     await waitFor(() => expect(removeButton("grafana")).toBeInTheDocument());
-    await expectValue({ id: grafana.id });
+    await expectValue({ search: `id=${grafana.id}` });
   });
 
   it("stays open when a result row is clicked", async () => {
@@ -270,7 +270,7 @@ describe("FormikConfigsSelector", () => {
 
     expect(checkbox(/grafana/)).toBeChecked();
     expect(checkbox(/prometheus/)).toBeInTheDocument();
-    await expectValue({ id: grafana.id });
+    await expectValue({ search: `id=${grafana.id}` });
   });
 
   it("checks and unchecks the highlighted item with the arrow keys and enter", async () => {
@@ -283,13 +283,13 @@ describe("FormikConfigsSelector", () => {
 
     // first row is highlighted by default
     await user.keyboard("{Enter}");
-    await expectValue({ id: grafana.id });
+    await expectValue({ search: `id=${grafana.id}` });
 
     await user.keyboard("{ArrowDown}{Enter}");
-    await expectValue({ id: `${grafana.id},${prometheus.id}` });
+    await expectValue({ search: `id=${grafana.id};id=${prometheus.id}` });
 
     await user.keyboard("{ArrowUp}{Enter}");
-    await expectValue({ id: prometheus.id });
+    await expectValue({ search: `id=${prometheus.id}` });
   });
 
   it("offers the typed query as a pinned option that closes the results", async () => {
@@ -339,7 +339,7 @@ describe("FormikConfigsSelector", () => {
     await user.click(document.body);
 
     await waitFor(() => expect(input).toHaveValue(""));
-    await expectValue({ id: grafana.id });
+    await expectValue({ search: `id=${grafana.id}` });
   });
 
   it("clears the typed text on close when nothing was chosen", async () => {
@@ -387,7 +387,7 @@ describe("FormikConfigsSelector", () => {
     await user.click(document.body);
 
     await waitFor(() => expect(input).toHaveValue(""));
-    await expectValue({ id: grafana.id });
+    await expectValue({ search: `id=${grafana.id}` });
   });
 
   it("swallows escape while the results are open so the modal stays up", async () => {
@@ -419,18 +419,33 @@ describe("FormikConfigsSelector", () => {
     window.removeEventListener("keydown", onWindowEscape);
   });
 
-  it("removes a chip when its remove button is clicked", async () => {
+  it("rebuilds the selector when selected chips are removed", async () => {
     const user = userEvent.setup();
-    renderSelector(JSON.stringify({ id: grafana.id }));
+    renderSelector(
+      JSON.stringify({ search: `id=${grafana.id};id=${prometheus.id}` })
+    );
 
     await waitFor(() => expect(removeButton("grafana")).toBeInTheDocument());
+    expect(removeButton("prometheus")).toBeInTheDocument();
+    expect(searchApi.searchResources).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configs: [
+          expect.objectContaining({
+            search: `id=${grafana.id};id=${prometheus.id}`
+          })
+        ]
+      })
+    );
 
     await user.click(removeButton("grafana"));
+    await expectValue({ search: `id=${prometheus.id}` });
 
+    await user.click(removeButton("prometheus"));
     await waitFor(() =>
       expect(
         screen.queryByRole("button", { name: /Remove/ })
       ).not.toBeInTheDocument()
     );
+    expect(screen.getByTestId("value")).toHaveTextContent("");
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource selection when choosing multiple configurations.
  * Added validation for resource identifiers, preventing invalid or empty selections.
  * Fixed synchronization of preselected and externally updated resources.
  * Improved removal of selected resource chips, including intermediate and empty states.
  * Updated selector focus behavior so opening occurs directly from the input field.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->