### PR TITLE
fix(views): dropdown flopping and duplicate backend requests

### DIFF
--- a/src/pages/audit-report/components/View/GlobalFiltersForm.tsx
+++ b/src/pages/audit-report/components/View/GlobalFiltersForm.tsx
@@ -24,8 +24,13 @@ function GlobalFiltersListener({
   // Keep a stable ref so the form→URL effect doesn't re-run on every URL
   // change. React-router recreates setSearchParams on each URL change, which
   // would cause this effect to fight external navigations with stale values.
+  // Published from an Effect, declared first so the sync below always reads
+  // the setter from the render that actually committed.
   const setGlobalParamsRef = useRef(setGlobalParams);
-  setGlobalParamsRef.current = setGlobalParams;
+
+  useEffect(() => {
+    setGlobalParamsRef.current = setGlobalParams;
+  });
 
   // Sync form → URL whenever values change.
   // The reverse direction (URL → form) is handled by initialValues in the

--- a/src/pages/audit-report/components/View/GlobalFiltersForm.tsx
+++ b/src/pages/audit-report/components/View/GlobalFiltersForm.tsx
@@ -1,5 +1,5 @@
 import { Form, Formik, useFormikContext } from "formik";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { usePrefixedSearchParams } from "../../../../hooks/usePrefixedSearchParams";
 import { ViewVariable } from "../../types";
 
@@ -21,25 +21,40 @@ function GlobalFiltersListener({
   const { values } = useFormikContext<Record<string, string | undefined>>();
   const [, setGlobalParams] = usePrefixedSearchParams(globalVarPrefix);
 
+  // Keep a stable ref so the form→URL effect doesn't re-run on every URL
+  // change. React-router recreates setSearchParams on each URL change, which
+  // would cause this effect to fight external navigations with stale values.
+  const setGlobalParamsRef = useRef(setGlobalParams);
+  setGlobalParamsRef.current = setGlobalParams;
+
   // Sync form → URL whenever values change.
   // The reverse direction (URL → form) is handled by initialValues in the
   // parent so that we avoid an Effect chain (write URL → read URL → set field
   // → write URL → …).
+  //
+  // Only the variables this form knows about are written. Params for other
+  // keys are left untouched: `variables` is derived from in-flight requests
+  // and a key that is momentarily absent must not lose its value.
   useEffect(() => {
-    setGlobalParams(() => {
-      const newParams = new URLSearchParams();
+    setGlobalParamsRef.current(
+      (currentParams) => {
+        let changed = false;
+        const nextParams = new URLSearchParams(currentParams);
 
-      variables.forEach((variable) => {
-        const value = values[variable.key];
-        if (value) {
-          newParams.set(variable.key, value);
-        }
-      });
+        variables.forEach((variable) => {
+          const value = values[variable.key];
+          if (value && nextParams.get(variable.key) !== value) {
+            nextParams.set(variable.key, value);
+            changed = true;
+          }
+        });
 
-      return newParams;
-    });
+        return changed ? nextParams : currentParams;
+      },
+      { replace: true }
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [values, setGlobalParams]);
+  }, [values]);
 
   return children as React.ReactElement;
 }

--- a/src/pages/views/components/__tests__/ViewContainer.templateVariables.unit.test.tsx
+++ b/src/pages/views/components/__tests__/ViewContainer.templateVariables.unit.test.tsx
@@ -263,8 +263,8 @@ describe("ViewContainer metadata loading", () => {
           key: "namespace",
           value: "",
           type: "select",
-          options: ["ns-a"],
-          default: "ns-a"
+          options: ["ns-a", "ns-b"],
+          default: "ns-b"
         }
       ],
       sections: [
@@ -285,8 +285,8 @@ describe("ViewContainer metadata loading", () => {
       }
     });
 
-    // When URL vars are present, the data endpoint is used instead of
-    // metadata so the primary view panels/table reflect the variables.
+    // When a URL var differs from its default, the data endpoint is used
+    // instead of metadata so the primary view panels/table reflect it.
     renderWithProviders("/?viewvar__namespace=ns-a");
 
     await waitFor(() => {

--- a/src/pages/views/components/__tests__/ViewContainer.variableSync.unit.test.tsx
+++ b/src/pages/views/components/__tests__/ViewContainer.variableSync.unit.test.tsx
@@ -1,0 +1,221 @@
+// Reproduces duplicate view fetches on load and the variable dropdown
+// reverting to its default when global filters change.
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import ViewContainer from "../ViewContainer";
+import * as viewsApi from "../../../../api/services/views";
+
+jest.mock("../../../../api/services/views", () => ({
+  ...jest.requireActual("../../../../api/services/views"),
+  getViewDataById: jest.fn(),
+  getViewMetadataById: jest.fn(),
+  getViewDataByNamespace: jest.fn(),
+  getViewDisplayPluginVariables: jest.fn()
+}));
+
+// The audit-report View renders panels/tables and issues its own table query,
+// neither of which participate in the variable ↔ URL sync under test.
+jest.mock("../../../audit-report/components/View/View", () => ({
+  __esModule: true,
+  default: ({ requestFingerprint }: { requestFingerprint: string }) => (
+    <div data-testid="view-fingerprint">{requestFingerprint}</div>
+  )
+}));
+
+// Replace the react-windowed-select widget with a native <select> so the real
+// GlobalFilters / GlobalFiltersForm logic stays under test but is drivable.
+jest.mock("../../../../ui/Dropdowns/MultiSelectDropdown", () => ({
+  __esModule: true,
+  MultiSelectDropdown: ({ label, options, value, onChange }: any) => (
+    <select
+      aria-label={label}
+      value={value?.value ?? ""}
+      onChange={(e) =>
+        onChange(options.find((o: any) => o.value === e.target.value))
+      }
+    >
+      {options.map((o: any) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  )
+}));
+
+const mockedGetViewDataById = viewsApi.getViewDataById as jest.MockedFunction<
+  typeof viewsApi.getViewDataById
+>;
+const mockedGetViewMetadataById =
+  viewsApi.getViewMetadataById as jest.MockedFunction<
+    typeof viewsApi.getViewMetadataById
+  >;
+const mockedGetViewDataByNamespace =
+  viewsApi.getViewDataByNamespace as jest.MockedFunction<
+    typeof viewsApi.getViewDataByNamespace
+  >;
+
+const searchHistory: string[] = [];
+
+function SearchRecorder() {
+  const { search } = useLocation();
+  if (searchHistory[searchHistory.length - 1] !== search) {
+    searchHistory.push(search);
+  }
+  return null;
+}
+
+function renderView(initialPath = "/") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <QueryClientProvider client={queryClient}>
+        <SearchRecorder />
+        <ViewContainer id="view-1" />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+const namespaceVariable = {
+  key: "namespace",
+  value: "",
+  type: "select",
+  options: ["ns-a", "ns-b"],
+  default: "ns-a"
+};
+
+const clusterVariable = {
+  key: "cluster",
+  value: "",
+  type: "select",
+  options: ["c1", "c2"],
+  default: "c1"
+};
+
+const sections = [
+  {
+    title: "Section A",
+    viewRef: { namespace: "mission-control", name: "section-a" }
+  }
+];
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  searchHistory.length = 0;
+});
+
+describe("view loading with variables", () => {
+  it("does not re-fetch the view or its prefetched sections when the form writes default variables to the URL", async () => {
+    mockedGetViewMetadataById.mockResolvedValue({
+      id: "view-1",
+      namespace: "mission-control",
+      name: "cluster-view",
+      requestFingerprint: "primary:none",
+      variables: [namespaceVariable],
+      sections,
+      sectionResults: {
+        "mission-control/section-a": {
+          namespace: "mission-control",
+          name: "section-a",
+          requestFingerprint: "section:ns-a",
+          variables: [namespaceVariable]
+        }
+      }
+    });
+
+    mockedGetViewDataById.mockImplementation(async (_id, variables) => ({
+      namespace: "mission-control",
+      name: "cluster-view",
+      requestFingerprint: `primary:${variables?.namespace ?? "none"}`,
+      variables: [namespaceVariable],
+      sections
+    }));
+
+    mockedGetViewDataByNamespace.mockImplementation(
+      async (namespace, name, variables) => ({
+        namespace,
+        name,
+        requestFingerprint: `section:${variables?.namespace ?? "none"}`,
+        variables: [namespaceVariable]
+      })
+    );
+
+    renderView("/");
+
+    await screen.findByLabelText("Namespace");
+    // Let every knock-on fetch settle.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect({
+      metadata: mockedGetViewMetadataById.mock.calls.length,
+      viewData: mockedGetViewDataById.mock.calls.length,
+      sectionData: mockedGetViewDataByNamespace.mock.calls.length
+    }).toEqual({ metadata: 1, viewData: 0, sectionData: 0 });
+  });
+});
+
+describe("changing a global filter", () => {
+  it("keeps a section-provided variable selection instead of reverting to its default", async () => {
+    // `cluster` is defined only by the top-level view; `namespace` only by the
+    // section — the common aggregator-dashboard shape.
+    mockedGetViewMetadataById.mockResolvedValue({
+      id: "view-1",
+      namespace: "mission-control",
+      name: "cluster-view",
+      requestFingerprint: "primary:none",
+      variables: [clusterVariable],
+      sections,
+      sectionResults: {
+        "mission-control/section-a": {
+          namespace: "mission-control",
+          name: "section-a",
+          requestFingerprint: "section:ns-a",
+          variables: [namespaceVariable]
+        }
+      }
+    });
+
+    mockedGetViewDataById.mockImplementation(async (_id, variables) => ({
+      namespace: "mission-control",
+      name: "cluster-view",
+      requestFingerprint: `primary:${variables?.namespace ?? "none"}`,
+      variables: [clusterVariable],
+      sections
+    }));
+
+    mockedGetViewDataByNamespace.mockImplementation(
+      async (namespace, name, variables) => ({
+        namespace,
+        name,
+        requestFingerprint: `section:${variables?.namespace ?? "none"}`,
+        variables: [namespaceVariable]
+      })
+    );
+
+    renderView("/");
+
+    const namespaceSelect = await screen.findByLabelText("Namespace");
+    await screen.findByLabelText("Cluster");
+
+    await userEvent.selectOptions(namespaceSelect, "ns-b");
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Namespace")).toHaveValue("ns-b");
+    });
+
+    // The selection must survive the refetch it triggers.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(screen.getByLabelText("Namespace")).toHaveValue("ns-b");
+    expect(searchHistory[searchHistory.length - 1]).toContain(
+      "viewvar__namespace=ns-b"
+    );
+  });
+});

--- a/src/pages/views/components/__tests__/ViewContainer.variableSync.unit.test.tsx
+++ b/src/pages/views/components/__tests__/ViewContainer.variableSync.unit.test.tsx
@@ -153,6 +153,12 @@ describe("view loading with variables", () => {
     // Let every knock-on fetch settle.
     await new Promise((resolve) => setTimeout(resolve, 100));
 
+    // The default really was written to the URL — without this the request
+    // counts below could pass simply because no sync happened at all.
+    expect(searchHistory[searchHistory.length - 1]).toContain(
+      "viewvar__namespace=ns-a"
+    );
+
     expect({
       metadata: mockedGetViewMetadataById.mock.calls.length,
       viewData: mockedGetViewDataById.mock.calls.length,
@@ -217,5 +223,58 @@ describe("changing a global filter", () => {
     expect(searchHistory[searchHistory.length - 1]).toContain(
       "viewvar__namespace=ns-b"
     );
+
+    // Changing a second variable must not clobber the first: each write
+    // touches only its own key.
+    await userEvent.selectOptions(screen.getByLabelText("Cluster"), "c2");
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(screen.getByLabelText("Cluster")).toHaveValue("c2");
+    expect(screen.getByLabelText("Namespace")).toHaveValue("ns-b");
+  });
+});
+
+describe("resetting a global filter to its default", () => {
+  it("renders the metadata result rather than the retained non-default data", async () => {
+    mockedGetViewMetadataById.mockResolvedValue({
+      id: "view-1",
+      namespace: "mission-control",
+      name: "cluster-view",
+      requestFingerprint: "primary:default",
+      variables: [namespaceVariable]
+    });
+
+    mockedGetViewDataById.mockImplementation(async (_id, variables) => ({
+      namespace: "mission-control",
+      name: "cluster-view",
+      requestFingerprint: `primary:${variables?.namespace ?? "none"}`,
+      variables: [namespaceVariable]
+    }));
+
+    renderView("/");
+
+    const namespaceSelect = await screen.findByLabelText("Namespace");
+    await waitFor(() => {
+      expect(screen.getByTestId("view-fingerprint")).toHaveTextContent(
+        "primary:default"
+      );
+    });
+
+    await userEvent.selectOptions(namespaceSelect, "ns-b");
+    await waitFor(() => {
+      expect(screen.getByTestId("view-fingerprint")).toHaveTextContent(
+        "primary:ns-b"
+      );
+    });
+
+    // Back to the default: the data query switches off, so the metadata
+    // result — not the retained ns-b response — is what should render.
+    await userEvent.selectOptions(screen.getByLabelText("Namespace"), "ns-a");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("view-fingerprint")).toHaveTextContent(
+        "primary:default"
+      );
+    });
   });
 });

