### PR TITLE
Keep Catalog Changes tags compact and filterable

### DIFF
--- a/src/components/Configs/Changes/ConfigChangeTable.stories.tsx
+++ b/src/components/Configs/Changes/ConfigChangeTable.stories.tsx
@@ -1,20 +1,47 @@
 import { Meta, StoryFn } from "@storybook/react";
+import { useSearchParams } from "react-router-dom";
 import { ConfigChange } from "../../../api/types/configs";
 import { ConfigChangeTable } from "./ConfigChangeTable";
 
 export default {
-  title: "ConfigChangeHistory",
+  title: "Catalog/Changes/ConfigChangeTable",
   component: ConfigChangeTable,
+  parameters: {
+    layout: "fullscreen"
+  },
   decorators: [
     (Story) => {
-      return <Story />;
+      return (
+        <div className="flex h-screen min-h-[500px] w-full p-4">
+          <Story />
+        </div>
+      );
     }
   ]
 } satisfies Meta<typeof ConfigChangeTable>;
 
-const Template: StoryFn<typeof ConfigChangeTable> = (args) => (
-  <ConfigChangeTable {...args} />
-);
+const Template: StoryFn<typeof ConfigChangeTable> = (args) => {
+  const [params] = useSearchParams();
+  const tagFilters = (params.get("tags")?.split(",") ?? []).map((filter) => {
+    const [tag, action] = filter.split(":");
+    const [key, value] = tag.split("____");
+    return { key, value, exclude: action === "-1" };
+  });
+  const filteredData = args.data.filter((change) =>
+    tagFilters.every(({ key, value, exclude }) => {
+      const matches = String(change.tags?.[key]) === value;
+      return exclude ? !matches : matches;
+    })
+  );
+
+  return (
+    <ConfigChangeTable
+      {...args}
+      data={filteredData}
+      totalRecords={filteredData.length}
+    />
+  );
+};
 
 export const Default = Template.bind({});
 
@@ -33,29 +60,47 @@ const data = Array(10)
   .fill(0)
   .map((_, i) => ({
     id: `id-${i}`,
-    created_by: {
-      id: `id-${i}`,
-      email: `email-${i}`,
-      name: `name-${i}`
-    },
     details: "",
     external_change_id: `id-${i}`,
     source: "source",
-    external_created_by: "external_created_by",
+    external_created_by: i % 2 === 0 ? "kubernetes/" : "source-controller",
     config_type: "config_type",
     severity: "severity",
-    change_type: "diff",
-    summary: `Summary - ${i}`,
-    created_at: new Date(),
-    config_id: `id-${i}`,
-    patches: codeSample(i)
-  })) as unknown as ConfigChange[];
+    change_type: i % 3 === 0 ? "PolicyViolation" : "diff",
+    summary:
+      i % 3 === 0
+        ? "Policy require-run-as-nonroot failed: validation error: running as root is not allowed"
+        : `status.history changed for catalog item ${i}`,
+    created_at: `2026-08-14T15:34:${String(i).padStart(2, "0")}.000Z`,
+    first_observed: "2026-08-14T13:34:00.000Z",
+    count: i % 2 === 0 ? 12 : 1,
+    config_id: `config-${i}`,
+    config: {
+      id: `config-${i}`,
+      name: i % 2 === 0 ? "config-db-6db85d9c9-k5m2r" : "immich",
+      type: i % 3 === 0 ? "Kubernetes::Pod" : "Kubernetes::Kustomization"
+    },
+    tags: {
+      cluster: "homelab",
+      namespace: i % 3 === 0 ? "mission-control" : "flux-system",
+      environment: "production",
+      team: i % 2 === 0 ? "platform" : "applications"
+    },
+    patches: JSON.stringify(codeSample(i))
+  })) satisfies ConfigChange[];
 
-Default.args = { data: Array.from(data), isLoading: false };
+Default.args = {
+  data: Array.from(data),
+  isLoading: false,
+  totalRecords: data.length,
+  numberOfPages: 1
+};
 
 export const WithConfigLink = Template.bind({});
 
 WithConfigLink.args = {
   data: Array.from(data),
-  isLoading: false
+  isLoading: false,
+  totalRecords: data.length,
+  numberOfPages: 1
 };

