### PR TITLE
fix: remove usage of 7d cost

### DIFF
--- a/src/api/query-hooks/index.ts
+++ b/src/api/query-hooks/index.ts
@@ -189,7 +189,7 @@ export function prepareConfigListQuery({
 }: ConfigListFilterQueryOptions) {
   const query = new URLSearchParams({
     select:
-      "id,type,config_class,status,health,labels,name,tags,created_at,updated_at,deleted_at,cost_per_minute,cost_total_1d,cost_total_7d,cost_total_30d,changes,analysis"
+      "id,type,config_class,status,health,labels,name,tags,created_at,updated_at,deleted_at,cost_per_minute,cost_total_1d,cost_total_30d,changes,analysis"
   });
 
   if (includeAgents) {

--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -993,7 +993,7 @@ export const getAllConfigInsights = async (
 
 export const getConfigAnalysis = async <T>(configId: string) => {
   const res = await ConfigDB.get<T>(
-    `/configs?id=eq.${configId}&select=cost_per_minute,cost_total_1d,cost_total_7d,cost_total_30d`
+    `/configs?id=eq.${configId}&select=cost_per_minute,cost_total_1d,cost_total_30d`
   );
   return res.data;
 };

--- a/src/api/types/common.ts
+++ b/src/api/types/common.ts
@@ -11,7 +11,6 @@ export type VersionInfo = {
 export type CostsData = {
   cost_per_minute?: number;
   cost_total_1d?: number;
-  cost_total_7d?: number;
   cost_total_30d?: number;
 };
 

--- a/src/api/types/configs.ts
+++ b/src/api/types/configs.ts
@@ -37,16 +37,12 @@ export interface Change {
 export interface Costs {
   cost_per_minute?: number;
   cost_total_1d?: number;
-  cost_total_7d?: number;
   cost_total_30d?: number;
 }
 
 export function isCostsEmpty(costs: Costs) {
   return (
-    !costs.cost_per_minute &&
-    !costs.cost_total_1d &&
-    !costs.cost_total_7d &&
-    !costs.cost_total_30d
+    !costs.cost_per_minute && !costs.cost_total_1d && !costs.cost_total_30d
   );
 }
 
@@ -219,7 +215,6 @@ export type ConfigSummary = {
   };
   cost_per_minute?: number;
   cost_total_1d?: number;
-  cost_total_7d?: number;
   cost_total_30d?: number;
   agent?: {
     id: string;

--- a/src/components/Configs/ConfigCosts/ConfigCostValue.tsx
+++ b/src/components/Configs/ConfigCosts/ConfigCostValue.tsx
@@ -57,7 +57,6 @@ export default function ConfigCostValue({
           cost_per_minute={config.cost_per_minute}
           cost_total_1d={config.cost_total_1d}
           cost_total_30d={config.cost_total_30d}
-          cost_total_7d={config.cost_total_7d}
         />
       </Popover.Panel>
     </Popover>

--- a/src/components/Configs/ConfigCosts/ConfigCostValue.tsx
+++ b/src/components/Configs/ConfigCosts/ConfigCostValue.tsx
@@ -13,11 +13,7 @@ export default function ConfigCostValue({
   config: Costs;
   popover?: boolean;
 }) {
-  if (
-    !config.cost_total_1d ||
-    !config.cost_total_7d ||
-    !config.cost_total_30d
-  ) {
+  if (!config.cost_total_1d || !config.cost_total_30d) {
     return null;
   }
 

--- a/src/components/Configs/ConfigList/Cells/ConfigListCostCell.tsx
+++ b/src/components/Configs/ConfigList/Cells/ConfigListCostCell.tsx
@@ -32,7 +32,6 @@ export const aggregatedCosts = (
   return subRows.reduce((acc, row) => {
     if (row.original) {
       acc.cost_total_30d! += row.original.cost_total_30d ?? 0;
-      acc.cost_total_7d! += row.original.cost_total_7d ?? 0;
       acc.cost_total_1d! += row.original.cost_total_1d ?? 0;
       acc.cost_per_minute! = row.original.cost_per_minute ?? 0;
     }
@@ -43,7 +42,6 @@ export const aggregatedCosts = (
 export function ConfigListCostAggregate({ row }: CellContext<ConfigItem, any>) {
   const configGroupCosts = aggregatedCosts(row, {
     cost_total_30d: 0,
-    cost_total_7d: 0,
     cost_total_1d: 0,
     cost_per_minute: 0
   } as Required<Costs>);

--- a/src/components/Configs/ConfigList/ConfigList.stories.tsx
+++ b/src/components/Configs/ConfigList/ConfigList.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { ConfigItem } from "../../../api/types/configs";
 import sampleConfigList from "../../../data/sampleConfigList";
 import ConfigsTable from "./ConfigsTable";
 
@@ -15,4 +16,42 @@ const Template: ComponentStory<typeof ConfigsTable> = (args) => (
 export const Default = Template.bind({});
 Default.args = {
   data: sampleConfigList
+};
+
+const thirtyDayCostConfigs: ConfigItem[] = [
+  {
+    id: "production-postgres",
+    name: "production-postgres",
+    type: "Kubernetes::StatefulSet",
+    health: "healthy",
+    status: "Ready",
+    changes: 3,
+    cost_per_minute: 0.0083,
+    cost_total_1d: 12,
+    cost_total_30d: 360,
+    created_at: "2026-07-18T10:00:00Z",
+    updated_at: "2026-08-21T14:30:00Z"
+  },
+  {
+    id: "payments-api",
+    name: "payments-api",
+    type: "Kubernetes::Deployment",
+    health: "healthy",
+    status: "Ready",
+    changes: 1,
+    cost_per_minute: 0.0042,
+    cost_total_1d: 6,
+    cost_total_30d: 180,
+    created_at: "2026-07-24T08:00:00Z",
+    updated_at: "2026-08-21T14:45:00Z"
+  }
+];
+
+export const ThirtyDayCosts = Template.bind({});
+ThirtyDayCosts.args = {
+  data: thirtyDayCostConfigs,
+  isLoading: false,
+  columnsToHide: ["type", "tags", "analysis", "created_at", "updated_at"],
+  totalRecords: thirtyDayCostConfigs.length,
+  pageCount: 1
 };

--- a/src/components/Configs/ConfigList/MRTConfigListColumn.tsx
+++ b/src/components/Configs/ConfigList/MRTConfigListColumn.tsx
@@ -232,7 +232,6 @@ export const mrtConfigListColumns = (
     AggregatedCell: ({ row }) => {
       const configGroupCosts = aggregatedCosts(row, {
         cost_total_30d: 0,
-        cost_total_7d: 0,
         cost_total_1d: 0,
         cost_per_minute: 0
       } as Required<Costs>);

--- a/src/components/CostDetails/CostDetails.stories.tsx
+++ b/src/components/CostDetails/CostDetails.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CostDetailsTable } from "./CostDetails";
+
+const costs = {
+  cost_per_minute: 0.01,
+  cost_total_1d: 12,
+  cost_total_30d: 360
+};
+
+const meta = {
+  title: "Configs/Cost Details",
+  component: CostDetailsTable,
+  parameters: {
+    layout: "centered"
+  }
+} satisfies Meta<typeof CostDetailsTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium shadow-sm">
+      <CostDetailsTable {...costs} />
+    </div>
+  )
+};

--- a/src/components/CostDetails/CostDetails.tsx
+++ b/src/components/CostDetails/CostDetails.tsx
@@ -57,13 +57,11 @@ export function CostInfo({ label, value, defaultValue }: CostInfoProps) {
 export function CostDetailsTable({
   cost_per_minute,
   cost_total_1d,
-  cost_total_7d,
   cost_total_30d
 }: CostDetailsTableProps) {
   return (
     <div className="flex flex-row">
       <CostInfo value={cost_total_1d} label="1d" defaultValue="" />
-      <CostInfo value={cost_total_7d} label="7d" defaultValue="" />
       <CostInfo value={cost_total_30d} label="30d" defaultValue="" />
     </div>
   );


### PR DESCRIPTION
The catalog config list queried the PostgREST `configs` view for the removed `cost_total_7d` field, causing PostgreSQL error `42703` (`column configs.cost_total_7d does not exist`).

Remove that field from every `/configs` cost request and stop requiring it before rendering costs. The catalog now fetches and displays the supported `cost_total_30d` value.

## Visual comparison

### Catalog list

The same catalog rows contain valid 1-day and 30-day costs but no retired 7-day value. Before, their Cost cells were blank; after, the 30-day totals are visible.

| Before | After |
| --- | --- |
| Valid 30-day costs are hidden | 30-day costs render in the catalog | 
| ![Before: blank catalog Cost cells](https://ampcode.com/user-content/artifacts/ef8f6d9ac4c48ad5d393f95c716c5d810fe347767e68ea618b8008baeac1e5c2-file.png) | ![After: catalog Cost cells show $360 and $180](https://ampcode.com/user-content/artifacts/ff5dbed29843dfe15e2cc92a711798c28f1a2285d2daa744c82c670e24a4f42b-file.png) |

### Cost details

The focused `Configs/Cost Details` story uses the same fixed cost values in both revisions.

| Before | After |
| --- | --- |
| Shows the retired 7-day total | Shows only the supported 1-day and 30-day totals |
| ![Before: 1-day, 7-day, and 30-day costs](https://ampcode.com/user-content/artifacts/8393358efe5c7425323bfb13e9598646458578cf8b2b03859c97fbb52a85deab-file.png) | ![After: 1-day and 30-day costs](https://ampcode.com/user-content/artifacts/284eb7a05a96bdf44f2d26f5f0cb0b8f34782d149ef96a26b0d92503734037c1-file.png) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated configuration cost displays to rely on available 1-day and 30-day totals.
  * Prevented cost values from being hidden when 7-day cost data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
