### PR TITLE
chore: update icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@clerk/nextjs": "^5.7.6",
         "@dagrejs/dagre": "^1.1.1",
-        "@flanksource/icons": "^1.0.46",
+        "@flanksource/icons": "^1.0.65",
         "@floating-ui/react": "^0.26.9",
         "@headlessui/react": "^2.1.2",
         "@heroicons/react": "^1.0.3",
@@ -3366,7 +3366,9 @@
       "license": "MIT"
     },
     "node_modules/@flanksource/icons": {
-      "version": "1.0.46",
+      "version": "1.0.65",
+      "resolved": "https://registry.npmjs.org/@flanksource/icons/-/icons-1.0.65.tgz",
+      "integrity": "sha512-Z8EW8V0c4YJWs529wS3RNrN/1Q65eYgxqrkln3djUzBLg3acfHLYUGmXoSBQnPXQSGO4No+2wr9uLVsnE53wlA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@clerk/nextjs": "^5.7.6",
     "@dagrejs/dagre": "^1.1.1",
-    "@flanksource/icons": "^1.0.46",
+    "@flanksource/icons": "^1.0.65",
     "@floating-ui/react": "^0.26.9",
     "@headlessui/react": "^2.1.2",
     "@heroicons/react": "^1.0.3",

--- a/src/ui/Icons/Icon.tsx
+++ b/src/ui/Icons/Icon.tsx
@@ -160,6 +160,8 @@ export const aliases: IconMap = {
   bash: "console",
   "cert-manager.io": "cert-manager",
   cmd: "console",
+  cnpg: "cloudnative-pg",
+  tailscale: "tailscale-inverted",
   deletingnode: "trash",
   invaliddiskcapacity: "warning",
   resourceupdated: "edit",
@@ -636,6 +638,8 @@ export var prefixes: IconMap = {
   ready: "check",
   notready: "broken-heart",
   cilium: "cilium",
+  cnpg: "cloudnative-pg",
+  tailscale: "tailscale-inverted",
   pending: "hourglass",
   invalid: "error",
   wait: "hourglass",
@@ -797,13 +801,13 @@ export function findIconName(name?: string): IconType | undefined {
     return undefined;
   }
 
+  if (aliases[name as keyof typeof aliases]) {
+    return Icons[aliases[name] as keyof typeof Icons];
+  }
+
   let icon = Icons[name as keyof typeof Icons];
   if (icon != null) {
     return icon;
-  }
-
-  if (aliases[name as keyof typeof aliases]) {
-    return Icons[aliases[name] as keyof typeof Icons];
   }
 
   for (let prefix in prefixes) {

--- a/src/ui/Icons/__tests__/catalog-icons.unit.test.tsx
+++ b/src/ui/Icons/__tests__/catalog-icons.unit.test.tsx
@@ -1,0 +1,23 @@
+import { findByName as resolveIcon } from "../Icon";
+
+describe("Catalog type icons", () => {
+  it.each([
+    "Tailscale",
+    "tailscale",
+    "Tailscale::Device",
+    "Kubernetes::Tailscale::Connector"
+  ])("maps %s to the inverted Tailscale icon", (type) => {
+    const tailscaleIcon = resolveIcon("tailscale-inverted");
+    expect(tailscaleIcon).toBeDefined();
+    expect(resolveIcon(type)).toBe(tailscaleIcon);
+  });
+
+  it.each(["CNPG", "cnpg", "CNPG::Cluster", "Kubernetes::CNPG::Cluster"])(
+    "maps %s to the CloudNativePG icon",
+    (type) => {
+      const cnpgIcon = resolveIcon("cloudnative-pg");
+      expect(cnpgIcon).toBeDefined();
+      expect(resolveIcon(type)).toBe(cnpgIcon);
+    }
+  );
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added icon support for CloudNativePG and Tailscale catalog types.
  - Improved recognition across capitalization and fully qualified catalog names.
  - Tailscale entries now display the inverted Tailscale icon where applicable.

- **Bug Fixes**
  - Improved icon alias matching to ensure supported aliases resolve to the intended icons.

- **Tests**
  - Added coverage for CloudNativePG and Tailscale icon mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->