### PR TITLE
fix(views): drop column prefix from single-label timeseries legends

### DIFF
--- a/src/pages/audit-report/components/View/panels/TimeseriesPanel.tsx
+++ b/src/pages/audit-report/components/View/panels/TimeseriesPanel.tsx
@@ -20,6 +20,7 @@ import {
 import { formatTick, parseTimestamp } from "@flanksource-ui/lib/timeseries";
 import { getSeriesColor } from "./utils";
 import { buildEvenlySpacedRange } from "./timeRange";
+import { buildSeriesKey } from "./seriesKey";
 import PanelHeader from "./PanelHeader";
 
 interface TimeseriesPanelProps {
@@ -108,11 +109,7 @@ const TimeseriesPanel: React.FC<TimeseriesPanelProps> = ({ summary }) => {
       const { numericValue, label } = parseTimestamp(row[timeKey], index);
       if (!Number.isFinite(numericValue)) return;
 
-      const labelKeys = Object.keys(row).filter(
-        (key) => key !== timeKey && key !== valueKey
-      );
-      const labelPairs = labelKeys.map((key) => `${key}=${row[key]}`);
-      const seriesKey = labelPairs.join(", ") || "default";
+      const seriesKey = buildSeriesKey(row, timeKey, valueKey);
 
       if (!seriesMap.has(seriesKey)) {
         seriesMap.set(seriesKey, {

--- a/src/pages/audit-report/components/View/panels/__tests__/seriesKey.test.ts
+++ b/src/pages/audit-report/components/View/panels/__tests__/seriesKey.test.ts
@@ -1,0 +1,48 @@
+import { buildSeriesKey } from "../seriesKey";
+
+describe("buildSeriesKey", () => {
+  it("uses the value alone when one column names the series", () => {
+    expect(
+      buildSeriesKey(
+        { timestamp: "2026-08-11", service: "Compute Engine", value: 12 },
+        "timestamp",
+        "value"
+      )
+    ).toBe("Compute Engine");
+  });
+
+  it("keeps column names when several columns identify the series", () => {
+    expect(
+      buildSeriesKey(
+        {
+          timestamp: "2026-08-11",
+          service: "Compute Engine",
+          region: "europe-west1",
+          value: 12
+        },
+        "timestamp",
+        "value"
+      )
+    ).toBe("service=Compute Engine, region=europe-west1");
+  });
+
+  it("keeps the labelled form when the only label has no value", () => {
+    expect(
+      buildSeriesKey(
+        { timestamp: "2026-08-11", service: null, value: 12 },
+        "timestamp",
+        "value"
+      )
+    ).toBe("service=null");
+  });
+
+  it("falls back to a single series when no column identifies one", () => {
+    expect(
+      buildSeriesKey(
+        { timestamp: "2026-08-11", value: 12 },
+        "timestamp",
+        "value"
+      )
+    ).toBe("default");
+  });
+});

--- a/src/pages/audit-report/components/View/panels/seriesKey.ts
+++ b/src/pages/audit-report/components/View/panels/seriesKey.ts
@@ -1,0 +1,26 @@
+/**
+ * Names the series a timeseries row belongs to, using whichever of its columns are
+ * neither the time nor the value.
+ */
+export function buildSeriesKey(
+  row: Record<string, any>,
+  timeKey: string,
+  valueKey: string
+): string {
+  const labelKeys = Object.keys(row).filter(
+    (key) => key !== timeKey && key !== valueKey
+  );
+
+  // A single label column already names the series on its own, so the column name adds
+  // nothing to the legend — "service=Compute Engine" reads as debug output where
+  // "Compute Engine" reads as a label. With more than one, the names are what keep the
+  // combination unambiguous, so they stay.
+  if (labelKeys.length === 1) {
+    const value = row[labelKeys[0]];
+    if (value != null && String(value) !== "") {
+      return String(value);
+    }
+  }
+
+  return labelKeys.map((key) => `${key}=${row[key]}`).join(", ") || "default";
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved timeseries series labeling for clearer chart legends and grouping.
  * Single label fields now display their values directly.
  * Multiple label fields are shown together as descriptive key-value pairs.
  * Rows without usable labels now use a consistent default series label.
  * Null or empty label values are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->