### PR TITLE
fix: expand scraper code editor

### DIFF
--- a/src/components/Forms/SpecEditorForm.stories.tsx
+++ b/src/components/Forms/SpecEditorForm.stories.tsx
@@ -1,10 +1,35 @@
 import { Story } from "@storybook/react";
+import { userEvent, within } from "@storybook/testing-library";
 import React, { ComponentProps } from "react";
+import YAML from "yaml";
 import { schemaResourceTypes } from "../SchemaResourcePage/resourceTypes";
 import AWSConfigsFormEditor from "./Configs/AWSConfigsFormEditor";
+import HttpConfigsFormEditor from "./Configs/HttpConfigsFormEditor";
 import KubernetesConfigsFormEditor from "./Configs/KubernetesConfigsFormEditor";
 import { HTTPHealthFormEditor } from "./Health/HTTPHealthFormEditor";
 import SpecEditorForm from "./SpecEditorForm";
+
+const catalogScraper = YAML.parse(`apiVersion: configs.flanksource.com/v1
+kind: ScrapeConfig
+metadata:
+  name: lastfm-scraper
+  namespace: mc
+spec:
+  http:
+    - type: 'LastFM::Singer'
+      name: '$.name'
+      id: '$.url'
+      env:
+        - name: api_key
+          valueFrom:
+            secretKeyRef:
+              name: lastfm
+              key: API_KEY
+      url: 'http://ws.audioscrobbler.com/2.0/?method=chart.gettopartists&api_key={{.api_key}}&format=json'
+      transform:
+        expr: |
+          dyn(config).artists.artist.map(item, item).toJSON()
+`);
 
 export default {
   title: "SpecEditorForm",
@@ -92,4 +117,34 @@ HTTPHealthFormEditorConfigs.args = {
     updateSpec: () => {}
   },
   resourceInfo: schemaResourceTypes.at(-1)
+};
+
+export const CatalogScraperCodeTab: Story<
+  ComponentProps<typeof SpecEditorForm>
+> = Template.bind({});
+
+CatalogScraperCodeTab.args = {
+  loadSpec: () => ({
+    name: catalogScraper.metadata.name,
+    source: "UI",
+    spec: catalogScraper.spec
+  }),
+  selectedSpec: {
+    configForm: HttpConfigsFormEditor,
+    icon: "http",
+    label: "HTTP",
+    loadSpec: () => ({}),
+    type: "form",
+    name: "http",
+    schemaFileName: undefined,
+    specsMapField: "http.0",
+    updateSpec: () => {}
+  },
+  resourceInfo: schemaResourceTypes.find(
+    ({ table }) => table === "config_scrapers"
+  )
+};
+
+CatalogScraperCodeTab.play = async ({ canvasElement }) => {
+  await userEvent.click(within(canvasElement).getByText("Code"));
 };

--- a/src/components/Forms/SpecEditorForm.tsx
+++ b/src/components/Forms/SpecEditorForm.tsx
@@ -197,6 +197,7 @@ export default function SpecEditorForm({
                   <Tab label="Code" value="Code">
                     <FormikCodeEditor
                       format={specFormat}
+                      className="flex h-[min(600px,calc(90vh))] flex-col"
                       fieldName="spec"
                       schemaFileName={selectedSpec.schemaFileName}
                     />


### PR DESCRIPTION
Catalog scraper form specs render Monaco inside the Form/Code tabs, but the Code-tab wrapper had no height, causing the editor to collapse.

Apply the existing viewport-capped 600px editor height and add a LastFM scraper Storybook case that opens the Code tab for review.

## Before and after

| Before | After |
| --- | --- |
| <img src="https://ampcode.com/user-content/artifacts/12a7044c03ca11531dca95825d2a884899099fd750d06eb52770a457613361a5-file.png" alt="Collapsed scraper code editor before the fix" width="600" /> | <img src="https://ampcode.com/user-content/artifacts/84cabf1e8748e101327158bd8036cacda8abba179c9354b62254c15af2c56bf5-file.png" alt="Expanded scraper code editor after the fix" width="600" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Storybook scenario for viewing catalog scraper specifications in the Code tab.
  * Added support for loading and displaying parsed YAML scraper configurations in the HTTP editor.

* **Style**
  * Improved the Code tab layout for form-based editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->