--- a/src/pages/views/hooks/useViewData.ts
+++ b/src/pages/views/hooks/useViewData.ts
@@ -287,9 +287,14 @@ export function useViewData({
     keepPreviousData: true
   });
 
+  // `keepPreviousData` keeps serving the previous key's response after the
+  // query is disabled, so a reset back to the defaults would otherwise keep
+  // rendering the last non-default result forever.
   const viewResult = isDisplayPluginMode
     ? dataResult
-    : (dataResult ?? metadataResult);
+    : isDataQueryEnabled
+      ? (dataResult ?? metadataResult)
+      : metadataResult;
 
   const allSectionRefs = useMemo<ViewRef[]>(() => {
     const sections = isDisplayPluginMode

--- a/src/pages/views/hooks/useViewData.ts
+++ b/src/pages/views/hooks/useViewData.ts
@@ -4,8 +4,7 @@ import {
   getViewDataById,
   getViewDisplayPluginVariables,
   getViewMetadataById,
-  getSectionResultByViewRef,
-  type DashboardResponse
+  getSectionResultByViewRef
 } from "../../../api/services/views";
 import {
   useAggregatedViewVariables,
@@ -59,13 +58,20 @@ export interface UseViewDataResult {
  * `aggregatedVariables` is intentionally emptied in this mode because the
  * global variable filter UI should not be shown inside an embedded tab.
  *
- * **Fetching strategy** — when `sectionResults` are already present on
- * `/api/dashboard` or `/api/view/metadata/:id`, those prefetched section
- * payloads are used directly and per-section POST calls are skipped. Otherwise,
- * section data is fetched exactly once inside `useAggregatedViewVariables`
- * (which also aggregates section variables) and surfaced here as `sectionData`.
- * `ViewSection` components receive that data as props rather than issuing their
- * own queries.
+ * **Fetching strategy** — `/api/view/metadata/:id` describes the view: its
+ * sections, variable definitions and their defaults, none of which depend on
+ * the selected variable values. It is fetched independently of the data
+ * endpoint and carries prefetched `sectionResults`, so a view whose variables
+ * are all at their defaults costs a single request. The data endpoint
+ * (`/api/view/:id`) is only used once a variable is set to something other
+ * than its default, and section data is then fetched inside
+ * `useAggregatedViewVariables` (which also aggregates section variables) and
+ * surfaced here as `sectionData`. `ViewSection` components receive that data
+ * as props rather than issuing their own queries.
+ *
+ * Variables are aggregated metadata-first so the set of keys can only grow
+ * while requests are in flight. A variable that vanished mid-fetch would be
+ * dropped from the URL by the filter form and reset to its default.
  *
  * **Force-refresh** — `handleForceRefresh` re-fetches the top-level view with
  * a `cache-control: max-age=1` header to bypass server-side caching, then
@@ -111,52 +117,24 @@ export function useViewData({
     [standardModeVariables]
   );
 
-  // Include standard-mode variables in the query key so that the primary
-  // view data (panels, table, fingerprint) is re-fetched whenever the
-  // global filter values change.  The metadata endpoint does not accept
-  // variables, so we switch to the data endpoint when any are present.
-  const viewQueryKey = isDisplayPluginMode
-    ? ["viewDataById", viewId, configId, variables]
-    : hasStandardModeVariables
-      ? ["viewDataById", viewId, viewVarParamsString]
-      : ["view-metadata", viewId];
+  const refreshHeaders = () =>
+    forceRefreshRef.current ? { "cache-control": "max-age=1" } : undefined;
 
   const {
-    data: viewResult,
-    isLoading: isLoadingViewResult,
-    isFetching: isFetchingViewResult,
-    isPreviousData,
-    error: viewResultError,
-    refetch
+    data: metadataResult,
+    isLoading: isLoadingMetadata,
+    isFetching: isFetchingMetadata,
+    error: metadataError,
+    refetch: refetchMetadata
   } = useQuery({
-    queryKey: viewQueryKey,
-    queryFn: () => {
-      const headers = forceRefreshRef.current
-        ? { "cache-control": "max-age=1" }
-        : undefined;
-
-      if (isDisplayPluginMode) {
-        return getViewDataById(viewId, variables, headers);
-      }
-
-      if (hasStandardModeVariables) {
-        return getViewDataById(viewId, standardModeVariables, headers);
-      }
-
-      return getViewMetadataById(viewId, headers);
-    },
-    enabled: isDisplayPluginMode ? !!variables : !!viewId,
-    staleTime: 5 * 60 * 1000,
-    keepPreviousData: true
+    queryKey: ["view-metadata", viewId],
+    queryFn: () => getViewMetadataById(viewId, refreshHeaders()),
+    enabled: !isDisplayPluginMode && !!viewId,
+    staleTime: 5 * 60 * 1000
   });
 
   useEffect(() => {
-    if (isDisplayPluginMode || !viewResult?.name) {
-      return;
-    }
-
-    const metadataResult = viewResult as DashboardResponse;
-    if (!metadataResult.id) {
+    if (isDisplayPluginMode || !metadataResult?.name || !metadataResult.id) {
       return;
     }
 
@@ -194,32 +172,16 @@ export function useViewData({
         sectionResult
       );
     });
-  }, [isDisplayPluginMode, queryClient, viewResult]);
-
-  const allSectionRefs = useMemo<ViewRef[]>(() => {
-    if (!viewResult?.sections) {
-      return [];
-    }
-
-    return viewResult.sections
-      .filter((section) => !!section.viewRef)
-      .map((section) => ({
-        namespace: section.viewRef?.namespace ?? "",
-        name: section.viewRef?.name ?? ""
-      }))
-      .filter((ref) => !!ref.name);
-  }, [viewResult?.sections]);
+  }, [isDisplayPluginMode, queryClient, metadataResult]);
 
   const prefetchedSectionData = useMemo(() => {
     const sectionDataMap = new Map<string, SectionDataEntry>();
 
-    if (isDisplayPluginMode || !viewResult?.sections) {
+    if (isDisplayPluginMode || !metadataResult?.sections) {
       return sectionDataMap;
     }
 
-    const metadataResult = viewResult as DashboardResponse;
-
-    metadataResult.sections?.forEach((section) => {
+    metadataResult.sections.forEach((section) => {
       if (!section.viewRef?.name) {
         return;
       }
@@ -241,7 +203,7 @@ export function useViewData({
     });
 
     return sectionDataMap;
-  }, [isDisplayPluginMode, viewResult]);
+  }, [isDisplayPluginMode, metadataResult]);
 
   const prefetchedSectionAggregatedVariables = useMemo(
     () =>
@@ -253,13 +215,17 @@ export function useViewData({
     [prefetchedSectionData]
   );
 
-  const shouldFetchSectionsForStandardModeVariables = useMemo(() => {
-    if (isDisplayPluginMode || !hasStandardModeVariables) {
+  // The filter form seeds the URL with every variable's default, so the mere
+  // presence of URL variables says nothing about whether the user changed
+  // anything. Only a value that differs from its default needs the data
+  // endpoint; anything else is already covered by the metadata response.
+  const hasNonDefaultVariables = useMemo(() => {
+    if (isDisplayPluginMode || !hasStandardModeVariables || !metadataResult) {
       return false;
     }
 
     const metadataVariables = aggregateVariables([
-      viewResult?.variables,
+      metadataResult.variables,
       prefetchedSectionAggregatedVariables
     ]);
 
@@ -290,13 +256,61 @@ export function useViewData({
   }, [
     hasStandardModeVariables,
     isDisplayPluginMode,
+    metadataResult,
     prefetchedSectionAggregatedVariables,
-    standardModeVariables,
-    viewResult?.variables
+    standardModeVariables
   ]);
 
+  const isDataQueryEnabled = isDisplayPluginMode
+    ? !!variables
+    : hasNonDefaultVariables;
+
+  const {
+    data: dataResult,
+    isLoading: isLoadingDataResult,
+    isFetching: isFetchingDataResult,
+    isPreviousData,
+    error: dataResultError,
+    refetch: refetchData
+  } = useQuery({
+    queryKey: isDisplayPluginMode
+      ? ["viewDataById", viewId, configId, variables]
+      : ["viewDataById", viewId, viewVarParamsString],
+    queryFn: () =>
+      getViewDataById(
+        viewId,
+        isDisplayPluginMode ? variables : standardModeVariables,
+        refreshHeaders()
+      ),
+    enabled: isDataQueryEnabled,
+    staleTime: 5 * 60 * 1000,
+    keepPreviousData: true
+  });
+
+  const viewResult = isDisplayPluginMode
+    ? dataResult
+    : (dataResult ?? metadataResult);
+
+  const allSectionRefs = useMemo<ViewRef[]>(() => {
+    const sections = isDisplayPluginMode
+      ? dataResult?.sections
+      : metadataResult?.sections;
+
+    if (!sections) {
+      return [];
+    }
+
+    return sections
+      .filter((section) => !!section.viewRef)
+      .map((section) => ({
+        namespace: section.viewRef?.namespace ?? "",
+        name: section.viewRef?.name ?? ""
+      }))
+      .filter((ref) => !!ref.name);
+  }, [isDisplayPluginMode, dataResult?.sections, metadataResult?.sections]);
+
   const sectionsToQuery = useMemo<ViewRef[]>(() => {
-    if (isDisplayPluginMode || shouldFetchSectionsForStandardModeVariables) {
+    if (isDisplayPluginMode || hasNonDefaultVariables) {
       return allSectionRefs;
     }
 
@@ -308,7 +322,7 @@ export function useViewData({
     allSectionRefs,
     isDisplayPluginMode,
     prefetchedSectionData,
-    shouldFetchSectionsForStandardModeVariables
+    hasNonDefaultVariables
   ]);
 
   const {
@@ -332,22 +346,22 @@ export function useViewData({
     return mergedSectionData;
   }, [prefetchedSectionData, queriedSectionData]);
 
-  const metadataSectionVariables =
-    !isDisplayPluginMode && !shouldFetchSectionsForStandardModeVariables
-      ? prefetchedSectionAggregatedVariables
-      : EMPTY_VARIABLES;
-
+  // Metadata first: its keys, labels and defaults are stable across fetches,
+  // so the aggregate can only gain keys as data responses arrive. Later
+  // sources still contribute their options, which `aggregateVariables` unions.
   const aggregatedVariables = useMemo(
     () =>
       aggregateVariables([
-        viewResult?.variables,
-        metadataSectionVariables,
+        metadataResult?.variables,
+        prefetchedSectionAggregatedVariables,
+        dataResult?.variables,
         queriedSectionAggregatedVariables
       ]),
     [
-      metadataSectionVariables,
-      queriedSectionAggregatedVariables,
-      viewResult?.variables
+      dataResult?.variables,
+      metadataResult?.variables,
+      prefetchedSectionAggregatedVariables,
+      queriedSectionAggregatedVariables
     ]
   );
 
@@ -357,10 +371,15 @@ export function useViewData({
 
   const handleForceRefresh = useCallback(async () => {
     forceRefreshRef.current = true;
-    const result = await refetch();
+    const results = await Promise.all([
+      isDisplayPluginMode ? undefined : refetchMetadata(),
+      isDataQueryEnabled ? refetchData() : undefined
+    ]);
     forceRefreshRef.current = false;
 
-    if (result.isError) {
+    const result = results.find((it) => it?.isError);
+
+    if (result?.isError) {
       const err = result.error as any;
       toastError(
         err?.message ||
@@ -396,18 +415,25 @@ export function useViewData({
   }, [
     allSectionRefs,
     configId,
+    isDataQueryEnabled,
     isDisplayPluginMode,
     queryClient,
-    refetch,
+    refetchData,
+    refetchMetadata,
     viewId
   ]);
 
   return {
     viewResult,
-    isLoading: isLoadingViewResult || isLoadingDisplayPluginVariables,
-    isFetching: isFetchingViewResult || isFetchingDisplayPluginVariables,
+    isLoading: isDisplayPluginMode
+      ? isLoadingDataResult || isLoadingDisplayPluginVariables
+      : isLoadingMetadata,
+    isFetching:
+      isFetchingMetadata ||
+      (isDataQueryEnabled && isFetchingDataResult) ||
+      isFetchingDisplayPluginVariables,
     isPreviousData,
-    error: displayPluginVariablesError || viewResultError,
+    error: displayPluginVariablesError || dataResultError || metadataError,
     aggregatedVariables: isDisplayPluginMode
       ? EMPTY_VARIABLES
       : aggregatedVariables,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter-to-URL synchronization to preserve unrelated parameters and avoid unnecessary URL updates.
  * Prevented duplicate view and section data requests when filter values remain at their defaults.
  * Preserved section-specific selections, such as namespace choices, when global filters change.
  * Improved view loading and refresh behavior by separating metadata retrieval from variable-dependent data requests.
  * Ensured data is fetched when URL-selected variables differ from their defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->