### PR TITLE
fix: display form defaults in playbook run modal

### DIFF
--- a/src/components/Forms/Formik/FormikTextArea.tsx
+++ b/src/components/Forms/Formik/FormikTextArea.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { useField } from "formik";
 import React from "react";
 import { TextArea } from "../../../ui/FormControls/TextArea";
@@ -7,6 +8,7 @@ type FormikTextAreaProps = {
   required?: boolean;
   label?: string;
   hint?: string;
+  inputClassName?: string;
 } & Omit<React.HTMLProps<HTMLTextAreaElement>, "id">;
 
 export default function FormikTextArea({
@@ -14,6 +16,7 @@ export default function FormikTextArea({
   required = false,
   label,
   className = "flex flex-col",
+  inputClassName,
   hint,
   defaultValue,
   ...props
@@ -38,7 +41,7 @@ export default function FormikTextArea({
         required={required}
         id={name}
         {...field}
-        className="resize-none"
+        className={clsx("resize-none", inputClassName)}
       />
       {hint && <p className="py-1 text-sm text-gray-500">{hint}</p>}
       {meta.touched && meta.error ? (

--- a/src/components/Forms/Formik/FormikTextInput.tsx
+++ b/src/components/Forms/Formik/FormikTextInput.tsx
@@ -7,6 +7,7 @@ export type FormikTextInputProps = {
   required?: boolean;
   label?: string;
   className?: string;
+  inputClassName?: string;
   hint?: string;
   hintPosition?: "top" | "bottom";
 } & Omit<React.ComponentProps<typeof TextInput>, "id">;
@@ -16,6 +17,7 @@ export default function FormikTextInput({
   required = false,
   label,
   className = "flex flex-col",
+  inputClassName,
   hintPosition = "bottom",
   hint,
   type = "text",
@@ -43,7 +45,13 @@ export default function FormikTextInput({
         {hint && hintPosition === "top" && (
           <p className="py-1 text-sm text-gray-500">{hint}</p>
         )}
-        <TextInput {...props} id={name} type={type} {...field} />
+        <TextInput
+          {...props}
+          id={name}
+          type={type}
+          {...field}
+          className={inputClassName}
+        />
         {hint && hintPosition === "bottom" && (
           <p className="py-1 text-sm text-gray-500">{hint}</p>
         )}

--- a/src/components/Playbooks/Runs/Submit/PlaybookParamsFieldsRenderer.tsx
+++ b/src/components/Playbooks/Runs/Submit/PlaybookParamsFieldsRenderer.tsx
@@ -4,6 +4,8 @@ import FormikMillicoresTextField from "@flanksource-ui/components/Forms/Formik/F
 import FormikResourceSelectorDropdown from "@flanksource-ui/components/Forms/Formik/FormikResourceSelectorDropdown";
 import FormikDurationDropdown from "@flanksource-ui/components/Forms/Formik/FormikDurationDropdown";
 import { ModalSize } from "@flanksource-ui/ui/Modal";
+import { useField } from "formik";
+import React from "react";
 import { PlaybookParam } from "../../../../api/types/playbooks";
 import FormikCheckbox from "../../../Forms/Formik/FormikCheckbox";
 import { FormikCodeEditor } from "../../../Forms/Formik/FormikCodeEditor";
@@ -29,6 +31,21 @@ export default function PlaybookParamsFieldsRenderer({
   params
 }: PlaybookParamsFieldsRendererProps) {
   const { type, name: fieldName, required, label } = params;
+  const [field] = useField(`params.${fieldName}`);
+
+  // A text value that is still the spec default is dimmed and gets selected on
+  // focus, so that typing replaces it in one go
+  const isUnchangedDefault =
+    params.default !== undefined && field.value === params.default;
+  const textDefaultProps = {
+    inputClassName: isUnchangedDefault ? "text-gray-400" : undefined,
+    onFocus: (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (isUnchangedDefault) {
+        e.target.select();
+      }
+    }
+  };
+
   switch (type) {
     case "code":
       const size = params.properties?.size ?? "small";
@@ -119,6 +136,7 @@ export default function PlaybookParamsFieldsRenderer({
       if (params.properties?.multiline) {
         return (
           <FormikTextArea
+            {...textDefaultProps}
             maxLength={params.properties?.maxLength}
             minLength={params.properties?.minLength}
             pattern={params.properties?.regex}
@@ -131,6 +149,7 @@ export default function PlaybookParamsFieldsRenderer({
       if (params.properties?.format === "bytes") {
         return (
           <FormikBytesTextField
+            onFocus={textDefaultProps.onFocus}
             name={`params.${fieldName}`}
             required={required}
             min={params.properties?.min}
@@ -142,6 +161,7 @@ export default function PlaybookParamsFieldsRenderer({
       if (params.properties?.format === "millicores") {
         return (
           <FormikMillicoresTextField
+            onFocus={textDefaultProps.onFocus}
             name={`params.${fieldName}`}
             required={required}
             min={params.properties?.min}
@@ -153,6 +173,7 @@ export default function PlaybookParamsFieldsRenderer({
       if (params.properties?.format === "dns1123") {
         return (
           <FormikTextInput
+            {...textDefaultProps}
             name={`params.${fieldName}`}
             required={required}
             pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
@@ -162,6 +183,7 @@ export default function PlaybookParamsFieldsRenderer({
 
       return (
         <FormikTextInput
+          {...textDefaultProps}
           type={params.properties?.format}
           min={params.properties?.min}
           max={params.properties?.max}

--- a/src/components/Playbooks/Runs/Submit/PlaybookRunParams.tsx
+++ b/src/components/Playbooks/Runs/Submit/PlaybookRunParams.tsx
@@ -1,7 +1,6 @@
 import { getPlaybookParams } from "@flanksource-ui/api/services/playbooks";
 import { getErrorMessage } from "@flanksource-ui/api/types/error";
 import {
-  PlaybookParam,
   PlaybookParamCodeEditor,
   PlaybookSpec
 } from "@flanksource-ui/api/types/playbooks";
@@ -10,28 +9,14 @@ import { useQuery } from "@tanstack/react-query";
 import clsx from "clsx";
 import { useFormikContext } from "formik";
 import { useAtom } from "jotai/react";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { FaExclamationTriangle } from "react-icons/fa";
-import YAML from "yaml";
 import PlaybookParamsFieldsRenderer from "./PlaybookParamsFieldsRenderer";
 import {
   SubmitPlaybookRunFormValues,
   submitPlaybookRunFormModalSizesAtom
 } from "./SubmitPlaybookRunForm";
-
-function parseCodeDefaultValue(parameter: PlaybookParam) {
-  if (parameter.type !== "code" || !parameter.default) {
-    return parameter.default;
-  }
-  const language = parameter.properties?.language ?? "yaml";
-  if (language === "yaml") {
-    return YAML.parse(parameter.default);
-  }
-  if (language === "json") {
-    return JSON.parse(parameter.default);
-  }
-  return parameter.default;
-}
+import { getPlaybookParamDefaults } from "./playbookParamDefaults";
 
 type PlaybookRunParamsProps = {
   isResourceRequired: boolean;
@@ -76,6 +61,13 @@ export default function PlaybookRunParams({
     staleTime: 0
   });
 
+  // parameters that depend on a resource are resolved by the API, the rest are
+  // read straight off the spec and are always available
+  const parameters = useMemo(
+    () => (isResourceRequired ? data?.params : playbook.spec?.parameters) ?? [],
+    [data?.params, isResourceRequired, playbook.spec?.parameters]
+  );
+
   // update modal size when params are loaded
   useEffect(() => {
     data?.params
@@ -89,20 +81,18 @@ export default function PlaybookRunParams({
       });
   }, [data, setModalSize]);
 
-  // After the params are loaded, set the default values for the form
+  // API resolved params only arrive after mount, so their defaults are seeded
+  // here rather than in the form's initial values. We don't want to override
+  // form values if they are already set by user action, like for instance when
+  // re-running a playbook with the same parameters
   useEffect(() => {
-    if (data?.params && data.params.length > 0) {
-      data.params.forEach((param) => {
-        // We don't want to override form values if they are already set by user
-        // action, like for instance when re-running a playbook with the same
-        // parameters, we don't want to set the default values again
-        if (param.default !== undefined && !overrideParams) {
-          const defaultValue = parseCodeDefaultValue(param);
-          setFieldValue(`params.${param.name}`, defaultValue);
-        }
-      });
+    if (overrideParams || !data?.params) {
+      return;
     }
-  }, [data, overrideParams, setFieldValue]);
+    Object.entries(getPlaybookParamDefaults(data.params)).forEach(
+      ([name, value]) => setFieldValue(`params.${name}`, value)
+    );
+  }, [data?.params, overrideParams, setFieldValue]);
 
   // if no resource is selected, show a message and hide the parameters
   if (!componentId && !configId && !checkId && isResourceRequired) {
@@ -127,16 +117,10 @@ export default function PlaybookRunParams({
     );
   }
 
-  // if no resource is required, show the playbook parameters, as they are not
-  // dependent on the resource and are always available
-  const parameters = isResourceRequired
-    ? data?.params
-    : playbook.spec?.parameters || [];
-
   return (
     <div className="flex flex-col">
       <div className="flex flex-col gap-2">
-        {parameters && parameters.length > 0 ? (
+        {parameters.length > 0 ? (
           parameters.map((i) => (
             <div
               className={clsx(

--- a/src/components/Playbooks/Runs/Submit/PlaybookRunParams.tsx
+++ b/src/components/Playbooks/Runs/Submit/PlaybookRunParams.tsx
@@ -31,8 +31,7 @@ export default function PlaybookRunParams({
 }: PlaybookRunParamsProps) {
   const [, setModalSize] = useAtom(submitPlaybookRunFormModalSizesAtom);
 
-  const { setFieldValue, values } =
-    useFormikContext<SubmitPlaybookRunFormValues>();
+  const { setValues, values } = useFormikContext<SubmitPlaybookRunFormValues>();
 
   const componentId = values.component_id;
   const configId = values.config_id;
@@ -82,17 +81,19 @@ export default function PlaybookRunParams({
   }, [data, setModalSize]);
 
   // API resolved params only arrive after mount, so their defaults are seeded
-  // here rather than in the form's initial values. We don't want to override
-  // form values if they are already set by user action, like for instance when
-  // re-running a playbook with the same parameters
+  // here rather than in the form's initial values. Defaults only fill in params
+  // the form has no value for, so anything supplied to the form or typed by the
+  // user survives, including across a refetch
   useEffect(() => {
     if (overrideParams || !data?.params) {
       return;
     }
-    Object.entries(getPlaybookParamDefaults(data.params)).forEach(
-      ([name, value]) => setFieldValue(`params.${name}`, value)
-    );
-  }, [data?.params, overrideParams, setFieldValue]);
+    const defaults = getPlaybookParamDefaults(data.params);
+    setValues((current) => ({
+      ...current,
+      params: { ...defaults, ...current.params }
+    }));
+  }, [data?.params, overrideParams, setValues]);
 
   // if no resource is selected, show a message and hide the parameters
   if (!componentId && !configId && !checkId && isResourceRequired) {

--- a/src/components/Playbooks/Runs/Submit/SubmitPlaybookRunForm.tsx
+++ b/src/components/Playbooks/Runs/Submit/SubmitPlaybookRunForm.tsx
@@ -13,6 +13,7 @@ import PlaybookSpecModalTitle from "../../PlaybookSpecModalTitle";
 import { getResourceForRun } from "../services";
 import PlaybookRunParams from "./PlaybookRunParams";
 import PlaybookSelectResource from "./PlaybookSelectResource";
+import { getPlaybookParamDefaults } from "./playbookParamDefaults";
 
 type SubmitPlaybookRunFormModalSizes = {
   width: ModalSize;
@@ -61,16 +62,29 @@ export default function SubmitPlaybookRunForm({
   const recordTouchpoint = useRecordTouchpoint();
 
   const initialValues: Partial<SubmitPlaybookRunFormValues> = useMemo(() => {
+    // params resolved by the API are seeded once they load, see PlaybookRunParams
+    const defaults = overrideParams
+      ? {}
+      : getPlaybookParamDefaults(playbook.spec?.parameters);
     return {
       id: playbook.id,
       component_id: componentId,
       check_id: checkId,
       config_id: configId,
       params: {
+        ...defaults,
         ...params
       }
     };
-  }, [checkId, componentId, configId, params, playbook.id]);
+  }, [
+    checkId,
+    componentId,
+    configId,
+    overrideParams,
+    params,
+    playbook.id,
+    playbook.spec?.parameters
+  ]);
 
   const { mutate: submitPlaybookRun, isLoading } = useSubmitPlaybookRunMutation(
     {

--- a/src/components/Playbooks/Runs/Submit/__tests__/SubmitPlaybookRunForm.unit.test.tsx
+++ b/src/components/Playbooks/Runs/Submit/__tests__/SubmitPlaybookRunForm.unit.test.tsx
@@ -7,12 +7,19 @@ import {
 } from "../../../../../api/types/playbooks";
 import SubmitPlaybookRunForm from "./../SubmitPlaybookRunForm";
 import * as playbooksApi from "../../../../../api/services/playbooks";
+import * as topologyApi from "../../../../../api/services/topology";
 
 // Mock the API functions directly
 jest.mock("../../../../../api/services/playbooks", () => ({
   ...jest.requireActual("../../../../../api/services/playbooks"),
   submitPlaybookRun: jest.fn(),
   getPlaybookParams: jest.fn()
+}));
+
+// the selected component is rendered as a TopologyLink, which looks up its name
+jest.mock("../../../../../api/services/topology", () => ({
+  ...jest.requireActual("../../../../../api/services/topology"),
+  getTopologyNameByID: jest.fn()
 }));
 
 const playbook: RunnablePlaybook & {
@@ -42,6 +49,44 @@ const playbook: RunnablePlaybook & {
   }
 };
 
+const playbookWithoutResource: Pick<
+  PlaybookSpec,
+  "id" | "name" | "title" | "spec"
+> = {
+  id: "2",
+  name: "Playbook 2",
+  title: "Playbook 2",
+  spec: {
+    actions: [],
+    parameters: [
+      {
+        label: "Image",
+        name: "image",
+        type: "text",
+        default: "nginx"
+      },
+      {
+        label: "Dry Run",
+        name: "dryRun",
+        type: "checkbox",
+        default: "true"
+      },
+      {
+        label: "Environment",
+        name: "environment",
+        type: "list",
+        default: "prod",
+        properties: {
+          options: [
+            { label: "Production", value: "prod" },
+            { label: "Staging", value: "staging" }
+          ]
+        }
+      }
+    ]
+  }
+};
+
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
   unobserve: jest.fn(),
@@ -49,6 +94,9 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
 }));
 
 beforeEach(() => {
+  (topologyApi.getTopologyNameByID as jest.Mock).mockResolvedValue({
+    data: [{ id: "component-1", name: "Component 1" }]
+  });
   (playbooksApi.submitPlaybookRun as jest.Mock).mockResolvedValue(playbook);
   (playbooksApi.getPlaybookParams as jest.Mock).mockResolvedValue({
     params: [
@@ -142,5 +190,47 @@ describe("SubmitPlaybookRunForm", () => {
     const btn = screen.getByRole("button", { name: /Run/i });
 
     userEvent.click(btn);
+  });
+
+  describe("playbook without a resource", () => {
+    const renderForm = () =>
+      render(
+        <QueryClientProvider client={createQueryClient()}>
+          <SubmitPlaybookRunForm
+            isOpen={true}
+            playbook={playbookWithoutResource}
+          />
+        </QueryClientProvider>
+      );
+
+    it("should pre-fill the spec defaults for text, checkbox and list params", async () => {
+      renderForm();
+
+      expect(await screen.findByLabelText("Image")).toHaveValue("nginx");
+      expect(screen.getByRole("checkbox")).toBeChecked();
+      expect(screen.getByText("Production")).toBeInTheDocument();
+    });
+
+    it("should dim a text default until the user changes it", async () => {
+      renderForm();
+
+      const input = await screen.findByLabelText("Image");
+      expect(input).toHaveClass("text-gray-400");
+
+      fireEvent.change(input, { target: { value: "redis" } });
+
+      expect(input).not.toHaveClass("text-gray-400");
+    });
+
+    it("should select the whole text default on focus so typing replaces it", async () => {
+      renderForm();
+
+      const input = (await screen.findByLabelText("Image")) as HTMLInputElement;
+
+      fireEvent.focus(input);
+
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe("nginx".length);
+    });
   });
 });

--- a/src/components/Playbooks/Runs/Submit/__tests__/SubmitPlaybookRunForm.unit.test.tsx
+++ b/src/components/Playbooks/Runs/Submit/__tests__/SubmitPlaybookRunForm.unit.test.tsx
@@ -192,6 +192,29 @@ describe("SubmitPlaybookRunForm", () => {
     userEvent.click(btn);
   });
 
+  it("should keep params supplied to the form when the query resolves", async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SubmitPlaybookRunForm
+          isOpen={true}
+          playbook={playbook}
+          componentId={componentId}
+          params={{ name: "supplied" }}
+        />
+      </QueryClientProvider>
+    );
+
+    // the field only renders once the params query has resolved
+    const input = await screen.findByLabelText("Label");
+
+    await waitFor(() => {
+      expect(playbooksApi.getPlaybookParams).toHaveBeenCalled();
+    });
+
+    expect(input).toHaveValue("supplied");
+  });
+
   describe("playbook without a resource", () => {
     const renderForm = () =>
       render(

--- a/src/components/Playbooks/Runs/Submit/playbookParamDefaults.ts
+++ b/src/components/Playbooks/Runs/Submit/playbookParamDefaults.ts
@@ -1,0 +1,30 @@
+// Resolves the `default` declared on playbook parameters into form values,
+// parsing code parameters according to the language they are written in.
+import { PlaybookParam } from "@flanksource-ui/api/types/playbooks";
+import YAML from "yaml";
+
+function parseDefaultValue(parameter: PlaybookParam) {
+  // checkbox values are held as strings, but a spec default may be a boolean
+  if (parameter.type === "checkbox") {
+    return String(parameter.default);
+  }
+  if (parameter.type !== "code" || !parameter.default) {
+    return parameter.default;
+  }
+  const language = parameter.properties?.language ?? "yaml";
+  if (language === "yaml") {
+    return YAML.parse(parameter.default);
+  }
+  if (language === "json") {
+    return JSON.parse(parameter.default);
+  }
+  return parameter.default;
+}
+
+export function getPlaybookParamDefaults(parameters: PlaybookParam[] = []) {
+  return Object.fromEntries(
+    parameters
+      .filter((parameter) => parameter.default !== undefined)
+      .map((parameter) => [parameter.name, parseDefaultValue(parameter)])
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playbook run forms now populate declared parameter defaults automatically.
  * Default text values are dimmed and selected on focus for quick replacement.
  * Added support for custom styling on form text inputs and text areas.
  * Defaults for checkboxes, YAML, and JSON parameters are handled appropriately.

* **Bug Fixes**
  * Explicit parameter values continue to take precedence over generated defaults.

* **Tests**
  * Added coverage for default values, styling, focus selection, and resource-independent playbooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->