--- a/src/components/Configs/Changes/ConfigChangeTable.tsx
+++ b/src/components/Configs/Changes/ConfigChangeTable.tsx
@@ -50,6 +50,8 @@ const configChangesColumn = (
     meta: {
       cellClassName: "text-ellipsis overflow-hidden"
     },
+    minSize: 100,
+    size: 120,
     maxSize: 160,
     Cell: ({ cell, row, column }) => {
       const dateString = row?.getValue<string>(column.id);
@@ -146,9 +148,12 @@ const configChangesColumn = (
         {...props}
         enableFilterByTag
         paramPrefix={paramPrefix}
+        maxVisibleTags={1}
       />
     ),
-    size: 100
+    minSize: 120,
+    size: 180,
+    maxSize: 260
   },
   {
     header: "Created By",

--- a/src/components/Configs/ConfigList/Cells/MRTConfigListTagsCell.tsx
+++ b/src/components/Configs/ConfigList/Cells/MRTConfigListTagsCell.tsx
@@ -16,6 +16,7 @@ type MRTConfigListTagsCellProps<
    * Optional prefix to namespace the search params.
    */
   paramPrefix?: string;
+  maxVisibleTags?: number;
 };
 
 export default function MRTConfigListTagsCell<
@@ -25,7 +26,8 @@ export default function MRTConfigListTagsCell<
   hideGroupByView = false,
   enableFilterByTag = false,
   filterByTagParamKey = "tags",
-  paramPrefix
+  paramPrefix,
+  maxVisibleTags
 }: MRTConfigListTagsCellProps<T>): JSX.Element | null {
   const [params] = usePrefixedSearchParams(paramPrefix, false);
 
@@ -80,6 +82,7 @@ export default function MRTConfigListTagsCell<
       tags={tagMap}
       filterByTagParamKey={filterByTagParamKey}
       paramPrefix={paramPrefix}
+      maxVisibleTags={maxVisibleTags}
     />
   );
 }

--- a/src/ui/Tags/TagsFilterCell.tsx
+++ b/src/ui/Tags/TagsFilterCell.tsx
@@ -1,4 +1,14 @@
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from "@flanksource-ui/components/ui/popover";
+import { IconButton } from "@flanksource-ui/ui/Buttons/IconButton";
 import { useCallback } from "react";
+import {
+  PiMagnifyingGlassMinusThin,
+  PiMagnifyingGlassPlusThin
+} from "react-icons/pi";
 import { usePrefixedSearchParams } from "@flanksource-ui/hooks/usePrefixedSearchParams";
 import { fromBase64, toBase64 } from "../../utils/common";
 import { Tag } from "./Tag";
