### PR TITLE
chore: remove prefix for cnpg and tailscale icons

### DIFF
--- a/src/ui/Icons/Icon.tsx
+++ b/src/ui/Icons/Icon.tsx
@@ -638,8 +638,6 @@ export var prefixes: IconMap = {
   ready: "check",
   notready: "broken-heart",
   cilium: "cilium",
-  cnpg: "cloudnative-pg",
-  tailscale: "tailscale-inverted",
   pending: "hourglass",
   invalid: "error",
   wait: "hourglass",

--- a/src/ui/Icons/__tests__/catalog-icons.unit.test.tsx
+++ b/src/ui/Icons/__tests__/catalog-icons.unit.test.tsx
@@ -1,23 +1,27 @@
 import { findByName as resolveIcon } from "../Icon";
 
 describe("Catalog type icons", () => {
-  it.each([
-    "Tailscale",
-    "tailscale",
-    "Tailscale::Device",
-    "Kubernetes::Tailscale::Connector"
-  ])("maps %s to the inverted Tailscale icon", (type) => {
-    const tailscaleIcon = resolveIcon("tailscale-inverted");
-    expect(tailscaleIcon).toBeDefined();
-    expect(resolveIcon(type)).toBe(tailscaleIcon);
-  });
-
-  it.each(["CNPG", "cnpg", "CNPG::Cluster", "Kubernetes::CNPG::Cluster"])(
-    "maps %s to the CloudNativePG icon",
+  it.each(["Tailscale", "tailscale"])(
+    "maps %s to the inverted Tailscale icon",
     (type) => {
-      const cnpgIcon = resolveIcon("cloudnative-pg");
-      expect(cnpgIcon).toBeDefined();
-      expect(resolveIcon(type)).toBe(cnpgIcon);
+      const tailscaleIcon = resolveIcon("tailscale-inverted");
+      expect(tailscaleIcon).toBeDefined();
+      expect(resolveIcon(type)).toBe(tailscaleIcon);
     }
   );
+
+  it.each(["CNPG", "cnpg"])("maps %s to the CloudNativePG icon", (type) => {
+    const cnpgIcon = resolveIcon("cloudnative-pg");
+    expect(cnpgIcon).toBeDefined();
+    expect(resolveIcon(type)).toBe(cnpgIcon);
+  });
+
+  it.each([
+    "Tailscale::Device",
+    "Kubernetes::Tailscale::Connector",
+    "CNPG::Cluster",
+    "Kubernetes::CNPG::Cluster"
+  ])("does not assign a logo to child type %s", (type) => {
+    expect(resolveIcon(type)).toBeUndefined();
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated icon resolution so only top-level Tailscale and CloudNativePG types display their respective logos.
  * Child resource types now correctly display no icon instead of inheriting a parent logo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->