### PR TITLE
feat(catalog): include soft relationships in config changes

### DIFF
--- a/src/api/query-hooks/useConfigChangesHooks.ts
+++ b/src/api/query-hooks/useConfigChangesHooks.ts
@@ -112,6 +112,7 @@ export function useGetConfigChangesByIDQuery(
   const [params] = usePrefixedSearchParams(undefined, false, {
     downstream: "true",
     upstream: "false",
+    soft: "false",
     sortBy: "created_at",
     sortDirection: "desc"
   });
@@ -124,6 +125,7 @@ export function useGetConfigChangesByIDQuery(
   const [sortBy] = useReactTableSortState();
   const upstream = params.get("upstream") === "true";
   const downstream = params.get("downstream") === "true";
+  const soft = params.get("soft") === "true";
   const all = upstream && downstream;
 
   const arbitraryFilter = useConfigChangesArbitraryFilters();
@@ -146,6 +148,7 @@ export function useGetConfigChangesByIDQuery(
   const props = {
     id,
     type_filter: relationshipType,
+    soft,
     include_deleted_configs: showChangesFromDeletedConfigs,
     changeType: change_type,
     severity,

--- a/src/api/services/__tests__/configs.unit.test.ts
+++ b/src/api/services/__tests__/configs.unit.test.ts
@@ -1,0 +1,47 @@
+import { Catalog } from "../../axios";
+import { getConfigsChanges } from "../configs";
+
+jest.mock("../../axios", () => ({
+  Catalog: {
+    post: jest.fn()
+  }
+}));
+
+const mockedPost = Catalog.post as jest.MockedFunction<typeof Catalog.post>;
+
+describe("getConfigsChanges", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedPost.mockResolvedValue({
+      data: { summary: {}, changes: [], total: 0 }
+    } as any);
+  });
+
+  it("includes soft relationships in config-specific change requests", async () => {
+    await getConfigsChanges({
+      id: "config-1",
+      type_filter: "downstream",
+      soft: true,
+      include_deleted_configs: false
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/changes",
+      expect.objectContaining({
+        id: "config-1",
+        recursive: "downstream",
+        depth: 5,
+        soft: true
+      })
+    );
+  });
+
+  it("omits the soft option from global change requests", async () => {
+    await getConfigsChanges({ include_deleted_configs: false });
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/changes",
+      expect.not.objectContaining({ soft: expect.anything() })
+    );
+  });
+});

--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -225,6 +225,7 @@ export type CatalogChangesSearchResponse = {
 export type GetConfigsRelatedChangesParams = {
   id?: string;
   type_filter?: "all" | "upstream" | "downstream" | "none";
+  soft?: boolean;
   include_deleted_configs: boolean;
   changeType?: string;
   severity?: string;
@@ -248,6 +249,7 @@ export type GetConfigsRelatedChangesParams = {
 export async function getConfigsChanges({
   id,
   type_filter,
+  soft,
   include_deleted_configs = false,
   changeType,
   severity,
@@ -354,6 +356,9 @@ export async function getConfigsChanges({
     requestData.set("depth", 5);
   } else {
     requestData.set("recursive", "none");
+  }
+  if (soft !== undefined) {
+    requestData.set("soft", soft);
   }
 
   if (severity) {

--- a/src/components/Configs/Changes/ConfigChangesFilters/ConfigRelatedChangesToggles.tsx
+++ b/src/components/Configs/Changes/ConfigChangesFilters/ConfigRelatedChangesToggles.tsx
@@ -4,11 +4,13 @@ import { useSearchParams } from "react-router-dom";
 export function ConfigRelatedChangesToggles() {
   const [params, setParams] = useSearchParams({
     downstream: "true",
-    upstream: "false"
+    upstream: "false",
+    soft: "false"
   });
 
   const downstream = params.get("downstream") === "true";
   const upstream = params.get("upstream") === "true";
+  const soft = params.get("soft") === "true";
 
   return (
     <div className="flex flex-row gap-2 px-2">
@@ -25,6 +27,14 @@ export function ConfigRelatedChangesToggles() {
         value={upstream}
         onChange={(value) => {
           params.set("upstream", value ? "true" : "false");
+          setParams(params);
+        }}
+      />
+      <Toggle
+        label="Soft"
+        value={soft}
+        onChange={(value) => {
+          params.set("soft", value ? "true" : "false");
           setParams(params);
         }}
       />

--- a/src/components/Configs/Changes/ConfigChangesFilters/__tests__/ConfigRelatedChangesToggles.unit.test.tsx
+++ b/src/components/Configs/Changes/ConfigChangesFilters/__tests__/ConfigRelatedChangesToggles.unit.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { ConfigRelatedChangesToggles } from "../ConfigRelatedChangesToggles";
+
+function SearchParams() {
+  return <div data-testid="search">{useLocation().search}</div>;
+}
+
+describe("ConfigRelatedChangesToggles", () => {
+  it("stores the soft relationship selection in the URL", () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/catalog/config-1/changes"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <ConfigRelatedChangesToggles />
+        <SearchParams />
+      </MemoryRouter>
+    );
+
+    const softToggle = screen.getByRole("switch", { name: "Soft" });
+    expect(softToggle).not.toBeChecked();
+
+    fireEvent.click(softToggle);
+
+    expect(softToggle).toBeChecked();
+    expect(
+      new URLSearchParams(screen.getByTestId("search").textContent ?? "").get(
+        "soft"
+      )
+    ).toBe("true");
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Soft** filter toggle for related configuration changes.
  * Soft-filter selections are reflected in the URL and preserved when loading results.
  * Related-change requests now support including soft relationships when enabled.

* **Bug Fixes**
  * Ensured the Soft filter defaults to disabled when no selection is provided.

* **Tests**
  * Added coverage for Soft-filter behavior and related-change request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->