### PR TITLE
fix(views): prevent panel cards from continuously growing

### DIFF
--- a/src/pages/audit-report/components/View/View.tsx
+++ b/src/pages/audit-report/components/View/View.tsx
@@ -287,7 +287,9 @@ const View: React.FC<ViewProps> = ({
               className="grid gap-4"
               style={{
                 gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-                gridAutoRows: "minmax(250px, auto)"
+                // Keep the upper track size definite so percentage-height chart
+                // children cannot repeatedly increase an intrinsically sized row.
+                gridAutoRows: "minmax(auto, 250px)"
               }}
             >
               {groupAndRenderPanels(panels)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit report panel sizing to prevent chart content from repeatedly expanding rows.
  * Ensured panels maintain a consistent maximum height while adapting to their content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->