### PR TITLE
fix: encode query for catalog insight filter

### DIFF
--- a/src/api/services/__tests__/configs.unit.test.ts
+++ b/src/api/services/__tests__/configs.unit.test.ts
@@ -1,13 +1,17 @@
-import { Catalog } from "../../axios";
-import { getConfigsChanges } from "../configs";
+import { Catalog, ConfigDB } from "../../axios";
+import { getAllConfigInsights, getConfigsChanges } from "../configs";
 
 jest.mock("../../axios", () => ({
   Catalog: {
     post: jest.fn()
+  },
+  ConfigDB: {
+    get: jest.fn()
   }
 }));
 
 const mockedPost = Catalog.post as jest.MockedFunction<typeof Catalog.post>;
+const mockedGet = ConfigDB.get as jest.MockedFunction<typeof ConfigDB.get>;
 
 describe("getConfigsChanges", () => {
   beforeEach(() => {
@@ -43,5 +47,104 @@ describe("getConfigsChanges", () => {
       "/changes",
       expect.not.objectContaining({ soft: expect.anything() })
     );
+  });
+});
+
+describe("getAllConfigInsights", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGet.mockResolvedValue({ data: [], headers: {} } as any);
+  });
+
+  it("uses an exact PostgREST filter for tristate values containing slashes", async () => {
+    await getAllConfigInsights(
+      { source: "recon/prowler:1" },
+      {},
+      { pageIndex: 0, pageSize: 50 }
+    );
+
+    const url = mockedGet.mock.calls[0][0];
+    expect(url).toContain("&source=eq.recon%2Fprowler");
+    expect(url).not.toContain("source.filter=");
+  });
+
+  it("supports multiple included and excluded tristate values", async () => {
+    await getAllConfigInsights(
+      {
+        source:
+          "recon/prowler:1,recon/trivy:1,recon/checkov:-1,recon/kubescape:-1"
+      },
+      {},
+      { pageIndex: 0, pageSize: 50 }
+    );
+
+    const url = mockedGet.mock.calls[0][0];
+    expect(decodeURIComponent(url)).toContain(
+      '&source=in.("recon/prowler","recon/trivy")'
+    );
+    expect(decodeURIComponent(url)).toContain(
+      '&source=not.in.("recon/checkov","recon/kubescape")'
+    );
+  });
+
+  it("uses neq for a single excluded value", async () => {
+    await getAllConfigInsights(
+      { analyzer: "recon/prowler:-1" },
+      {},
+      { pageIndex: 0, pageSize: 50 }
+    );
+
+    expect(mockedGet.mock.calls[0][0]).toContain(
+      "&analyzer=neq.recon%2Fprowler"
+    );
+  });
+
+  it("URL-encodes slashes in plain filter values", async () => {
+    await getAllConfigInsights(
+      { source: "recon/prowler" },
+      {},
+      { pageIndex: 0, pageSize: 50 }
+    );
+
+    expect(mockedGet.mock.calls[0][0]).toContain("&source=eq.recon%2Fprowler");
+  });
+
+  it("preserves all existing insight filter fields", async () => {
+    await getAllConfigInsights(
+      {
+        status: "open:1",
+        severity: "critical:1",
+        type: "security:1,performance:1",
+        analyzer: "recon/prowler:1",
+        source: "prowler:1",
+        configType: "Kubernetes________Pod:1",
+        catalogId: "config-id:1"
+      },
+      { sortBy: "catalog", sortOrder: "asc" },
+      { pageIndex: 2, pageSize: 25 }
+    );
+
+    const url = decodeURIComponent(mockedGet.mock.calls[0][0]);
+    expect(url).toContain("&status=eq.open");
+    expect(url).toContain("&severity=eq.critical");
+    expect(url).toContain('&analysis_type=in.("security","performance")');
+    expect(url).toContain("&analyzer=eq.recon/prowler");
+    expect(url).toContain("&source=eq.prowler");
+    expect(url).toContain("&config_type=eq.Kubernetes::Pod");
+    expect(url).toContain("&config_id=eq.config-id");
+    expect(url).toContain("&limit=25&offset=50");
+    expect(url).toContain("&order=config_name.asc");
+  });
+
+  it("keeps configId precedence over the catalogId URL filter", async () => {
+    await getAllConfigInsights(
+      { configId: "details-config", catalogId: "catalog-config:1" },
+      {},
+      { pageIndex: 0, pageSize: 50 }
+    );
+
+    const url = mockedGet.mock.calls[0][0];
+    expect(url).toContain("&config_id=eq.details-config");
+    expect(url).not.toContain("catalog-config");
   });
 });

--- a/src/api/services/configs.ts
+++ b/src/api/services/configs.ts
@@ -1,4 +1,8 @@
 import {
+  decodeTristateKey,
+  parseTristateKeyState
+} from "@flanksource-ui/lib/tristate";
+import {
   tristateOutputToQueryFilterParam,
   tristateOutputToQueryParamValue
 } from "@flanksource-ui/ui/Dropdowns/TristateReactSelect";
@@ -930,10 +934,46 @@ export const getAllConfigInsights = async (
     }
 
     if (/(^|,).+:(-1|1)(,|$)/.test(value)) {
-      return tristateOutputToQueryFilterParam(value, key);
+      const parsedValues = value
+        .split(",")
+        .map(parseTristateKeyState)
+        .filter((item): item is NonNullable<typeof item> => item !== null);
+      const included = parsedValues
+        .filter(({ state }) => state === 1)
+        .map(({ key }) => decodeTristateKey(key));
+      const excluded = parsedValues
+        .filter(({ state }) => state === -1)
+        .map(({ key }) => decodeTristateKey(key));
+
+      const buildFilter = (
+        values: string[],
+        singleOperator: "eq" | "neq",
+        multipleOperator: "in" | "not.in"
+      ) => {
+        if (values.length === 0) {
+          return "";
+        }
+
+        const expression =
+          values.length === 1
+            ? `${singleOperator}.${values[0]}`
+            : `${multipleOperator}.(${values
+                .map(
+                  (item) =>
+                    `"${item.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`
+                )
+                .join(",")})`;
+
+        return `&${key}=${encodeURIComponent(expression)}`;
+      };
+
+      return [
+        buildFilter(included, "eq", "in"),
+        buildFilter(excluded, "neq", "not.in")
+      ].join("");
     }
 
-    return `&${key}=eq.${value}`;
+    return `&${key}=${encodeURIComponent(`eq.${value}`)}`;
   };
 
   const params = {

--- a/src/ui/Dropdowns/TristateReactSelect.tsx
+++ b/src/ui/Dropdowns/TristateReactSelect.tsx
@@ -114,12 +114,13 @@ export function tristateOutputToQueryParamValue(
  */
 export function tristateOutputToQueryFilterParam(
   param: string | undefined,
-  key: string
+  key: string,
+  encodeValue = false
 ) {
   if (param === undefined) {
     return "";
   }
-  const paramValue = tristateOutputToQueryParamValue(param);
+  const paramValue = tristateOutputToQueryParamValue(param, encodeValue);
   return `&${key}.filter=${paramValue}`;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration insight filters so values containing slashes are correctly URL-encoded.
  * Improved handling of tristate and standard filter parameters when generating requests.
  * Preserved empty results for undefined tristate filter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->