@@ -15,17 +25,25 @@ type TagsFilterCellProps = {
    * Optional prefix to namespace the search params.
    */
   paramPrefix?: string;
+  /** Maximum number of tags shown before the remainder moves into a popover. */
+  maxVisibleTags?: number;
 };
 
 export default function TagsFilterCell({
   tags,
   filterByTagParamKey = "labels",
   useBase64Encoding = false,
-  paramPrefix
+  paramPrefix,
+  maxVisibleTags
 }: TagsFilterCellProps) {
   const [, setParams] = usePrefixedSearchParams(paramPrefix, false);
 
   const tagEntries = Object.entries(tags).filter(([key]) => key !== "toString");
+  const visibleTagEntries =
+    maxVisibleTags === undefined
+      ? tagEntries
+      : tagEntries.slice(0, maxVisibleTags);
+  const hiddenTagEntries = tagEntries.slice(visibleTagEntries.length);
 
   const onFilterByTag = useCallback(
     (
@@ -78,17 +96,89 @@ export default function TagsFilterCell({
   }
 
   return (
-    <div className="flex flex-wrap gap-1">
-      {tagEntries.map(([key, value]) => (
+    <div
+      className={
+        maxVisibleTags === undefined
+          ? "flex flex-wrap gap-1"
+          : "flex min-w-0 flex-nowrap items-center gap-1 overflow-hidden"
+      }
+    >
+      {visibleTagEntries.map(([key, value]) => (
         <Tag
           key={key}
           tag={{ key, value: String(value) }}
           variant="gray"
           onFilterByTag={onFilterByTag}
+          className={
+            maxVisibleTags === undefined
+              ? undefined
+              : "flex min-w-0 flex-row overflow-hidden text-ellipsis whitespace-nowrap rounded-md bg-gray-100 px-1 py-0.5 text-xs"
+          }
         >
-          {key}: {String(value)}
+          <span className="overflow-hidden text-ellipsis">
+            {key}: {String(value)}
+          </span>
         </Tag>
       ))}
+      {hiddenTagEntries.length > 0 && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="shrink-0 cursor-pointer whitespace-nowrap text-xs text-gray-600 underline decoration-dotted underline-offset-2"
+              aria-label={`${hiddenTagEntries.length} more tags`}
+              onClick={(event) => event.stopPropagation()}
+            >
+              +{hiddenTagEntries.length} more
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            className="w-auto min-w-72 max-w-[32rem] bg-white p-2 text-gray-900 shadow-xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="mb-1 px-1.5 text-xs font-semibold text-gray-700">
+              More tags
+            </div>
+            <div className="flex max-h-64 flex-col gap-1 overflow-y-auto">
+              {hiddenTagEntries.map(([key, value]) => {
+                const tag = { key, value: String(value) };
+
+                return (
+                  <div
+                    key={key}
+                    className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 hover:bg-gray-50"
+                  >
+                    <span className="min-w-0 flex-1 break-all rounded-md bg-gray-100 px-1 py-0.5 text-xs text-gray-600">
+                      {key}: {String(value)}
+                    </span>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <IconButton
+                        className="rounded p-1 text-gray-600 hover:bg-gray-200"
+                        onClick={(event) =>
+                          onFilterByTag(event, tag, "include")
+                        }
+                        icon={<PiMagnifyingGlassPlusThin size={18} />}
+                        title="Include"
+                        aria-label={`Include ${key}: ${String(value)}`}
+                      />
+                      <IconButton
+                        className="rounded p-1 text-gray-600 hover:bg-gray-200"
+                        onClick={(event) =>
+                          onFilterByTag(event, tag, "exclude")
+                        }
+                        icon={<PiMagnifyingGlassMinusThin size={18} />}
+                        title="Exclude"
+                        aria-label={`Exclude ${key}: ${String(value)}`}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
     </div>
   );
 }

--- a/src/ui/Tags/__tests__/TagsFilterCell.unit.test.tsx
+++ b/src/ui/Tags/__tests__/TagsFilterCell.unit.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import TagsFilterCell from "../TagsFilterCell";
+
+function SearchParams() {
+  return <div data-testid="search">{useLocation().search}</div>;
+}
+
+describe("TagsFilterCell", () => {
+  it("keeps hidden tags filterable in a popover", async () => {
+    const onRowClick = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <div onClick={onRowClick}>
+          <TagsFilterCell
+            tags={{
+              cluster: "homelab",
+              namespace: "mission-control",
+              environment: "production"
+            }}
+            maxVisibleTags={1}
+          />
+        </div>
+        <SearchParams />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("cluster: homelab")).toBeVisible();
+    expect(screen.getByText("+2 more")).toBeVisible();
+    expect(
+      screen.queryByText("namespace: mission-control")
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "2 more tags" }));
+
+    expect(screen.getByText("namespace: mission-control")).toBeVisible();
+    expect(screen.getByText("environment: production")).toBeVisible();
+    expect(onRowClick).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Include namespace: mission-control"
+      })
+    );
+
+    expect(
+      new URLSearchParams(screen.getByTestId("search").textContent ?? "").get(
+        "labels"
+      )
+    ).toBe("namespace____mission-control:1");
+    expect(screen.getByText("namespace: mission-control")).toBeVisible();
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Keeps Catalog Changes rows single-line by narrowing the Last Seen column and collapsing excess tags behind a +N more popover, while preserving include/exclude filtering for every hidden tag and adding an interactive Storybook regression scenario with unit coverage.

<img width="1477" height="565" alt="image" src="https://github.com/user-attachments/assets/1a66802d-c20b-4651-bc06-2a0138d4f250" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compact tag displays with overflow tags available in a popover.
  - Added include and exclude filtering controls for hidden tags.
  - Added URL-driven tag filtering to configuration change views.

- **Improvements**
  - Improved table column sizing for tags and last-seen timestamps.
  - Expanded configuration change examples with realistic metadata and policy violations.

- **Bug Fixes**
  - Hidden tags remain filterable and visible after selection without triggering row navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->